### PR TITLE
Remove struct argument from struct.reduce()

### DIFF
--- a/docs/03.reference/05.objects/struct/reduce/_arguments/struct.md
+++ b/docs/03.reference/05.objects/struct/reduce/_arguments/struct.md
@@ -1,1 +1,0 @@
-struct to iterate


### PR DESCRIPTION
the struct.reduce() member function does not require a struct as an argument