### PR TITLE
Remove cfmodule as specific to Lucee

### DIFF
--- a/docs/03.reference/04.additional/chapter.md
+++ b/docs/03.reference/04.additional/chapter.md
@@ -11,7 +11,6 @@ The following tags are specific to Lucee:
 * [[tag-graph]]
 * [[tag-graphdata]]
 * [[tag-htmlbody]]
-* [[tag-module]]
 * [[tag-pageencoding]]
 * [[tag-retry]]
 * [[tag-servlet]]


### PR DESCRIPTION
Tag implementation is the same as ACF