### PR TITLE
Update length.md

### DIFF
--- a/docs/03.reference/01.functions/arrayslice/_arguments/length.md
+++ b/docs/03.reference/01.functions/arrayslice/_arguments/length.md
@@ -1,1 +1,1 @@
-maximum elements to slice from offset
+number of elements to slice from offset


### PR DESCRIPTION
"Maximum" implied if the array was shorter than the desired slice, the 'smaller' slice would be returned. This is not the case.