### PR TITLE
Update description of getTickCount()

### DIFF
--- a/docs/03.reference/01.functions/gettickcount/function.md
+++ b/docs/03.reference/01.functions/gettickcount/function.md
@@ -5,4 +5,4 @@ categories:
 - debugging
 ---
 
-Returns the number of milliseconds since the start of the application server
+Returns the native system time in milliseconds.


### PR DESCRIPTION
The old description of this function seems misleading or outdated. New description reflects the underlying implementation (https://github.com/lucee/Lucee/blob/master/core/src/main/java/lucee/runtime/functions/other/GetTickCount.java) which uses System.currentTimeMillis() or System.nanoTime().