### PR TITLE
Fix formatting issue and improve accuracy

### DIFF
--- a/docs/03.reference/02.tags/timer/_attributes/type.md
+++ b/docs/03.reference/02.tags/timer/_attributes/type.md
@@ -1,11 +1,6 @@
-- inline: displays timing information inline, following the
-              resulting HTML.
-            - outline: displays timing information and also displays a line
-              around the output produced by the timed code. The browser
-              must support the FIELDSET tag to display the outline.
-            - comment: displays timing information in an HTML comment
-              in the format <!-- label: elapsed-time ms -->. The default label
-              is cftimer.
-            - debug: displays timing information in the debug output
-              under the heading CFTimer Times.
-            Default: debug
+- debug: displays timing information in a table in the debug output under the heading "CFTimer Times". There is a column for Label, Time (in ms), and Template. The default label is an empty string.
+- comment: displays timing information as an inline HTML comment following the closing `</cftimer>`. Uses the format `<!-- [label]: [elapsed time in ms] -->`. The default label is an empty string.
+- inline: displays timing information as inline HTML following the closing `</cftimer>`. Uses the format `[label]: [elapsed time in ms]`. The default label is an empty string.
+- outline: wraps the `<cftimer>` block with a `<fieldset>` element, then displays timing information as a `<legend>` element rendered just before the closing `</fieldset>`. Uses the format `<legend align="top">[label]: [elapsed time in ms]</legend>`. The `<fieldset>` element is given a class of `cftimer`. The default label is an empty string.
+
+Default: debug


### PR DESCRIPTION
Did some thorough testing on Lucee to more clearly explain how the different timer types will render output.