### PR TITLE
fix table responsiveness on mobile view

### DIFF
--- a/docs/04.guides/13.Various/01.system-properties/page.md
+++ b/docs/04.guides/13.Various/01.system-properties/page.md
@@ -31,11 +31,26 @@ On startup Lucee identifies specific *Environment Variables* or JVM *System Prop
 While system environment variable names need to be notated as *MACRO_CASE*, system property names need to be in *dot.notation*.
 
 See as an example of variable/property name notation for enabling full null support in the table below:
-
-|  Use as 	|	Notation Example	|
-|---	|---	|
-|	  Environment Variables	| `LUCEE_FULL_NULL_SUPPORT=true` *(MACRO_CASE)*	|
-|	  System Properties		| `lucee.full.null.support=true` *(dot.notation)* |
+<div class="table-responsive">
+    <table>
+        <thead>
+            <tr>
+                <th>Use as </th>
+                <th>Notation Example </th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>Environment Variables </td>
+                <td><code>LUCEE_FULL_NULL_SUPPORT=true</code> <em>(MACRO_CASE)</em> </td>
+            </tr>
+            <tr>
+                <td>System Properties </td>
+                <td><code>lucee.full.null.support=true</code> <em>(dot.notation)</em> </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 <br>
 
 ### 3. Setting The Variables ###
@@ -47,13 +62,39 @@ There are many different ways to make *Environment Variables* or *System Propert
 ### 3.1 How To Set Environment Variables ###
 
 Find below a brief overview of available options about where and how to set your *Environment Variables*:
