### PR TITLE
Replace Ilich VS Code extension with KamasamaK

### DIFF
--- a/docs/04.guides/01.getting-started/07.lucee-editors-IDEs/page.md
+++ b/docs/04.guides/01.getting-started/07.lucee-editors-IDEs/page.md
@@ -21,7 +21,7 @@ Lucee dictionaries are available for download to support spell checking your cod
 ## VS Code
 <https://code.visualstudio.com>
 
-<https://marketplace.visualstudio.com/items?itemName=ilich8086.ColdFusion>
+<https://marketplace.visualstudio.com/items?itemName=KamasamaK.vscode-cfml>
 
 <https://marketplace.visualstudio.com/items?itemName=KamasamaK.vscode-cflint>
 


### PR DESCRIPTION
I think it's better to promote the [CFML extension](https://marketplace.visualstudio.com/items?itemName=KamasamaK.vscode-cfml) than the [coldfusion extension](https://marketplace.visualstudio.com/items?itemName=ilich8086.ColdFusion) simply because the former is more up to date.

Perhaps I am wrong, and we should simply list the two side-by-side?