### PR TITLE
Updated _examples.md for String.findOneOf()

### DIFF
--- a/docs/03.reference/05.objects/string/findoneof/_examples.md
+++ b/docs/03.reference/05.objects/string/findoneof/_examples.md
@@ -1,5 +1,4 @@
-
 ```luceescript+trycf
-	dump(FindOneOf("L", "I Love Lucee" ));
-  	dump(FindOneOf("L", "I Love Lucee",6));
+dump("I".findoneof("I Love Lucee"));
+dump("Lu".findoneof("I Love Lucee"));
 ```


### PR DESCRIPTION
Updated the example to use the member method instead of FindOneOf() standalone.