### PR TITLE
provide service name

### DIFF
--- a/docs/04.guides/02.running-lucee/02.windows/12.configuring-tomcat-as-a-windows-service/page.md
+++ b/docs/04.guides/02.running-lucee/02.windows/12.configuring-tomcat-as-a-windows-service/page.md
@@ -49,7 +49,7 @@ And finally we add the **Startup** and **Shutdown** properties:
 ```
 
 Please check the configuration by starting the Tomcat applet:
-> C:\Program Files\Tomcat\bin\tomcat8w.exe
+> "C:\Program Files\Tomcat\bin\tomcat8w.exe" //ES//Tomcat8
 
 ![apache-tomcat-properties-java1.png](https://bitbucket.org/repo/rX87Rq/images/2957749731-apache-tomcat-properties-java1.png)
 


### PR DESCRIPTION
When there are multiple tomcat installations present on one machine information for the default instance is shown. It's therefore good practice to prvide the name of the service on the command line.