### PR TITLE
Updated _examples.md for ComponentInfo()

### DIFF
--- a/docs/03.reference/01.functions/componentinfo/_examples.md
+++ b/docs/03.reference/01.functions/componentinfo/_examples.md
@@ -1,1 +1,4 @@
-*There are currently no examples for this function.*
+```luceescript+trycf
+q = new Query();
+dump(ComponentInfo(q));
+```


### PR DESCRIPTION
I know it's deprecated, but it can't hurt to have an example just in case.