### PR TITLE
fixed a shell error [: ==: unary operator expected

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,7 @@ if [ -f .exitcode ]; then
 fi
 
 echo "Building complete"
-if [ $TRAVIS_BRANCH == 'master' ] && [ $TRAVIS_PULL_REQUEST == 'false' ] ; then
+if [ '$TRAVIS_BRANCH' == 'master' ] && [ '$TRAVIS_PULL_REQUEST' == 'false' ] ; then
   echo "Zipping up docs for offline download..."
   cd builds/html
   zip -q -r lucee-docs.zip *


### PR DESCRIPTION
Here's the result from running `build.sh` in Terminal.
```
$ ./build.sh
Building documentation with Lucee :)




Building complete
./build.sh: line 16: [: ==: unary operator expected
```
By putting quotes around the variables, comparison operator can work correctly even when those variables are null.