### PR TITLE
Move instruction to remove all other JARs to its own bullet

### DIFF
--- a/docs/04.guides/08.lucee-5/15.upgrading-lucee-45/page.md
+++ b/docs/04.guides/08.lucee-5/15.upgrading-lucee-45/page.md
@@ -6,7 +6,8 @@ id: lucee-5-upgrading-lucee-45
 #Upgrade from Lucee 4.5 (or Railo 4.2)#
 
 1. Stop the servlet engine.
-2. Add the lucee.jar you download from [here](http://lucee.org/downloads.html) to "/lib/etc" directory and remove all other jars (NOTE you must remove the JARs, DO NOT simply rename them) in the same directory, however *do not* remove the directory "lucee-server" (or "railo-server") if that directory is present, this is the case with default installations.
+2. Add the lucee.jar you download from [here](http://lucee.org/downloads.html) to "/lib/etc" directory.
+3. Remove all other JARs (NOTE you must remove the JARs, DO NOT simply rename them) in the same directory, however *do not* remove the directory "lucee-server" (or "railo-server") if that directory is present, this is the case with default installations.
 3. Start the servlet engine.
 
 **Important information**


### PR DESCRIPTION
I read the instruction initially, but missed the part about removing all the other jars (my fault).  Since it is an important step it might be better to have it on it's own line.  There are 4 steps total.