### PR TITLE
Ensure we only render one of two highlighter languages

### DIFF
--- a/api/rendering/SyntaxHighlighter.cfc
+++ b/api/rendering/SyntaxHighlighter.cfc
@@ -19,9 +19,9 @@ component {
 		var highlighter = CreateObject( 'java', 'com.dominicwatson.pyginblankets.PygmentsWrapper', jars );
 		var useTryCf    = reFind( "\+trycf$", arguments.language ) > 0;
 
-		if ( arguments.language.startsWith( "luceescript" ) ) {
+		if ( arguments.language.startsWith( "luceescript" ) || arguments.language == "cfs" ) {
 			arguments.language = "cfs";
-		} else if ( arguments.language.startsWith( "lucee" ) ) {
+		} else {
 			arguments.language = "cfm";
 		}
 


### PR DESCRIPTION
I broke the build recently because I tried to use a syntax highlighter language of `cfml`. From what I can tell, the Lucee Docs only support `cfm` or `cfs` language syntaxes, so this update will ensure that the language passed to the highlight parser is one of those two syntaxes.