### PR TITLE
Update spreadsheet library links.

### DIFF
--- a/docs/03.reference/01.functions/spreadsheetnew/page.md
+++ b/docs/03.reference/01.functions/spreadsheetnew/page.md
@@ -12,4 +12,4 @@ Third party support is available via the following projects:
 
 <https://github.com/Leftbower/cfspreadsheet-lucee-5>
 
-<https://github.com/cfsimplicity/lucee-spreadsheet>
+<https://github.com/cfsimplicity/spreadsheet-cfml>

--- a/docs/03.reference/02.tags/spreadsheet/page.md
+++ b/docs/03.reference/02.tags/spreadsheet/page.md
@@ -11,4 +11,4 @@ Third party support is available via the following projects:
 
 <https://github.com/Leftbower/cfspreadsheet-lucee-5>
 
-<https://github.com/cfsimplicity/lucee-spreadsheet>
+<https://github.com/cfsimplicity/spreadsheet-cfml>

--- a/docs/04.guides/03.updating-lucee/02.migrate-from-railo/page.md
+++ b/docs/04.guides/03.updating-lucee/02.migrate-from-railo/page.md
@@ -119,7 +119,7 @@ However a [modified version by Andrew Kretzer for Lucee 4.5](https://github.com/
 
 An updated version for Lucee 5 can be found at [https://github.com/Leftbower/cfspreadsheet-lucee-5](https://github.com/Leftbower/cfspreadsheet-lucee-5).
 
-Alternatively, a standalone (non-extension) [spreadsheet library for Lucee](https://github.com/cfsimplicity/lucee-spreadsheet) is available which supports almost all of the extension's functionality.
+Alternatively, a standalone (non-extension) [CFML spreadsheet library](https://github.com/cfsimplicity/spreadsheet-cfml) is available which supports all of the extension's functionality and more.
 
 ### Video
 

--- a/docs/04.guides/04.cookbooks/55.working-with-spreadsheets/page.md
+++ b/docs/04.guides/04.cookbooks/55.working-with-spreadsheets/page.md
@@ -18,8 +18,8 @@ You can install this extension either via the Lucee Admin GUI or programmaticall
 
 Note that there is a [version of this extension for Lucee 4.x](https://github.com/Leftbower/cfspreadsheet-lucee)
 
-## *cfsimplicity/lucee-spreadsheet* Standalone Library
+## *cfsimplicity/spreadsheet-cfml* Standalone Library
 
-[https://github.com/cfsimplicity/lucee-spreadsheet](https://github.com/cfsimplicity/lucee-spreadsheet)
+[https://github.com/cfsimplicity/spreadsheet-cfml](https://github.com/cfsimplicity/spreadsheet-cfml)
 
-Developed by Julian Halliwell, this approach to working with spreadsheets does not require installing an extension. However, if you are working with an existing codebase, it will need to be rewritten in order to invoke the library's spreadsheet functions. That is, this library doesn't replicate Adobe CFML's spreadsheet functions or `<cfspreadsheet>` tag. The benefits of this approach include cross-engine compatibility and a range of more powerful functions and options for working with spreadsheets.
+A full featured library for working with spreadsheets in CFML which does not require installing an extension. However, if you are working with an existing Adobe ColdFusion codebase, it will need to be rewritten in order to invoke the library's spreadsheet functions since it doesn't replicate ColdFusion's spreadsheet function syntax exactly or support the `<cfspreadsheet>` tag. The benefits of this approach include cross-engine compatibility and a range of more powerful functions and options for working with spreadsheets.


### PR DESCRIPTION
Repo now called `spreadsheet-cfml`. Plus a few minor copy edits.