### PR TITLE
add text mode build logging

### DIFF
--- a/api/build/Logger.cfc
+++ b/api/build/Logger.cfc
@@ -9,6 +9,7 @@ component {
 		    request.logs = [];
 		    request.loggerStart = getTickCount();
             request.loggerFlushEnabled = false;
+            this.textOnly = (url.KeyExists("textlogs") and url.textlogs ); // nice for curl --trace http://localhost:4040/build_docs/all/
         }
 		return this;
 	}
@@ -29,7 +30,8 @@ component {
     public void function enableFlush(required boolean _flush){
         request.loggerFlushEnabled = arguments._flush;
         if (request.loggerFlushEnabled){
-            writeOutput("<ol>");
+            if (!this.textOnly)
+                writeOutput("<ol>");
             return;
         }
     }
@@ -37,16 +39,19 @@ component {
     public void function renderLogs(){
         if (request.loggerFlushEnabled){
             // logs were output as they were generated;
-            writeOutput("</ol>");
+            if (!this.textOnly)
+                writeOutput("</ol>");
             return;
         }
 
 		if (request.logs.len() eq 0)
 			return;
-		writeOutput("<ol>");
+        if (!this.textOnly)
+		    writeOutput("<ol>");
 		for (var log in request.logs)
 			_renderLog(log);
-		writeOutput("</ol>");
+        if (!this.textOnly)
+		    writeOutput("</ol>");
 	}
 
     public void function _renderLog(log){
@@ -63,6 +68,10 @@ component {
         }
         if (style.len() gt 0)
             style = ' style="#style#" ';
-		writeOutput("<li #style#>#numberformat(arguments.log.timeMs)#ms <b>#arguments.log.type#</b> #arguments.log.text# </li>");
+        var mess="";
+        if (this.textOnly)
+            writeOutput("#numberformat(arguments.log.timeMs)#ms #arguments.log.type# #arguments.log.text##chr(10)#");
+        else
+		    writeOutput("<li #style#>#numberformat(arguments.log.timeMs)#ms <b>#arguments.log.type#</b> #arguments.log.text#</li>#chr(10)#");
 	}
 }

--- a/api/reference/TagReferenceReader.cfc
+++ b/api/reference/TagReferenceReader.cfc
@@ -31,7 +31,9 @@ component accessors=true {
 	}
 
 	private struct function _getTagDefinition( required string tagName ) {
-		var coreDefinition = getTagData( "cf", arguments.tagName );
+		silent {  // some tags leak new lines https://luceeserver.atlassian.net/browse/LDEV-1796
+			var coreDefinition = getTagData( "cf", arguments.tagName );
+		}
 		var parsedTag      = StructNew( "linked" );
 
 		parsedTag.name                 = coreDefinition.name ?: NullValue();

--- a/server/Application.cfc
+++ b/server/Application.cfc
@@ -45,6 +45,7 @@
 				if (listlen(path,"/") gt 1 )
 					writeOutput("unknown build docs request: #path#");
 			}
+			//fileAppend("/performance.log", "#path# #numberFormat(getTickCount() - request.loggerStart)#ms #server.lucee.version##chr(10)#");
 			logger.renderLogs();
 		} else if ( path eq "/assets/js/searchIndex.json" ) {
 			_renderSearchIndex();
@@ -219,23 +220,32 @@
 			Menu: "Import References",
 			title: "Importing References (tags, functions, options, methods)"
 		};
-
+		var textOnly = (url.KeyExists("textlogs") and url.textlogs );
 		var selectedOption = listLast(arguments.path,"/");
-		writeOutput("<h1>Lucee Documentation Builder</h1>");
-		writeOutput('<style>.build-menu li { display: inline; list-style-type: none; padding-right: 10px;} ul, ol {padding-left:0;}</style>');
-		writeOutput('<ul class="build-menu">');
-		for (var link in opts){
-			var _link = "/build_docs/#lCase(link)#/";
-			var _target = "";
-			if (opts[link].keyExists("href")){
-				_link = opts[link].href;
-				var _target = " target='_blank'";
+		if (textOnly){ // nice for curl --trace http://localhost:4040/build_docs/all/
+			writeOutput("#chr(10)#Lucee Documentation Builder - #server.lucee.version##chr(10)#");
+
+			if (opts.keyExists(selectedOption))
+				writeOutput("#opts[selectedOption].title##chr(10)##chr(10)#");
+			setting showdebugoutput="false";
+		} else {
+			writeOutput("<h1>Lucee Documentation Builder - #server.lucee.version#</h1>");
+			writeOutput('<style>.build-menu li { display: inline; list-style-type: none; padding-right: 10px;} ul, ol {padding-left:0;}</style>');
+			writeOutput('<ul class="build-menu">');
+			for (var link in opts){
+				var _link = "/build_docs/#lCase(link)#/";
+				var _target = "";
+				if (opts[link].keyExists("href")){
+					_link = opts[link].href;
+					var _target = " target='_blank'";
+				}
+				writeOutput('<li><a href="#_link#" #_target# title="#htmlEditFormat(opts[link].title)#" >#htmlEditFormat(opts[link].menu)#</a></li>');
 			}
-			writeOutput('<li><a href="#_link#" #_target# title="#htmlEditFormat(opts[link].title)#" >#htmlEditFormat(opts[link].menu)#</a></li>');
+			writeOutput('</ul><hr>');
+			if (opts.keyExists(selectedOption))
+				writeOutput("<h2>#opts[selectedOption].title#</h2>");
 		}
-		writeOutput('</ul><hr>');
-		if (opts.keyExists(selectedOption))
-			writeOutput("<h2>#opts[selectedOption].title#</h2>");
+
 	}
 
 	private string function _getPagePathFromRequest() {


### PR DESCRIPTION
// nice for command line building with curl i.e.
curl --trace http://localhost:4040/build_docs/import/?textonly=true

```PS C:\www\lucee-docs> C:\commandBox\curl -trace http://localhost:4040/build_docs/import/?textlogs=true

Lucee Documentation Builder - 5.2.6.60
Importing References (tags, functions, options, methods)

73ms INFO Start Importing new tags and functions
1,531ms INFO 0 functions imported
3,522ms INFO 0 tags imported
3,552ms INFO 0 objects imported
3,816ms INFO 0 methods imported
3,817ms INFO Finished importing new tags and functions
```


use silent to suppress whitespace from getTagData
https://luceeserver.atlassian.net/browse/LDEV-1796