### PR TITLE
Lucee doesn't support autogenmap=false yet

### DIFF
--- a/docs/03.reference/02.tags/application/_attributes/ormsettings.md
+++ b/docs/03.reference/02.tags/application/_attributes/ormsettings.md
@@ -1,6 +1,6 @@
 A struct that defines all the ORM settings, the following keys are supported:
 
-- autogenmap(default:true): Specifies whether Lucee should automatically generate mapping for the persistent CFCs. If autogenmap=false, mapping should be provided in the form of "{cfc-name}.cfc.hbm.xml" files.
+- autogenmap(default:true; autogenmap=false is not supported yet): Specifies whether Lucee should automatically generate mapping for the persistent CFCs. If autogenmap=false, mapping should be provided in the form of "{cfc-name}.cfc.hbm.xml" files.
 - automanageSession(default:true; not supported yet): Lets you specify if Lucee must manage Hibernate session automatically. If enabled: Lucee manages the session completely. That is, it decides when to flush the session, when to clear the session, and when to close the session. If disabled: The application is responsible for managing flushing, clearing, or closing of the session. The only exception is (in the case of transaction), when the transaction commits, the application flushes the session. Lucee closes the ORM session at the end of request irrespective of this flag being enabled or disabled.
 - cacheconfig: Specifies the location of the configuration file that should be used by the secondary cache provider.This setting is used only when secondarycacheenabled=true.
 - cacheprovider: Specifies the cache provider that should be used by ORM as secondary cache.


### PR DESCRIPTION
There is no information at the documentation says Lucee doesn't support the ORM setting autogenmap=false yet. However, the server returns a message that says autogenmap=false is not supported yet.