### PR TITLE
Fix example of overriding tag properties in cflog

### DIFF
--- a/docs/03.reference/02.tags/listing.md
+++ b/docs/03.reference/02.tags/listing.md
@@ -25,7 +25,7 @@ You can also assign default values for any tag's attributes using *this.tag.tagn
 
 ```luceescript
 this.tag.cfhttp.username = "system";
-this.tag.cflog.logfile = "my-custom-log.log";
+this.tag.log.file = "my-custom-log.log";
 this.tag.cflocation.addtoken = false;
 ```
 


### PR DESCRIPTION
The existing example does not work.