### PR TITLE
Updated _examples.md for WriteOutput()

### DIFF
--- a/docs/03.reference/01.functions/writeoutput/_examples.md
+++ b/docs/03.reference/01.functions/writeoutput/_examples.md
@@ -1,1 +1,4 @@
-*There are currently no examples for this function.*
+```luceescript+trycf
+html_paragraph = "<p>The Lucee project is led by the Lucee Association&nbsp;Switzerland a non-profit&nbsp;<a href=""http://en.wikipedia.org/wiki/Swiss_Verein"">swiss association</a>. A growing project which is committed to the success of its community by delivering quality software and a nurturing&nbsp;and supportive environment for developers to get involved.</p>";
+writeOutput(html_paragraph);
+```


### PR DESCRIPTION
I didn't include an example with the ``` encodeFor ``` parameter, because Lucee 4.5.4.017 seems to have a problem with it.