### PR TITLE
HTML entities needed for <cfinclude>.

### DIFF
--- a/docs/04.guides/04.cookbooks/12.filesystem-mapping/01.filesystem-mapping-define-mapping/page.md
+++ b/docs/04.guides/04.cookbooks/12.filesystem-mapping/01.filesystem-mapping-define-mapping/page.md
@@ -8,7 +8,7 @@ related:
 
 # How to define a regular Mapping #
 
-Lucee allows you to define a mappings to a specific location in a filesystem, so you don't always have to use the full path, in most cases the full path is not working anyway, for example with <cfinclude> does not work with a full path.
+Lucee allows you to define a mappings to a specific location in a filesystem, so you don't always have to use the full path, in most cases the full path is not working anyway, for example with &LT;cfinclude&GT; does not work with a full path.
 This is supported with all filesystems Lucee supports (local,ftp,http,ram,zip,s3 ...).
 
 ## Create a regular Mapping in the Administrator ##


### PR DESCRIPTION
<cfinclude> should be &lt;cfinclude&gt; .  The following HTML is how it's presented at https://docs.lucee.org/guides/cookbooks/filesystem-mapping/filesystem-mapping-define-mapping.html

<cfinclude> does not work with a full path. This is supported with all filesystems Lucee supports (local,ftp,http,ram,zip,s3 ...).</cfinclude>