### PR TITLE
AWS Secret Key Variable Incorrect

### DIFF
--- a/docs/04.guides/04.cookbooks/36.s3_sourceCode/page.md
+++ b/docs/04.guides/04.cookbooks/36.s3_sourceCode/page.md
@@ -21,7 +21,7 @@ content file = "s3:///cfml1/lucee.png" type = "image/png"
 component{
 	this.name = 'exampleS3';
 	this.s3.accesskeyid = "JHKLJHGSGSGVSGVS";
-	this.s3.secretkey = "Jgftiutry3uwiumcx4bvhjf9ksepu5wrwnvwbh9gj";
+	this.s3.awssecretkey = "Jgftiutry3uwiumcx4bvhjf9ksepu5wrwnvwbh9gj";
 }
 ```
 


### PR DESCRIPTION
the Lucee application setting for the AWS secret key is `awsSecretKey`, not `secretKey`