### PR TITLE
Fix unary operator expected error on Mac

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ fi
 
 echo "Building complete"
 
-if [ $TRAVIS_BRANCH = 'master' ] && [ $TRAVIS_PULL_REQUEST = 'false' ] ; then
+if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ] ; then
   echo "Zipping up docs for offline download..."
   cd builds/html
   cp ../../.cloudfront-distribution-id ./


### PR DESCRIPTION
When I was building this project on my laptop, I ran across an error:

```bash
./build.sh: line 21: [: =: unary operator expected
```

I came across this Stack Overflow article that mentioned a fix: http://stackoverflow.com/questions/13617843/unary-operator-expected/13618376

I'm not sure if this will break the deployment and Travis test workflow at all.