### PR TITLE
Added mysql structure export for reference

### DIFF
--- a/docs/04.guides/13.Various/15.FAQs/01.technical-FAQs/02.database-session/page.md
+++ b/docs/04.guides/13.Various/15.FAQs/01.technical-FAQs/02.database-session/page.md
@@ -46,4 +46,26 @@ That's it!
 
 * Type of "data" column should be longtext, not text. Run ALTER TABLE cf_session_data MODIFY data longtext to change. (Fixed in versions 4.2.0, 4.1.2.006). This is a must have if you store big data (arrays, structs) in session. Otherwise you'll get the data truncation error
 
+For reference only and in case information about structure and indexes of the mysql tables is needed, find a MySql structure export of the cf_session_data and cf_client_data below:
+
+```
+CREATE TABLE IF NOT EXISTS `cf_session_data` (
+  `expires` varchar(64) NOT NULL,
+  `cfid` varchar(64) NOT NULL,
+  `name` varchar(255) NOT NULL,
+  `data` text NOT NULL,
+  UNIQUE KEY `ix_cf_session_data` (`cfid`,`name`,`expires`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+```
+
+```
+CREATE TABLE IF NOT EXISTS `cf_client_data` (
+  `expires` varchar(64) NOT NULL,
+  `cfid` varchar(64) NOT NULL,
+  `name` varchar(255) NOT NULL,
+  `data` text NOT NULL,
+  UNIQUE KEY `ix_cf_client_data` (`cfid`,`name`,`expires`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+```
+
 **Note** All manipulations with session data are always performed in memory. Only after session become inactive for about 10 sec Lucee will dump session data to database and free up memory. Every 1 hour Lucee automatically cleans database from expired sessions (session timeout value).


### PR DESCRIPTION
Added a mysql structure export of the cf_client_data and cf_session_data for reference, because that has been missed before ( please see https://dev.lucee.org/t/index-on-lucee-client-variables-in-mysql/941/3 ) Please feel free to edit, correct or delete if needed.