### PR TITLE
Update closure for struct.each()

### DIFF
--- a/docs/03.reference/05.objects/struct/each/_arguments/closure.md
+++ b/docs/03.reference/05.objects/struct/each/_arguments/closure.md
@@ -1,1 +1,1 @@
-UDF/Closure that call with the entries from struct
+UDF/Closure that call with the entries from struct with the signature ( key, [ value ]  )


### PR DESCRIPTION
It didn't explicitly indicate that the value could be passed into the closure (nor does the example). Now it does.