### PR TITLE
Fix htmlstripping of cfml tags in metadescription

### DIFF
--- a/builders/html/helpers/metaDescription.cfm
+++ b/builders/html/helpers/metaDescription.cfm
@@ -6,6 +6,8 @@
 			description = arguments.body;
 			description = ReReplaceNoCase( description, "^(.*?)</p>.*$", "\1" );
 		}
+		
+		description = ReReplaceNoCase( description, "`<(cf.*?)>`", "\1" );
 		description = stripHtml( description );
 
 		// max recommended length for a meta description is 320 characters


### PR DESCRIPTION
to see the issue please see the tag description for cfcalender at
https://docs.lucee.org/reference/tags.html
The fix ensures that cfml tags don't get stripped by converting
them to plain text before stripHtml() occurs.