### PR TITLE
Fix example rendering

### DIFF
--- a/docs/03.reference/02.tags/queryparam/_examples.md
+++ b/docs/03.reference/02.tags/queryparam/_examples.md
@@ -1,4 +1,4 @@
-```
+```luceescript
 <cfscript>
 	_test = queryNew("_id,_need,_forWorld","integer,varchar,varchar", [[01,'plant', 'agri'],[02, 'save','water']]);
 </cfscript>


### PR DESCRIPTION
Without the `luceescript`, it does not render as a code block