### PR TITLE
Update the link anchor text

### DIFF
--- a/docs/00.home/homepage.md
+++ b/docs/00.home/homepage.md
@@ -26,4 +26,4 @@ For Java API documentation of the Lucee server engine, please visit [https://jav
 
 ## Lucee on YouTube
 
-We also have a channel on YouTube where you can find further tutorials and tips: [https://www.youtube.com/channel/UCdsCTvG8-gKUu4zA309EZYA](https://www.youtube.com/channel/UCdsCTvG8-gKUu4zA309EZYA)
+We also have a channel on YouTube where you can find further tutorials and tips: [Lucee YouTube Channel](https://www.youtube.com/channel/UCdsCTvG8-gKUu4zA309EZYA)


### PR DESCRIPTION
Update the link anchor text of the Lucee YouTube Link, because on smaller devices the URL as anchor link text wont't fully wrap and force the top navigation header to expand to its full with: the result is parts of the navigation header being pushed out of devices view to the right, hiding for example the search box  icon.