### PR TITLE
Add docs for sessioncookie settings in application.cfc

### DIFF
--- a/docs/03.reference/02.tags/application/_attributes/sessioncookie.md
+++ b/docs/03.reference/02.tags/application/_attributes/sessioncookie.md
@@ -1,1 +1,5 @@
-session cookie behaviour
+A struct which defines session cookie behaviour; the following keys are supported:
+* httpOnly (boolean) Specifies if the session cookies (CFID/CFTOKEN) should have the HTTPOnly cookie flag set. This prevents the cookie value from being read from JavaScript.
+* secure (boolean) Specifies if the session cookies (CFID/CFTOKEN) should have the secure cookie flag set. When true the cookies are only sent over a secure transport (eg HTTPS).
+* domain (string) Specifies the cookie domain used in the session cookies (CFID/CFTOKEN).
+* timeout (string) Specifies the expires value of the session cookies (CFID/CFTOKEN), in days. Set to -1 for browser session cookies.


### PR DESCRIPTION
This is very much needed IMHO, the only documentation for how to use this.sessioncookie is at `https://cfdocs.org/application-cfc`.

Full disclosure, I copied these docs straight from that link. ^^ https://cfdocs.org/application-cfc