-
-|  Where | Variables availablility| How to configure |
-|---	|---	|---	|
-| OS (globally)| OS (system-wide)| Environment variables are configured within your OS configuration. Please refer to the documentation of your OS |
-| OS (user specific) | OS (system-wide), but limited to user | Environment variables are configured within the OS user's profile configuration. Please refer to the documentation of your OS  |
-|  Servlet Engine Tomcat | Limited to the running servlet instance  |  **Option I:** Use Tomcats *path-to-lucee-installation\tomcat\bin\setenv.bat (Windows) or path-to-lucee-installation\tomcat\bin\setenv.sh (Linux)*  as specified in [Tomcats 9.0 Documentation (see 3.4)](https://tomcat.apache.org/tomcat-9.0-doc/RUNNING.txt)<br> **Option II:** Run Tomcat with the argument *--Environment=key1=value1;key2=...* as specified in  [Tomcat 9 parameters](https://tomcat.apache.org/tomcat-9.0-doc/windows-service-howto.html) |
-| CommandBox | Limited to the running CommandBox instance | Since CommandBox 4.5 *Environment Variables* can be set in a file named ".env". You can easily create the .env file by running the command `dotenv set` from your CommanBox CLI. For more information please see [How to set it up CommandBox with .env files](https://github.com/commandbox-modules/commandbox-dotenv) and [CommandBox Environement Variables](https://commandbox.ortusbooks.com/usage/environment-variables) |
+<div class="table-responsive">
+    <table>
+        <thead>
+            <tr>
+                <th>Where </th>
+                <th>Variables availablility</th>
+                <th>How to configure </th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>OS (globally)</td>
+                <td>OS (system-wide)</td>
+                <td>Environment variables are configured within your OS configuration. Please refer to the documentation of your OS </td>
+            </tr>
+            <tr>
+                <td>OS (user specific) </td>
+                <td>OS (system-wide), but limited to user </td>
+                <td>Environment variables are configured within the OS user's profile configuration. Please refer to the documentation of your OS </td>
+            </tr>
+            <tr>
+                <td>Servlet Engine Tomcat </td>
+                <td>Limited to the running servlet instance </td>
+                <td><strong>Option I:</strong> Use Tomcats <em>path-to-lucee-installation\tomcat\bin\setenv.bat (Windows) or path-to-lucee-installation\tomcat\bin\setenv.sh (Linux)</em> as specified in <a href="https://tomcat.apache.org/tomcat-9.0-doc/RUNNING.txt">Tomcats 9.0 Documentation (see 3.4)</a><br> <strong>Option II:</strong> Run Tomcat with the argument <em>--Environment=key1=value1;key2=...</em> as specified in <a href="https://tomcat.apache.org/tomcat-9.0-doc/windows-service-howto.html">Tomcat 9 parameters</a> </td>
+            </tr>
+            <tr>
+                <td>CommandBox </td>
+                <td>Limited to the running CommandBox instance </td>
+                <td>Since CommandBox 4.5 <em>Environment Variables</em> can be set in a file named ".env". You can easily create the .env file by running the command <code>dotenv set</code> from your CommanBox CLI. For more information please see <a href="https://github.com/commandbox-modules/commandbox-dotenv">How to set it up CommandBox with .env files</a> and <a href="https://commandbox.ortusbooks.com/usage/environment-variables">CommandBox Environement Variables</a> </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
 
 In the following example we'll follow Tomcat's recommendation and set *Environment Variables* by using Tomcats setenv.bat/setenv.sh files.
 

--- a/docs/04.guides/13.Various/01.system-properties/page.md
+++ b/docs/04.guides/13.Various/01.system-properties/page.md
@@ -96,7 +96,7 @@ Find below a brief overview of available options about where and how to set your
     </table>
 </div>
 
-In the following example we'll follow Tomcat's recommendation and set *Environment Variables* by using Tomcats setenv.bat/setenv.sh files.
+In the following example we'll follow Tomcat's recommendation and set *Environment Variables* by using Tomcats setenv.bat/setenv.sh files. 
 
 **For Windows:** Create a batch file at  *path-to-lucee-installation\tomcat\bin\setenv.bat* with the following content:
 
@@ -110,6 +110,11 @@ set "LUCEE_FULL_NULL_SUPPORT=true"
 REM Set Simple whitespace management
 set "LUCEE_CFML_WRITER=white-space"
 ```
+
+If you have installed **Tomcat as service in Windows**, the service wrapper launches Java directly without using script files. 
+
+In this case you can alternatively add the *Environment Variables* by running the following Tomcat service update command in a terminal window: 
+`path-to-lucee-installation\tomcat\bin\tomcat9.exe //US//NameOfYourTomcatService --Environment=key1=value1;key2=...`
 
 **For Linux:** Create a shell script at  *path-to-lucee-installation\tomcat\bin\setenv.sh* with the following content:
 
@@ -138,10 +143,26 @@ In this example we will focus on configuring *System Properties* when running Lu
 
 Here is a brief overview.
 
-|	Configuration for | How to configure |
-|---				 |---					 |
-|	Servlet Engine Tomcat | Use Tomcats *path-to-lucee-installation\tomcat\bin\setenv.bat or path-to-lucee-installation\tomcat\bin\setenv.sh* and add the system property using `CATALINA_OPTS`. See [Tomcats 9.0 Documentation (see 3.3)](https://tomcat.apache.org/tomcat-9.0-doc/RUNNING.txt)	|
- CommandBox | In CommandBox *System Properties* can be set like Environment Variables in the `.env` file. |
+<div class="table-responsive">
+	<table>
+		<thead>
+			<tr>
+				<th>Configuration for </th>
+				<th>How to configure </th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td>Servlet Engine Tomcat </td>
+				<td>Use Tomcats <em>path-to-lucee-installation\tomcat\bin\setenv.bat or path-to-lucee-installation\tomcat\bin\setenv.sh</em> and add the system property using <code>CATALINA_OPTS</code>. See <a href="https://tomcat.apache.org/tomcat-9.0-doc/RUNNING.txt">Tomcats 9.0 Documentation (see 3.3)</a> </td>
+			</tr>
+			<tr>
+				<td>CommandBox </td>
+				<td>In CommandBox <em>System Properties</em> can be set like Environment Variables in the <code>.env</code> file. </td>
+			</tr>
+		</tbody>
+	</table>
+</div>
 
 In Tomcat *System Properties* are passed to the JVM servlet engine Tomcat on startup by populating CATALINA_OPTS with the -D flag, e.g. `-Dlucee.full.null.support=true` (note that there is no space between the -D flag and the system property key/value).
 
@@ -153,6 +174,12 @@ With Tomcat it's recommended to set CATALINA_OPTS in the setenv.bat/setenv.sh fi
 REM Set System Properties with CATALINA_OPTS
 set "CATALINA_OPTS=-Dlucee.full.null.support=true -Dlucee.cfml.writer=white-space -Dlucee.cfml.writer=white-space"
 ```
+
+If you have installed **Tomcat as service in Windows**, the service wrapper launches Java directly without using script files. 
+
+In this case you can alternatively add the *System Properties* in the JAVA tab of Tomcats GUI service editor.
+
+To launch Tomcat GUI service editor, open a terminal window and enter `path-to-lucee-installation\tomcat\bin\tomcat9w.exe //ES//NameOfYourTomcatService`. 
 
 **For Linux:** Create a shell script at  *path-to-lucee-installation\tomcat\bin\setenv.sh* with the following content:
 


### PR DESCRIPTION
This patch fixes table responsiveness on mobile view for the section "system properties". The markdown tables were breaking the mobile view because they were expanding the complete body/view witdth of the page with unwished results for smaller view widths. This fix contains the former markdown tables now as plain html, because actually it's not possible to wrap markdown tables inside html tags, such as e.g.

<div class="table-responsive">
|  Use as 	|   Notation Example	|
|---	|---	|
|     Environment Variables	| `LUCEE_FULL_NULL_SUPPORT=true` *(MACRO_CASE)*	|
</div>

Known workarounds such as using the 'markdown="1"' attribute on html tags or wrapping inside span tags don't work.