### PR TITLE
Show local changes and avoid case problems for files LDEV-3252

### DIFF
--- a/api/data/PageReader.cfc
+++ b/api/data/PageReader.cfc
@@ -183,7 +183,7 @@ component {
 		arrayAppend(arguments.related, links , true )
 	}
 
-	private struct function _getTagSpecification( required string tagName, required string pageFilePath ) output=true{
+	private struct function _getTagSpecification( required string tagName, required string pageFilePath ){
 		var tag           = _getTagReferenceReader().getTag( arguments.tagName );
 		var attributes    = tag.attributes ?: [];
 		var attributesDir = GetDirectoryFromPath( arguments.pageFilePath ) & "_attributes/";		

--- a/builders/html/helpers/sourceRepoLink.cfm
+++ b/builders/html/helpers/sourceRepoLink.cfm
@@ -13,6 +13,15 @@
 		return Replace( sourceBase, "{path}", fixPathCase( arguments.path ) );
 	}
 
+	string function showOriginalDescription( required struct props, required boolean edit, required any markdownToHtml ) {
+		if (arguments.edit
+			and structKeyExists(arguments.props, "descriptionOriginal") 
+			and arguments.props.descriptionOriginal neq arguments.props.description){
+				return "<b>Modifed in Lucee Docs, Source Lucee definition:</b>" & arguments.markdownToHtml(arguments.props.descriptionOriginal);
+		}
+		return "";
+	}
+
 	string function fixPathCase( required string path ) {
 		var dir = getDirectoryFromPath( arguments.path );
 		var files = directoryList( dir, false, 'name' );

--- a/builders/html/templates/_method.cfm
+++ b/builders/html/templates/_method.cfm
@@ -52,6 +52,7 @@
 								<cfif local.arg.keyExists("alias") and len(local.arg.alias) gt 0>
 									<p title="for compatibility, this argument has the following alias(es)"><sub>Alias:</strong> #ListChangeDelims(local.arg.alias,", ",",")#</sub></p>
 								</cfif>
+								#showOriginalDescription(props=local.arg, edit=args.edit, markdownToHtml=markdownToHtml)#
 							</td>
 							<cfif local.argumentsHaveDefaultValues>
  								<td>

--- a/builders/html/templates/function.cfm
+++ b/builders/html/templates/function.cfm
@@ -65,13 +65,14 @@
 								</cfif>
 								<cfif structKeyExists(local.arg, "status") and local.arg.status neq "implemented">
 									<em>* #local.attrib.arg# *</em>
-								</cfif>								
+								</cfif>
+								#showOriginalDescription(props=local.arg, edit=args.edit, markdownToHtml=markdownToHtml)#
 							</td>
 							<cfif local.argumentsHaveDefaultValues>
  								<td>
  									#markdownToHtml( local.arg.default ?: "" )#
  								</td>
- 							</cfif>
+							 </cfif>
 						</tr>
 					</cfloop>
 				</tbody>

--- a/builders/html/templates/tag.cfm
+++ b/builders/html/templates/tag.cfm
@@ -46,12 +46,13 @@
 								<cfif structKeyExists(local.attrib, "status") and local.attrib.status neq "implemented">
 									<em>* #local.attrib.status# *</em>
 								</cfif>
+								#showOriginalDescription(props=local.attrib, edit=args.edit, markdownToHtml=markdownToHtml)#
 							</td>
  							<cfif local.attributesHaveDefaultValues>
  								<td>
  									#markdownToHtml( local.attrib.defaultValue ?: "" )#
  								</td>
- 							</cfif>
+							 </cfif>
 						</tr>
 					</cfloop>
 				</tbody>


### PR DESCRIPTION
- on linux / CI the file system is case sensitive and the args and attributes filenames weren't being match
- show original Lucee provided args and attribute descriptions in edit mode, when they differ to docs

https://luceeserver.atlassian.net/browse/LDEV-3252

![image](https://user-images.githubusercontent.com/426404/106443187-7e24df00-647c-11eb-934a-0a7c2ef47a2b.png)
