### PR TITLE
Update _examples.md

### DIFF
--- a/docs/03.reference/02.tags/case/_examples.md
+++ b/docs/03.reference/02.tags/case/_examples.md
@@ -1,4 +1,5 @@
 ```lucee+trycf
+<!--- Tag syntax --->
 <cfset expr = 2>
 <cfswitch expression="#expr#">
     <cfcase value=1>
@@ -7,15 +8,23 @@
     <cfcase value=2$3$4 delimiters="$">
         this is from case 2
     </cfcase>
+    <cfcase value=5,6,7>
+        this is from case 3
+    </cfcase>
     <cfdefaultcase>
         this is from default part
     </cfdefaultcase>
 </cfswitch>
 
+<!--- Script syntax --->
 <cfscript>
-    switch(1){
+    expr = 1;
+    switch(expr){
         case 1:
             result = 1;
+            break;
+        case 2: case 3:
+            result = "2 or 3";
             break;
         case 0:
             result = 0;

--- a/docs/03.reference/02.tags/case/_examples.md
+++ b/docs/03.reference/02.tags/case/_examples.md
@@ -23,7 +23,8 @@
         case 1:
             result = 1;
             break;
-        case 2: case 3:
+        case 2: 
+        case 3:
             result = "2 or 3";
             break;
         case 0:


### PR DESCRIPTION
Tag syntax <cfswitch>/<cfcase> and scipting syntax “switch / case” 
[https://dev.lucee.org/t/scipting-version-switch-case-does-not-work-with-the-comma-as-standard-delimiter/8931](https://dev.lucee.org/t/scipting-version-switch-case-does-not-work-with-the-comma-as-standard-delimiter/8931)