### PR TITLE
Fixed cfrethrow tagContext mention

### DIFF
--- a/docs/03.reference/02.tags/rethrow/tag.md
+++ b/docs/03.reference/02.tags/rethrow/tag.md
@@ -6,5 +6,4 @@ related:
 - tag-try
 ---
 
-Rethrows the currently active exception. Preserves the exception's cfcatch.type and [[tag-catch]].
-  agContext information.
+Rethrows the currently active exception. Preserves the exception's cfcatch.type and cfcatch.tagContext information.


### PR DESCRIPTION
The cfcatch.tagContext mention was borked in this documentation, so I fixed it. :)