### PR TITLE
Update getnumericdate/function.md

### DIFF
--- a/docs/03.reference/01.functions/getnumericdate/function.md
+++ b/docs/03.reference/01.functions/getnumericdate/function.md
@@ -3,6 +3,7 @@ title: GetNumericDate
 id: function-getnumericdate
 related:
 categories:
+- datetime
 ---
 
-Returns a real number whose integer part represents the number of days since the EPOCH and whose fractional part represents the time value expressed in hours then divided by 24
+Returns a real number whose integer part represents the number of days since the Lucee Server's Epoch (default: December 30, 1899) and whose fractional part represents the time value expressed in hours then divided by 24


### PR DESCRIPTION
Added function to  `datetime` category and clarified the default date for the Lucee Server's Epoch.