### PR TITLE
Update date.diff() member function.

### DIFF
--- a/docs/03.reference/05.objects/datetime/diff/_arguments/date2.md
+++ b/docs/03.reference/05.objects/datetime/diff/_arguments/date2.md
@@ -1,1 +1,0 @@
-date time object to compare


### PR DESCRIPTION
Delete date2 argument for the `date.diff()` member function. It isn't a valid argument.