### PR TITLE
Document `terminateontimeout` default value for cfexecute

### DIFF
--- a/docs/03.reference/02.tags/execute/_attributes/terminateOnTimeout.md
+++ b/docs/03.reference/02.tags/execute/_attributes/terminateOnTimeout.md
@@ -1,1 +1,1 @@
-terminate execution of process when timeout occur
+terminate execution of process when timeout occur. Defaults to false.


### PR DESCRIPTION
I'm not a Java dev, but if I'm reading this right, the default is false - yes?
https://github.com/lucee/Lucee/blob/29b153fc4e126e5edb97da937f2ee2e231b87593/core/src/main/java/lucee/runtime/tag/Execute.java#L72