### PR TITLE
fix(css): add "white-space: pre-wrap" to PRE tag to make lines wrap correctly

### DIFF
--- a/builders/html/assets/css/base.css
+++ b/builders/html/assets/css/base.css
@@ -5867,6 +5867,7 @@ pre {
   padding: 12px 8px;
   word-break: break-all;
   word-wrap: break-word;
+  white-space: pre-wrap;
 }
 pre code {
   background-color: transparent;


### PR DESCRIPTION
to make long lines wrap correctly.

[BEFORE](http://docs.lucee.org/guides/lucee-5/component-static.html)

<img width="956" alt="screen shot 2016-03-19 at 18 11 18" src="https://cloud.githubusercontent.com/assets/108758/13897953/2a150c9a-edfe-11e5-9095-0913f8b8b2a3.png">

AFTER

<img width="884" alt="screen shot 2016-03-19 at 18 15 12" src="https://cloud.githubusercontent.com/assets/108758/13897966/91295df0-edfe-11e5-83a8-6bc2c5c9de8f.png">

Optionally, we can use `<pre><code>` combination as `<code>` already has `white-space: pre-wrap` applied. But the inherited border should be removed by adding `border: none;` to `pre code {...}` block ([line 5878](https://github.com/myleslee/lucee-docs/blob/b16cfb5cad4ccbcdafce0ee71e1848ab3b7f63a1/builders/html/assets/css/base.css#L5878)): 

===============

If you don't want it to wrap, make it scroll with the following addition to `pre` ([line 5870](https://github.com/myleslee/lucee-docs/blob/b16cfb5cad4ccbcdafce0ee71e1848ab3b7f63a1/builders/html/assets/css/base.css#L5870)). Your choice. :) 
```
overflow-x: scroll;
overflow-y: hidden;
```
<img width="886" alt="screen shot 2016-03-19 at 18 22 28" src="https://cloud.githubusercontent.com/assets/108758/13898013/f4e2da5a-edff-11e5-95d6-595416cb6f45.png">



 