### PR TITLE
Adding _examples.md for BundleInfo()

### DIFF
--- a/docs/03.reference/01.functions/bundleinfo/_examples.md
+++ b/docs/03.reference/01.functions/bundleinfo/_examples.md
@@ -1,0 +1,4 @@
+```luceescript+trycf
+bundle = createObject('java', 'org.joda.time.format.DateTimeFormat', 'org-joda-time', '2.1.0');
+dump(bundleinfo(bundle)); // version 2.1.0
+```


### PR DESCRIPTION
No _examples.md existed for BundleInfo(), so I created one.