### PR TITLE
Filter argument not used in member function

### DIFF
--- a/docs/03.reference/05.objects/struct/filter/_arguments/filter.md
+++ b/docs/03.reference/05.objects/struct/filter/_arguments/filter.md
@@ -1,1 +1,0 @@
-filter can be a function/closure that implements the following constructor [function(any key,any value):boolean].


### PR DESCRIPTION
Looks like this was copied from structFilter which needs the struct to filter as a first argument. The member function obviously does not.