### PR TITLE
add locks around non thread safe parsers

### DIFF
--- a/api/parsers/MarkdownParser.cfc
+++ b/api/parsers/MarkdownParser.cfc
@@ -17,7 +17,9 @@ component {
 			var doc = processor.parser.parse(arguments.markdown);
 			var html = processor.renderer.render( doc );
 		} else {
-			var html = _getMarkdownProcessor().markdownToHtml( arguments.markdown );
+			lock name="pegDownIsntThreadSafe" timeout="5" type="exclusive" {
+				var html = _getMarkdownProcessor().markdownToHtml( arguments.markdown );
+			}
 		}
 		return _getNoticeBoxRenderer().renderNoticeBoxes( html );
 	}

--- a/api/parsers/YamlParser.cfc
+++ b/api/parsers/YamlParser.cfc
@@ -7,12 +7,17 @@ component {
 		return this;
 	}
 
+	// snakeYaml only rarely has concurrency issues
 	public any function yamlToCfml( required string yaml ) {
-		return _stripEmpty( _getYamlParser().load( arguments.yaml ) );
+		lock name="snakeYamlIsntThreadSafe" timeout="5" type="exclusive" {
+			return _stripEmpty( _getYamlParser().load( arguments.yaml ) );
+		}
 	}
 
 	public any function cfmlToYaml( required struct data ) {
-		return _getYamlParser().dumpAsMap( _stripEmpty(arguments.data) );
+		lock name="snakeYamlIsntThreadSafe" timeout="5" type="exclusive" {
+			return _getYamlParser().dumpAsMap( _stripEmpty(arguments.data) );
+		}
 	}
 
 // PRIVATE

--- a/build.cfm
+++ b/build.cfm
@@ -12,7 +12,7 @@
 		startTime = getTickCount();
 
 		savecontent variable="suppressingwhitespacehere" {
-			new api.build.BuildRunner().buildAll();
+			new api.build.BuildRunner(threads=4).buildAll();
 		}
 
 		content reset="true" type="text/plain";

--- a/import.cfm
+++ b/import.cfm
@@ -1,6 +1,6 @@
 <cfsetting requesttimeout="60000" />
 <cfset startTime = getTickCount()>
-<cfset new api.reference.ReferenceImporter().importAll() />
+<cfset new api.reference.ReferenceImporter(threads=4).importAll() />
 <cfcontent reset="true" type="text/plain">
 <cfoutput>---
 Reference documentation imported in #NumberFormat( getTickCount()-startTime )#ms

--- a/server/Application.cfc
+++ b/server/Application.cfc
@@ -28,7 +28,7 @@
 		var importThreads = 4;
 		// pegdown doesn't work with parallel build, see MarkdownParser.cfc
 		// see https://luceeserver.atlassian.net/browse/LD-109
-		var buildThreads = 1;
+		var buildThreads = 4;
 		if ( path.startsWith( "/lucee/admin") ){
 			request.logger (text="ignoring /lucee/admin request #cgi.script_name#");
 			return;


### PR DESCRIPTION
enable parallel for all builds, use 4 threads
- add exclusive locks around pegdown and snakeYaml
- snakeYaml only rarely has concurrency issues in testing
LD-109