### PR TITLE
Corrected _examples.md for ArraySort()

### DIFF
--- a/docs/03.reference/01.functions/arraysort/_examples.md
+++ b/docs/03.reference/01.functions/arraysort/_examples.md
@@ -2,17 +2,13 @@
 ```luceescript+trycf
 SomeArray = ["COLDFUSION","coldfusion","adobe","LucEE","LUCEE"];
 
-
 arraySort(SomeArray,"text","desc");
 dump(SomeArray);
 
 //member function
 SomeArray.sort("text","desc");
 dump(SomeArray);
-```
 
-### Nested array of structs using closure
-```luceescript+trycf
 SomeArray = [
     {name="testemployee", age="32"},
     {name="employeetest", age="36"}
@@ -26,7 +22,7 @@ arraySort(
 );
 dump(SomeArray);
 
-//member function
+// member function with closure
 SomeArray.sort(
     function (e1, e2){
         return compare(e1.name, e2.name);


### PR DESCRIPTION
Code showing the closure example was malformed a bit and not showing up on the docs.