### PR TITLE
Add security warning to `encodeForSQL()` docs

### DIFF
--- a/docs/03.reference/05.objects/string/encodeforsql/_method.md
+++ b/docs/03.reference/05.objects/string/encodeforsql/_method.md
@@ -13,4 +13,4 @@ categories:
 - query
 ---
 
-Encodes the given string for safe output in a query to reduce the risk Cross Site Scripting attacks.
+Encodes the given string for safe output in a query to reduce the risk Cross Site Scripting attacks. _This method is not recommended_ - the use of query parameters are strongly encouraged. See [[tag-queryparam]].

--- a/docs/03.reference/05.objects/string/encodeforsql/_method.md
+++ b/docs/03.reference/05.objects/string/encodeforsql/_method.md
@@ -13,4 +13,4 @@ categories:
 - query
 ---
 
-Encodes the given string for safe output in a query to reduce the risk Cross Site Scripting attacks. _This method is not recommended_ - the use of query parameters are strongly encouraged. See [[tag-queryparam]].
+Encodes the given string for safe output in a query to reduce the risk of SQL Injection attacks. _This method is not recommended_ - the use of query parameters are strongly encouraged. See [[tag-queryparam]].


### PR DESCRIPTION
As mentioned in LDEV-3540, the `encodeForSQL()` method is not a safe alternative to using query parameters. This PR adds a note that the developer should consider using query parameters instead of this weaker "solution".

https://luceeserver.atlassian.net/browse/LDEV-3540