### PR TITLE
Update userpassword.md

### DIFF
--- a/docs/03.reference/02.tags/document/_attributes/userpassword.md
+++ b/docs/03.reference/02.tags/document/_attributes/userpassword.md
@@ -1,1 +1,1 @@
-Specifies a user password (format="PDF" only).
+Specifies a user password (format="PDF" only). Defaults to "empty" if is not set, and encyption is set to 40 bit or 128 bit.


### PR DESCRIPTION
When you encrypt a pdf document, it defaults the userpassword to "empty", which no one can figure out what it is, unless you search the code.
This is a compatibility bug, moving from ACF several documents started showing unknown passwords.