### PR TITLE
Add missing cfscript example for cfwddx

### DIFF
--- a/docs/03.reference/02.tags/wddx/_examples.md
+++ b/docs/03.reference/02.tags/wddx/_examples.md
@@ -1,1 +1,6 @@
-*There are currently no examples for this tag.*
+To use this tag in cfscript:
+```
+<cfscript>
+  wddx action='wddx2cfml' input=strWDDX output='local.example';
+</cfscript>
+```

--- a/docs/03.reference/02.tags/wddx/_examples.md
+++ b/docs/03.reference/02.tags/wddx/_examples.md
@@ -1,4 +1,5 @@
 To use this tag in cfscript:
+
 ```
 <cfscript>
   // This WDDX packet contains a struct with 4 keys: 3 strings and 1 array of numbers

--- a/docs/03.reference/02.tags/wddx/_examples.md
+++ b/docs/03.reference/02.tags/wddx/_examples.md
@@ -1,6 +1,11 @@
 To use this tag in cfscript:
 ```
 <cfscript>
-  wddx action='wddx2cfml' input=strWDDX output='local.example';
+  // This WDDX packet contains a struct with 4 keys: 3 strings and 1 array of numbers
+  strWDDX = "<wddxPacket version='1.0'><header/><data><struct><var name='VERSION'><string>1.0.0</string></var><var name='COUNTDOWNARRAY'><array length='5'><number>5.0</number><number>4.0</number><number>3.0</number><number>2.0</number><number>1.0</number></array></var><var name='NAME'><string>Test Struct</string></var><var name='DESCRIPTION'><string>To illustrate serializing to WDDX</string></var></struct></data></wddxPacket>";
+  
+  wddx action='wddx2cfml' input=strWDDX output='example';
+  
+  dump(example);
 </cfscript>
 ```


### PR DESCRIPTION
It took us a while to figure this one out so to save the next dev some  time, an example will do just fine.