### PR TITLE
Updated getDirectoryFromPath() example

### DIFF
--- a/docs/03.reference/01.functions/getdirectoryfrompath/_examples.md
+++ b/docs/03.reference/01.functions/getdirectoryfrompath/_examples.md
@@ -1,4 +1,4 @@
-```luceescript
-testDir = getDirectoryFromPath("path");
-writeDump(testDir);
+```luceescript+trycf
+some_directory = getDirectoryFromPath("path");
+dump(some_directory);
 ```


### PR DESCRIPTION
I was going to use `getCurrentTemplatePath()`, but I felt that that would expose too much of the underlying site structure to malicious-minded users.