### PR TITLE
Update page.md to correct image loading

### DIFF
--- a/docs/04.guides/04.cookbooks/22.Extension-Installation/page.md
+++ b/docs/04.guides/04.cookbooks/22.Extension-Installation/page.md
@@ -20,13 +20,13 @@ If you want to use an Extension for the whole server, you should install it unde
 
 All available Extensions are listed under  **Extension -> Applications**
 
-![Extension](assets/images/screenImages/Extension.png)
+![Extension](/assets/images/screenImages/Extension.png)
 
 Here you can see which extensions are installed and not installed.
 
 Installed extensions, with an update available have a red overlay.
 
-![Extension Details](assets/images/screenImages/Extension_Detail.png)
+![Extension Details](/assets/images/screenImages/Extension_Detail.png)
 
 On the Extension detail page, you can upgrade or downgrade the version or uninstall it.
 


### PR DESCRIPTION
I think I was able to correct the image links. What was causing the images not loading was the missing preceding single slash, that makes the browser request load from the root. Without the slash the image gets requested from https://docs.lucee.org/guides/cookbooks/assets/images/screenImages/Extension.png, but the image is located at https://docs.lucee.org/assets/images/screenImages/Extension.png.  This can be seen from Chromes Dev Tool in the network tab and the path column. Don't know why the path is correct when running in Win locally 127.0.0.1:4040