### PR TITLE
fix css for correcting long line code breaks in pre-tags

### DIFF
--- a/Application.cfc
+++ b/Application.cfc
@@ -1,7 +1,7 @@
 component {
 	this.name = "luceeDocumentationBuilder-" & Hash( GetCurrentTemplatePath() );
 
-	variables.assetBundleVersion = 34; // must match lucee-docs\builders\html\assets\Gruntfile.js _version
+	variables.assetBundleVersion = 35 // must match lucee-docs\builders\html\assets\Gruntfile.js _version
 
 	this.cwd = GetDirectoryFromPath( GetCurrentTemplatePath() )
 

--- a/builders/html/assets/Gruntfile.js
+++ b/builders/html/assets/Gruntfile.js
@@ -5,7 +5,7 @@ module.exports = function(grunt) {
 	grunt.registerTask( 'default', [ 'concat:base', 'uglify:base', 'sass:base', 'sassUnicode:base', 'cssmin:base', 'copy:base'] );
 
 
-	var _version = 34; // update in Application.cfc(s) too assetBundleVersion
+	var _version = 35; // update in Application.cfc(s) too assetBundleVersion
 
 	// grunt config
 	grunt.initConfig({

--- a/builders/html/assets/css/base.35.min.css
+++ b/builders/html/assets/css/base.35.min.css
@@ -1,0 +1,1255 @@
+@charset "UTF-8";*,:after,:before{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}@-ms-viewport{width:device-width}
+article,aside,footer,header,nav,section{display:block}audio{display:inline-block;max-width:100%;vertical-align:baseline}body{background-color:#fafafa;
+background-image:none;color:#212121;font-family:Roboto,"Helvetica Neue",Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:24px;
+margin:0;padding:0;-webkit-font-smoothing:subpixel-antialiased}html{font-family:sans-serif;font-size:100%;min-height:100%;position:relative;
+-webkit-tap-highlight-color:transparent;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%}svg:not(:root){overflow:hidden}[hidden],template{
+display:none}video{display:block;max-width:100%}button,input,optgroup,select,textarea{color:inherit;font:inherit;margin:0}button,input[type=button],
+input[type=reset],input[type=submit]{cursor:pointer;-webkit-appearance:button}button,select{text-transform:none}button{overflow:visible}
+button[disabled],input[disabled]{cursor:default}button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}fieldset{border:0;margin:0;
+min-width:0;padding:0}fieldset~fieldset{margin-top:24px}input{line-height:normal}input[type=checkbox],input[type=radio]{line-height:normal;margin:4px 
+0 0;padding:0}input[type=color]{min-width:24px;width:auto}input[type=date],input[type=datetime-local],input[type=month],input[type=time]{line-height:
+24px}input[type=file]{display:block;height:auto;line-height:1;min-height:36px;padding-top:6px;padding-bottom:6px}
+input[type=number]::-webkit-inner-spin-button,input[type=number]::-webkit-outer-spin-button{height:auto}input[type=range]{display:block;height:36px;
+width:100%}input[type=search]{-webkit-appearance:none;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}
+input[type=search]::-webkit-search-cancel-button,input[type=search]::-webkit-search-decoration{-webkit-appearance:none}label{display:inline-block;
+font-weight:400;margin:0;max-width:100%}legend{border:0;color:#212121;display:block;font-size:20px;font-weight:400;line-height:28px;margin:0 0 24px;
+padding:0;width:100%}optgroup{font-weight:700}select[multiple],select[size]{height:auto}textarea{overflow:auto}a{background-color:transparent;
+background-image:none;color:#2196f3;text-decoration:none}a:focus,a:hover{color:#0d47a1;outline:0;text-decoration:underline}abbr{border-bottom:1px 
+dotted #9e9e9e;cursor:help}address{font-size:16px;font-style:normal;font-weight:400;line-height:24px;margin:24px 0}b,strong{font-weight:700}blockquote
+,q{font-size:16px;font-style:italic;font-weight:300;line-height:24px;margin:36px 0;padding-right:32px;padding-left:32px;position:relative}
+blockquote:after,blockquote:before,q:after,q:before{color:#01798a;display:block;font-size:32px;font-weight:700;line-height:0;position:absolute;top:0}
+blockquote:after,q:after{content:close-quote;right:0}blockquote:before,q:before{border-right:1px solid #27e3fd;content:open-quote;bottom:0;left:0;
+width:8px}dd,dt,li{line-height:24px}dd{margin:0}dl{margin:24px 0}dt{font-weight:700}.h1,.h2,.h3,.h4,.h5,.h6,h1,h2,h3,h4,h5,h6{color:inherit;
+font-family:Roboto,"Helvetica Neue",Helvetica,Arial,sans-serif;font-weight:700;margin-top:12px;margin-bottom:8px}.h1,h1{font-size:32px;line-height:
+48px}.h2,h2{font-size:24px;line-height:32px}.h3,h3{font-size:20px;line-height:28px}.h4,h4{font-size:16px;line-height:24px}.h5,h5{font-size:12px;
+line-height:20px}.h6,h6{font-size:8px;line-height:16px}.h1 small,.h2 small,.h3 small,.h4 small,h1 small,h2 small,h3 small,h4 small{font-size:16px;
+font-weight:400}.hr,hr{border:0;border-top:1px solid #9e9e9e;display:block;height:0;margin-top:24px;margin-bottom:24px;-webkit-box-sizing:content-box;
+-moz-box-sizing:content-box;box-sizing:content-box}img{border:0;vertical-align:middle;max-width:98vw}ol,ul{margin:12px 0;padding:0 0 0 16px}ol ol,
+ol ul,ul ol,ul ul{margin-top:0;margin-bottom:0}p{margin:12px 0}small{font-size:75%;line-height:1}sub,sup{font-size:80%;line-height:0;position:relative
+;vertical-align:baseline}sub{bottom:-.25em}sup{top:-.5em}table{border-collapse:collapse;border-spacing:0}td,th{padding:0}th{text-align:left}@font-face
+{font-family:FontAwesome;font-style:normal;font-weight:400;src:url(./fonts/fontawesome-webfont.eot?v=4.3.0);src:
+url(./fonts/fontawesome-webfont.eot?#iefix&v=4.3.0) format("embedded-opentype"),url(./fonts/fontawesome-webfont.woff2?v=4.3.0) format("woff2"),
+url(./fonts/fontawesome-webfont.woff?v=4.3.0) format("woff"),url(./fonts/fontawesome-webfont.ttf?v=4.3.0) format("truetype"),
+url(./fonts/fontawesome-webfont.svg?v=4.3.0#fontawesomeregular) format("svg")}.fa{display:inline-block;font:normal normal normal 16px/1 FontAwesome;
+font-size:inherit;speak:none;text-rendering:auto;transform:none;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}.fa-pulse{
+-webkit-animation:fa-spin 1s infinite steps(8);animation:fa-spin 1s infinite steps(8)}.fa-spin{-webkit-animation:fa-spin 2s infinite linear;animation:
+fa-spin 2s infinite linear}@-webkit-keyframes fa-spin{0%{-webkit-transform:rotate(0);transform:rotate(0)}100%{-webkit-transform:rotate(359deg);
+transform:rotate(359deg)}}@keyframes fa-spin{0%{-webkit-transform:rotate(0);transform:rotate(0)}100%{-webkit-transform:rotate(359deg);transform:
+rotate(359deg)}}.fa-border{border:.08em solid #e0e0e0;border-radius:.1em;padding:.2em .25em .15em}.fa.pull-left{margin-right:.3em}.fa.pull-right{
+margin-left:.3em}.fa-fw{text-align:center;width:1.2857142857em}.fa-flip-horizontal{-webkit-transform:scale(-1,1);-ms-transform:scale(-1,1);transform:
+scale(-1,1)}.fa-flip-vertical{-webkit-transform:scale(1,-1);-ms-transform:scale(1,-1);transform:scale(1,-1)}.fa-rotate-90{-webkit-transform:
+rotate(90deg);-ms-transform:rotate(90deg);transform:rotate(90deg)}.fa-rotate-180{-webkit-transform:rotate(180deg);-ms-transform:rotate(180deg);
+transform:rotate(180deg)}.fa-rotate-270{-webkit-transform:rotate(270deg);-ms-transform:rotate(270deg);transform:rotate(270deg)}
+:root .fa-flip-horizontal,:root .fa-flip-vertical,:root .fa-rotate-180,:root .fa-rotate-270,:root .fa-rotate-90{filter:none}.fa-2x{font-size:2em}
+.fa-3x{font-size:3em}.fa-4x{font-size:4em}.fa-5x{font-size:5em}.fa-lg{font-size:1.3333333333em;line-height:.75em;vertical-align:-15%}.fa-li{position:
+absolute;top:.1428571429em;left:-2.1428571429em;text-align:center;width:2.1428571429em}.fa-li.fa-lg{left:-1.8571428571em}.fa-ul{list-style-type:none;
+margin-left:2.1428571429em;padding-left:0}.fa-ul>li{position:relative}.fa-inverse{color:#fff}.fa-stack{display:inline-block;height:2em;line-height:2em
+;position:relative;vertical-align:middle;width:2em}.fa-stack-1x,.fa-stack-2x{position:absolute;left:0;text-align:center;width:100%}.fa-stack-1x{
+line-height:inherit}.fa-stack-2x{font-size:2em}.fa-glass:before{content:"\f000"}.fa-music:before{content:"\f001"}.fa-search:before{content:"\f002"}
+.fa-envelope-o:before{content:"\f003"}.fa-heart:before{content:"\f004"}.fa-star:before{content:"\f005"}.fa-star-o:before{content:"\f006"}
+.fa-user:before{content:"\f007"}.fa-film:before{content:"\f008"}.fa-th-large:before{content:"\f009"}.fa-th:before{content:"\f00a"}.fa-th-list:before{
+content:"\f00b"}.fa-check:before{content:"\f00c"}.fa-close:before,.fa-remove:before,.fa-times:before{content:"\f00d"}.fa-search-plus:before{content:
+"\f00e"}.fa-search-minus:before{content:"\f010"}.fa-power-off:before{content:"\f011"}.fa-signal:before{content:"\f012"}.fa-cog:before,.fa-gear:before{
+content:"\f013"}.fa-trash-o:before{content:"\f014"}.fa-home:before{content:"\f015"}.fa-file-o:before{content:"\f016"}.fa-clock-o:before{content:
+"\f017"}.fa-road:before{content:"\f018"}.fa-download:before{content:"\f019"}.fa-arrow-circle-o-down:before{content:"\f01a"}
+.fa-arrow-circle-o-up:before{content:"\f01b"}.fa-inbox:before{content:"\f01c"}.fa-play-circle-o:before{content:"\f01d"}.fa-repeat:before,
+.fa-rotate-right:before{content:"\f01e"}.fa-refresh:before{content:"\f021"}.fa-list-alt:before{content:"\f022"}.fa-lock:before{content:"\f023"}
+.fa-flag:before{content:"\f024"}.fa-headphones:before{content:"\f025"}.fa-volume-off:before{content:"\f026"}.fa-volume-down:before{content:"\f027"}
+.fa-volume-up:before{content:"\f028"}.fa-qrcode:before{content:"\f029"}.fa-barcode:before{content:"\f02a"}.fa-tag:before{content:"\f02b"}
+.fa-tags:before{content:"\f02c"}.fa-book:before{content:"\f02d"}.fa-bookmark:before{content:"\f02e"}.fa-print:before{content:"\f02f"}.fa-camera:before
+{content:"\f030"}.fa-font:before{content:"\f031"}.fa-bold:before{content:"\f032"}.fa-italic:before{content:"\f033"}.fa-text-height:before{content:
+"\f034"}.fa-text-width:before{content:"\f035"}.fa-align-left:before{content:"\f036"}.fa-align-center:before{content:"\f037"}.fa-align-right:before{
+content:"\f038"}.fa-align-justify:before{content:"\f039"}.fa-list:before{content:"\f03a"}.fa-dedent:before,.fa-outdent:before{content:"\f03b"}
+.fa-indent:before{content:"\f03c"}.fa-video-camera:before{content:"\f03d"}.fa-image:before,.fa-photo:before,.fa-picture-o:before{content:"\f03e"}
+.fa-pencil:before{content:"\f040"}.fa-map-marker:before{content:"\f041"}.fa-adjust:before{content:"\f042"}.fa-tint:before{content:"\f043"}
+.fa-edit:before,.fa-pencil-square-o:before{content:"\f044"}.fa-share-square-o:before{content:"\f045"}.fa-check-square-o:before{content:"\f046"}
+.fa-arrows:before{content:"\f047"}.fa-step-backward:before{content:"\f048"}.fa-fast-backward:before{content:"\f049"}.fa-backward:before{content:
+"\f04a"}.fa-play:before{content:"\f04b"}.fa-pause:before{content:"\f04c"}.fa-stop:before{content:"\f04d"}.fa-forward:before{content:"\f04e"}
+.fa-fast-forward:before{content:"\f050"}.fa-step-forward:before{content:"\f051"}.fa-eject:before{content:"\f052"}.fa-chevron-left:before{content:
+"\f053"}.fa-chevron-right:before{content:"\f054"}.fa-plus-circle:before{content:"\f055"}.fa-minus-circle:before{content:"\f056"}
+.fa-times-circle:before{content:"\f057"}.fa-check-circle:before{content:"\f058"}.fa-question-circle:before{content:"\f059"}.fa-info-circle:before{
+content:"\f05a"}.fa-crosshairs:before{content:"\f05b"}.fa-times-circle-o:before{content:"\f05c"}.fa-check-circle-o:before{content:"\f05d"}
+.fa-ban:before{content:"\f05e"}.fa-arrow-left:before{content:"\f060"}.fa-arrow-right:before{content:"\f061"}.fa-arrow-up:before{content:"\f062"}
+.fa-arrow-down:before{content:"\f063"}.fa-mail-forward:before,.fa-share:before{content:"\f064"}.fa-expand:before{content:"\f065"}.fa-compress:before{
+content:"\f066"}.fa-plus:before{content:"\f067"}.fa-minus:before{content:"\f068"}.fa-asterisk:before{content:"\f069"}.fa-exclamation-circle:before{
+content:"\f06a"}.fa-gift:before{content:"\f06b"}.fa-leaf:before{content:"\f06c"}.fa-fire:before{content:"\f06d"}.fa-eye:before{content:"\f06e"}
+.fa-eye-slash:before{content:"\f070"}.fa-exclamation-triangle:before,.fa-warning:before{content:"\f071"}.fa-plane:before{content:"\f072"}
+.fa-calendar:before{content:"\f073"}.fa-random:before{content:"\f074"}.fa-comment:before{content:"\f075"}.fa-magnet:before{content:"\f076"}
+.fa-chevron-up:before{content:"\f077"}.fa-chevron-down:before{content:"\f078"}.fa-retweet:before{content:"\f079"}.fa-shopping-cart:before{content:
+"\f07a"}.fa-folder:before{content:"\f07b"}.fa-folder-open:before{content:"\f07c"}.fa-arrows-v:before{content:"\f07d"}.fa-arrows-h:before{content:
+"\f07e"}.fa-bar-chart-o:before,.fa-bar-chart:before{content:"\f080"}.fa-twitter-square:before{content:"\f081"}.fa-facebook-square:before{content:
+"\f082"}.fa-camera-retro:before{content:"\f083"}.fa-key:before{content:"\f084"}.fa-cogs:before,.fa-gears:before{content:"\f085"}.fa-comments:before{
+content:"\f086"}.fa-thumbs-o-up:before{content:"\f087"}.fa-thumbs-o-down:before{content:"\f088"}.fa-star-half:before{content:"\f089"}
+.fa-heart-o:before{content:"\f08a"}.fa-sign-out:before{content:"\f08b"}.fa-linkedin-square:before{content:"\f08c"}.fa-thumb-tack:before{content:
+"\f08d"}.fa-external-link:before{content:"\f08e"}.fa-sign-in:before{content:"\f090"}.fa-trophy:before{content:"\f091"}.fa-github-square:before{content
+:"\f092"}.fa-upload:before{content:"\f093"}.fa-lemon-o:before{content:"\f094"}.fa-phone:before{content:"\f095"}.fa-square-o:before{content:"\f096"}
+.fa-bookmark-o:before{content:"\f097"}.fa-phone-square:before{content:"\f098"}.fa-twitter:before{content:"\f099"}.fa-facebook-f:before,
+.fa-facebook:before{content:"\f09a"}.fa-github:before{content:"\f09b"}.fa-unlock:before{content:"\f09c"}.fa-credit-card:before{content:"\f09d"}
+.fa-rss:before{content:"\f09e"}.fa-hdd-o:before{content:"\f0a0"}.fa-bullhorn:before{content:"\f0a1"}.fa-bell:before{content:"\f0f3"}
+.fa-certificate:before{content:"\f0a3"}.fa-hand-o-right:before{content:"\f0a4"}.fa-hand-o-left:before{content:"\f0a5"}.fa-hand-o-up:before{content:
+"\f0a6"}.fa-hand-o-down:before{content:"\f0a7"}.fa-arrow-circle-left:before{content:"\f0a8"}.fa-arrow-circle-right:before{content:"\f0a9"}
+.fa-arrow-circle-up:before{content:"\f0aa"}.fa-arrow-circle-down:before{content:"\f0ab"}.fa-globe:before{content:"\f0ac"}.fa-wrench:before{content:
+"\f0ad"}.fa-tasks:before{content:"\f0ae"}.fa-filter:before{content:"\f0b0"}.fa-briefcase:before{content:"\f0b1"}.fa-arrows-alt:before{content:"\f0b2"}
+.fa-group:before,.fa-users:before{content:"\f0c0"}.fa-chain:before,.fa-link:before{content:"\f0c1"}.fa-cloud:before{content:"\f0c2"}.fa-flask:before{
+content:"\f0c3"}.fa-cut:before,.fa-scissors:before{content:"\f0c4"}.fa-copy:before,.fa-files-o:before{content:"\f0c5"}.fa-paperclip:before{content:
+"\f0c6"}.fa-floppy-o:before,.fa-save:before{content:"\f0c7"}.fa-square:before{content:"\f0c8"}.fa-bars:before,.fa-navicon:before,.fa-reorder:before{
+content:"\f0c9"}.fa-list-ul:before{content:"\f0ca"}.fa-list-ol:before{content:"\f0cb"}.fa-strikethrough:before{content:"\f0cc"}.fa-underline:before{
+content:"\f0cd"}.fa-table:before{content:"\f0ce"}.fa-magic:before{content:"\f0d0"}.fa-truck:before{content:"\f0d1"}.fa-pinterest:before{content:
+"\f0d2"}.fa-pinterest-square:before{content:"\f0d3"}.fa-google-plus-square:before{content:"\f0d4"}.fa-google-plus:before{content:"\f0d5"}
+.fa-money:before{content:"\f0d6"}.fa-caret-down:before{content:"\f0d7"}.fa-caret-up:before{content:"\f0d8"}.fa-caret-left:before{content:"\f0d9"}
+.fa-caret-right:before{content:"\f0da"}.fa-columns:before{content:"\f0db"}.fa-sort:before,.fa-unsorted:before{content:"\f0dc"}.fa-sort-desc:before,
+.fa-sort-down:before{content:"\f0dd"}.fa-sort-asc:before,.fa-sort-up:before{content:"\f0de"}.fa-envelope:before{content:"\f0e0"}.fa-linkedin:before{
+content:"\f0e1"}.fa-rotate-left:before,.fa-undo:before{content:"\f0e2"}.fa-gavel:before,.fa-legal:before{content:"\f0e3"}.fa-dashboard:before,
+.fa-tachometer:before{content:"\f0e4"}.fa-comment-o:before{content:"\f0e5"}.fa-comments-o:before{content:"\f0e6"}.fa-bolt:before,.fa-flash:before{
+content:"\f0e7"}.fa-sitemap:before{content:"\f0e8"}.fa-umbrella:before{content:"\f0e9"}.fa-clipboard:before,.fa-paste:before{content:"\f0ea"}
+.fa-lightbulb-o:before{content:"\f0eb"}.fa-exchange:before{content:"\f0ec"}.fa-cloud-download:before{content:"\f0ed"}.fa-cloud-upload:before{content:
+"\f0ee"}.fa-user-md:before{content:"\f0f0"}.fa-stethoscope:before{content:"\f0f1"}.fa-suitcase:before{content:"\f0f2"}.fa-bell-o:before{content:
+"\f0a2"}.fa-coffee:before{content:"\f0f4"}.fa-cutlery:before{content:"\f0f5"}.fa-file-text-o:before{content:"\f0f6"}.fa-building-o:before{content:
+"\f0f7"}.fa-hospital-o:before{content:"\f0f8"}.fa-ambulance:before{content:"\f0f9"}.fa-medkit:before{content:"\f0fa"}.fa-fighter-jet:before{content:
+"\f0fb"}.fa-beer:before{content:"\f0fc"}.fa-h-square:before{content:"\f0fd"}.fa-plus-square:before{content:"\f0fe"}.fa-angle-double-left:before{
+content:"\f100"}.fa-angle-double-right:before{content:"\f101"}.fa-angle-double-up:before{content:"\f102"}.fa-angle-double-down:before{content:"\f103"}
+.fa-angle-left:before{content:"\f104"}.fa-angle-right:before{content:"\f105"}.fa-angle-up:before{content:"\f106"}.fa-angle-down:before{content:"\f107"
+}.fa-desktop:before{content:"\f108"}.fa-laptop:before{content:"\f109"}.fa-tablet:before{content:"\f10a"}.fa-mobile-phone:before,.fa-mobile:before{
+content:"\f10b"}.fa-circle-o:before{content:"\f10c"}.fa-quote-left:before{content:"\f10d"}.fa-quote-right:before{content:"\f10e"}.fa-spinner:before{
+content:"\f110"}.fa-circle:before{content:"\f111"}.fa-mail-reply:before,.fa-reply:before{content:"\f112"}.fa-github-alt:before{content:"\f113"}
+.fa-folder-o:before{content:"\f114"}.fa-folder-open-o:before{content:"\f115"}.fa-smile-o:before{content:"\f118"}.fa-frown-o:before{content:"\f119"}
+.fa-meh-o:before{content:"\f11a"}.fa-gamepad:before{content:"\f11b"}.fa-keyboard-o:before{content:"\f11c"}.fa-flag-o:before{content:"\f11d"}
+.fa-flag-checkered:before{content:"\f11e"}.fa-terminal:before{content:"\f120"}.fa-code:before{content:"\f121"}.fa-mail-reply-all:before,
+.fa-reply-all:before{content:"\f122"}.fa-star-half-empty:before,.fa-star-half-full:before,.fa-star-half-o:before{content:"\f123"}
+.fa-location-arrow:before{content:"\f124"}.fa-crop:before{content:"\f125"}.fa-code-fork:before{content:"\f126"}.fa-chain-broken:before,
+.fa-unlink:before{content:"\f127"}.fa-question:before{content:"\f128"}.fa-info:before{content:"\f129"}.fa-exclamation:before{content:"\f12a"}
+.fa-superscript:before{content:"\f12b"}.fa-subscript:before{content:"\f12c"}.fa-eraser:before{content:"\f12d"}.fa-puzzle-piece:before{content:"\f12e"}
+.fa-microphone:before{content:"\f130"}.fa-microphone-slash:before{content:"\f131"}.fa-shield:before{content:"\f132"}.fa-calendar-o:before{content:
+"\f133"}.fa-fire-extinguisher:before{content:"\f134"}.fa-rocket:before{content:"\f135"}.fa-maxcdn:before{content:"\f136"}
+.fa-chevron-circle-left:before{content:"\f137"}.fa-chevron-circle-right:before{content:"\f138"}.fa-chevron-circle-up:before{content:"\f139"}
+.fa-chevron-circle-down:before{content:"\f13a"}.fa-html5:before{content:"\f13b"}.fa-css3:before{content:"\f13c"}.fa-anchor:before{content:"\f13d"}
+.fa-unlock-alt:before{content:"\f13e"}.fa-bullseye:before{content:"\f140"}.fa-ellipsis-h:before{content:"\f141"}.fa-ellipsis-v:before{content:"\f142"}
+.fa-rss-square:before{content:"\f143"}.fa-play-circle:before{content:"\f144"}.fa-ticket:before{content:"\f145"}.fa-minus-square:before{content:"\f146"
+}.fa-minus-square-o:before{content:"\f147"}.fa-level-up:before{content:"\f148"}.fa-level-down:before{content:"\f149"}.fa-check-square:before{content:
+"\f14a"}.fa-pencil-square:before{content:"\f14b"}.fa-external-link-square:before{content:"\f14c"}.fa-share-square:before{content:"\f14d"}
+.fa-compass:before{content:"\f14e"}.fa-caret-square-o-down:before,.fa-toggle-down:before{content:"\f150"}.fa-caret-square-o-up:before,
+.fa-toggle-up:before{content:"\f151"}.fa-caret-square-o-right:before,.fa-toggle-right:before{content:"\f152"}.fa-eur:before,.fa-euro:before{content:
+"\f153"}.fa-gbp:before{content:"\f154"}.fa-dollar:before,.fa-usd:before{content:"\f155"}.fa-inr:before,.fa-rupee:before{content:"\f156"}.fa-cny:before
+,.fa-jpy:before,.fa-rmb:before,.fa-yen:before{content:"\f157"}.fa-rouble:before,.fa-rub:before,.fa-ruble:before{content:"\f158"}.fa-krw:before,
+.fa-won:before{content:"\f159"}.fa-bitcoin:before,.fa-btc:before{content:"\f15a"}.fa-file:before{content:"\f15b"}.fa-file-text:before{content:"\f15c"}
+.fa-sort-alpha-asc:before{content:"\f15d"}.fa-sort-alpha-desc:before{content:"\f15e"}.fa-sort-amount-asc:before{content:"\f160"}
+.fa-sort-amount-desc:before{content:"\f161"}.fa-sort-numeric-asc:before{content:"\f162"}.fa-sort-numeric-desc:before{content:"\f163"}
+.fa-thumbs-up:before{content:"\f164"}.fa-thumbs-down:before{content:"\f165"}.fa-youtube-square:before{content:"\f166"}.fa-youtube:before{content:
+"\f167"}.fa-xing:before{content:"\f168"}.fa-xing-square:before{content:"\f169"}.fa-youtube-play:before{content:"\f16a"}.fa-dropbox:before{content:
+"\f16b"}.fa-stack-overflow:before{content:"\f16c"}.fa-instagram:before{content:"\f16d"}.fa-flickr:before{content:"\f16e"}.fa-adn:before{content:
+"\f170"}.fa-bitbucket:before{content:"\f171"}.fa-bitbucket-square:before{content:"\f172"}.fa-tumblr:before{content:"\f173"}.fa-tumblr-square:before{
+content:"\f174"}.fa-long-arrow-down:before{content:"\f175"}.fa-long-arrow-up:before{content:"\f176"}.fa-long-arrow-left:before{content:"\f177"}
+.fa-long-arrow-right:before{content:"\f178"}.fa-apple:before{content:"\f179"}.fa-windows:before{content:"\f17a"}.fa-android:before{content:"\f17b"}
+.fa-linux:before{content:"\f17c"}.fa-dribbble:before{content:"\f17d"}.fa-skype:before{content:"\f17e"}.fa-foursquare:before{content:"\f180"}
+.fa-trello:before{content:"\f181"}.fa-female:before{content:"\f182"}.fa-male:before{content:"\f183"}.fa-gittip:before,.fa-gratipay:before{content:
+"\f184"}.fa-sun-o:before{content:"\f185"}.fa-moon-o:before{content:"\f186"}.fa-archive:before{content:"\f187"}.fa-bug:before{content:"\f188"}
+.fa-vk:before{content:"\f189"}.fa-weibo:before{content:"\f18a"}.fa-renren:before{content:"\f18b"}.fa-pagelines:before{content:"\f18c"}
+.fa-stack-exchange:before{content:"\f18d"}.fa-arrow-circle-o-right:before{content:"\f18e"}.fa-arrow-circle-o-left:before{content:"\f190"}
+.fa-caret-square-o-left:before,.fa-toggle-left:before{content:"\f191"}.fa-dot-circle-o:before{content:"\f192"}.fa-wheelchair:before{content:"\f193"}
+.fa-vimeo-square:before{content:"\f194"}.fa-try:before,.fa-turkish-lira:before{content:"\f195"}.fa-plus-square-o:before{content:"\f196"}
+.fa-space-shuttle:before{content:"\f197"}.fa-slack:before{content:"\f198"}.fa-envelope-square:before{content:"\f199"}.fa-wordpress:before{content:
+"\f19a"}.fa-openid:before{content:"\f19b"}.fa-bank:before,.fa-institution:before,.fa-university:before{content:"\f19c"}.fa-graduation-cap:before,
+.fa-mortar-board:before{content:"\f19d"}.fa-yahoo:before{content:"\f19e"}.fa-google:before{content:"\f1a0"}.fa-reddit:before{content:"\f1a1"}
+.fa-reddit-square:before{content:"\f1a2"}.fa-stumbleupon-circle:before{content:"\f1a3"}.fa-stumbleupon:before{content:"\f1a4"}.fa-delicious:before{
+content:"\f1a5"}.fa-digg:before{content:"\f1a6"}.fa-pied-piper:before{content:"\f1a7"}.fa-pied-piper-alt:before{content:"\f1a8"}.fa-drupal:before{
+content:"\f1a9"}.fa-joomla:before{content:"\f1aa"}.fa-language:before{content:"\f1ab"}.fa-fax:before{content:"\f1ac"}.fa-building:before{content:
+"\f1ad"}.fa-child:before{content:"\f1ae"}.fa-paw:before{content:"\f1b0"}.fa-spoon:before{content:"\f1b1"}.fa-cube:before{content:"\f1b2"}
+.fa-cubes:before{content:"\f1b3"}.fa-behance:before{content:"\f1b4"}.fa-behance-square:before{content:"\f1b5"}.fa-steam:before{content:"\f1b6"}
+.fa-steam-square:before{content:"\f1b7"}.fa-recycle:before{content:"\f1b8"}.fa-automobile:before,.fa-car:before{content:"\f1b9"}.fa-cab:before,
+.fa-taxi:before{content:"\f1ba"}.fa-tree:before{content:"\f1bb"}.fa-spotify:before{content:"\f1bc"}.fa-deviantart:before{content:"\f1bd"}
+.fa-soundcloud:before{content:"\f1be"}.fa-database:before{content:"\f1c0"}.fa-file-pdf-o:before{content:"\f1c1"}.fa-file-word-o:before{content:"\f1c2"
+}.fa-file-excel-o:before{content:"\f1c3"}.fa-file-powerpoint-o:before{content:"\f1c4"}.fa-file-image-o:before,.fa-file-photo-o:before,
+.fa-file-picture-o:before{content:"\f1c5"}.fa-file-archive-o:before,.fa-file-zip-o:before{content:"\f1c6"}.fa-file-audio-o:before,
+.fa-file-sound-o:before{content:"\f1c7"}.fa-file-movie-o:before,.fa-file-video-o:before{content:"\f1c8"}.fa-file-code-o:before{content:"\f1c9"}
+.fa-vine:before{content:"\f1ca"}.fa-codepen:before{content:"\f1cb"}.fa-jsfiddle:before{content:"\f1cc"}.fa-life-bouy:before,.fa-life-buoy:before,
+.fa-life-ring:before,.fa-life-saver:before,.fa-support:before{content:"\f1cd"}.fa-circle-o-notch:before{content:"\f1ce"}.fa-ra:before,.fa-rebel:before
+{content:"\f1d0"}.fa-empire:before,.fa-ge:before{content:"\f1d1"}.fa-git-square:before{content:"\f1d2"}.fa-git:before{content:"\f1d3"}
+.fa-hacker-news:before{content:"\f1d4"}.fa-tencent-weibo:before{content:"\f1d5"}.fa-qq:before{content:"\f1d6"}.fa-wechat:before,.fa-weixin:before{
+content:"\f1d7"}.fa-paper-plane:before,.fa-send:before{content:"\f1d8"}.fa-paper-plane-o:before,.fa-send-o:before{content:"\f1d9"}.fa-history:before{
+content:"\f1da"}.fa-circle-thin:before,.fa-genderless:before{content:"\f1db"}.fa-header:before{content:"\f1dc"}.fa-paragraph:before{content:"\f1dd"}
+.fa-sliders:before{content:"\f1de"}.fa-share-alt:before{content:"\f1e0"}.fa-share-alt-square:before{content:"\f1e1"}.fa-bomb:before{content:"\f1e2"}
+.fa-futbol-o:before,.fa-soccer-ball-o:before{content:"\f1e3"}.fa-tty:before{content:"\f1e4"}.fa-binoculars:before{content:"\f1e5"}.fa-plug:before{
+content:"\f1e6"}.fa-slideshare:before{content:"\f1e7"}.fa-twitch:before{content:"\f1e8"}.fa-yelp:before{content:"\f1e9"}.fa-newspaper-o:before{content
+:"\f1ea"}.fa-wifi:before{content:"\f1eb"}.fa-calculator:before{content:"\f1ec"}.fa-paypal:before{content:"\f1ed"}.fa-google-wallet:before{content:
+"\f1ee"}.fa-cc-visa:before{content:"\f1f0"}.fa-cc-mastercard:before{content:"\f1f1"}.fa-cc-discover:before{content:"\f1f2"}.fa-cc-amex:before{content:
+"\f1f3"}.fa-cc-paypal:before{content:"\f1f4"}.fa-cc-stripe:before{content:"\f1f5"}.fa-bell-slash:before{content:"\f1f6"}.fa-bell-slash-o:before{
+content:"\f1f7"}.fa-trash:before{content:"\f1f8"}.fa-copyright:before{content:"\f1f9"}.fa-at:before{content:"\f1fa"}.fa-eyedropper:before{content:
+"\f1fb"}.fa-paint-brush:before{content:"\f1fc"}.fa-birthday-cake:before{content:"\f1fd"}.fa-area-chart:before{content:"\f1fe"}.fa-pie-chart:before{
+content:"\f200"}.fa-line-chart:before{content:"\f201"}.fa-lastfm:before{content:"\f202"}.fa-lastfm-square:before{content:"\f203"}.fa-toggle-off:before
+{content:"\f204"}.fa-toggle-on:before{content:"\f205"}.fa-bicycle:before{content:"\f206"}.fa-bus:before{content:"\f207"}.fa-ioxhost:before{content:
+"\f208"}.fa-angellist:before{content:"\f209"}.fa-cc:before{content:"\f20a"}.fa-ils:before,.fa-shekel:before,.fa-sheqel:before{content:"\f20b"}
+.fa-meanpath:before{content:"\f20c"}.fa-buysellads:before{content:"\f20d"}.fa-connectdevelop:before{content:"\f20e"}.fa-dashcube:before{content:
+"\f210"}.fa-forumbee:before{content:"\f211"}.fa-leanpub:before{content:"\f212"}.fa-sellsy:before{content:"\f213"}.fa-shirtsinbulk:before{content:
+"\f214"}.fa-simplybuilt:before{content:"\f215"}.fa-skyatlas:before{content:"\f216"}.fa-cart-plus:before{content:"\f217"}.fa-cart-arrow-down:before{
+content:"\f218"}.fa-diamond:before{content:"\f219"}.fa-ship:before{content:"\f21a"}.fa-user-secret:before{content:"\f21b"}.fa-motorcycle:before{
+content:"\f21c"}.fa-street-view:before{content:"\f21d"}.fa-heartbeat:before{content:"\f21e"}.fa-venus:before{content:"\f221"}.fa-mars:before{content:
+"\f222"}.fa-mercury:before{content:"\f223"}.fa-transgender:before{content:"\f224"}.fa-transgender-alt:before{content:"\f225"}.fa-venus-double:before{
+content:"\f226"}.fa-mars-double:before{content:"\f227"}.fa-venus-mars:before{content:"\f228"}.fa-mars-stroke:before{content:"\f229"}
+.fa-mars-stroke-v:before{content:"\f22a"}.fa-mars-stroke-h:before{content:"\f22b"}.fa-neuter:before{content:"\f22c"}.fa-facebook-official:before{
+content:"\f230"}.fa-pinterest-p:before{content:"\f231"}.fa-whatsapp:before{content:"\f232"}.fa-server:before{content:"\f233"}.fa-user-plus:before{
+content:"\f234"}.fa-user-times:before{content:"\f235"}.fa-bed:before,.fa-hotel:before{content:"\f236"}.fa-viacoin:before{content:"\f237"}
+.fa-train:before{content:"\f238"}.fa-subway:before{content:"\f239"}.fa-medium:before{content:"\f23a"}@font-face{font-family:MaterialDesignIcon;
+font-style:normal;font-weight:400;src:url(./fonts/MaterialDesignIcon.eot?v=1.1.1);src:url(./fonts/MaterialDesignIcon.eot?#iefix&v=1.1.1) 
+format("embedded-opentype"),url(./fonts/MaterialDesignIcon.woff?v=1.1.1) format("woff"),url(./fonts/MaterialDesignIcon.ttf?v=1.1.1) format("truetype")
+,url(./fonts/MaterialDesignIcon.svg?v=1.1.1#MaterialDesignIcon) format("svg")}.breadcrumb>li+li:before,.icon{display:inline-block;font:normal normal 
+normal 16px/1 MaterialDesignIcon;font-size:inherit;speak:none;text-rendering:auto;transform:none;vertical-align:-10%;-webkit-font-smoothing:
+antialiased;-moz-osx-font-smoothing:grayscale}.icon-lg{font-size:1.3333333333em;line-height:.75em;vertical-align:-20%}.icon-3d-rotation:before{content
+:"\f000"}.icon-accessibility:before{content:"\f001"}.icon-account-balance:before{content:"\f002"}.icon-account-balance-wallet:before{content:"\f003"}
+.icon-account-box:before{content:"\f004"}.icon-account-child:before{content:"\f005"}.icon-account-circle:before{content:"\f006"}
+.icon-add-shopping-cart:before{content:"\f007"}.icon-alarm:before{content:"\f008"}.icon-alarm-add:before{content:"\f009"}.icon-alarm-off:before{
+content:"\f00a"}.icon-alarm-on:before{content:"\f00b"}.icon-android:before{content:"\f00c"}.icon-announcement:before{content:"\f00d"}
+.icon-aspect-ratio:before{content:"\f00e"}.icon-assessment:before{content:"\f00f"}.icon-assignment:before{content:"\f010"}.icon-assignment-ind:before{
+content:"\f011"}.icon-assignment-late:before{content:"\f012"}.icon-assignment-return:before{content:"\f013"}.icon-assignment-returned:before{content:
+"\f014"}.icon-assignment-turned-in:before{content:"\f015"}.icon-autorenew:before{content:"\f016"}.icon-backup:before{content:"\f017"}.icon-book:before
+{content:"\f018"}.icon-bookmark:before{content:"\f019"}.icon-bookmark-outline:before{content:"\f01a"}.icon-bug-report:before{content:"\f01b"}
+.icon-cached:before{content:"\f01c"}.icon-class:before{content:"\f01d"}.icon-credit-card:before{content:"\f01e"}.icon-dashboard:before{content:"\f01f"
+}.icon-delete:before{content:"\f020"}.icon-description:before{content:"\f021"}.icon-dns:before{content:"\f022"}.icon-done:before{content:"\f023"}
+.icon-done-all:before{content:"\f024"}.icon-event:before{content:"\f025"}.icon-exit-to-app:before{content:"\f026"}.icon-explore:before{content:"\f027"
+}.icon-extension:before{content:"\f028"}.icon-face-unlock:before{content:"\f029"}.icon-favorite:before{content:"\f02a"}.icon-favorite-outline:before{
+content:"\f02b"}.icon-find-in-page:before{content:"\f02c"}.icon-find-replace:before{content:"\f02d"}.icon-flip-to-back:before{content:"\f02e"}
+.icon-flip-to-front:before{content:"\f02f"}.icon-get-app:before{content:"\f030"}.icon-grade:before{content:"\f031"}.icon-group-work:before{content:
+"\f032"}.icon-help:before{content:"\f033"}.icon-highlight-remove:before{content:"\f034"}.icon-history:before{content:"\f035"}.icon-home:before{content
+:"\f036"}.icon-https:before{content:"\f037"}.icon-info:before{content:"\f038"}.icon-info-outline:before{content:"\f039"}.icon-input:before{content:
+"\f03a"}.icon-invert-colors:before{content:"\f03b"}.icon-label:before{content:"\f03c"}.icon-label-outline:before{content:"\f03d"}.icon-language:before
+{content:"\f03e"}.icon-launch:before{content:"\f03f"}.icon-list:before{content:"\f040"}.icon-lock:before{content:"\f041"}.icon-lock-open:before{
+content:"\f042"}.icon-lock-outline:before{content:"\f043"}.icon-loyalty:before{content:"\f044"}.icon-markunread-mailbox:before{content:"\f045"}
+.icon-note-add:before{content:"\f046"}.icon-open-in-browser:before{content:"\f047"}.icon-open-in-new:before{content:"\f048"}.icon-open-with:before{
+content:"\f049"}.icon-pageview:before{content:"\f04a"}.icon-payment:before{content:"\f04b"}.icon-perm-camera-mic:before{content:"\f04c"}
+.icon-perm-contact-cal:before{content:"\f04d"}.icon-perm-data-setting:before{content:"\f04e"}.icon-perm-device-info:before{content:"\f04f"}
+.icon-perm-identity:before{content:"\f050"}.icon-perm-media:before{content:"\f051"}.icon-perm-phone-msg:before{content:"\f052"}
+.icon-perm-scan-wifi:before{content:"\f053"}.icon-picture-in-picture:before{content:"\f054"}.icon-polymer:before{content:"\f055"}.icon-print:before{
+content:"\f056"}.icon-query-builder:before{content:"\f057"}.icon-question-answer:before{content:"\f058"}.icon-receipt:before{content:"\f059"}
+.icon-redeem:before{content:"\f05a"}.icon-report-problem:before{content:"\f05b"}.icon-restore:before{content:"\f05c"}.icon-room:before{content:"\f05d"
+}.icon-schedule:before{content:"\f05e"}.icon-search:before{content:"\f05f"}.icon-settings:before{content:"\f060"}.icon-settings-applications:before{
+content:"\f061"}.icon-settings-backup-restore:before{content:"\f062"}.icon-settings-bluetooth:before{content:"\f063"}.icon-settings-cell:before{
+content:"\f064"}.icon-settings-display:before{content:"\f065"}.icon-settings-ethernet:before{content:"\f066"}.icon-settings-input-antenna:before{
+content:"\f067"}.icon-settings-input-component:before{content:"\f068"}.icon-settings-input-composite:before{content:"\f069"}
+.icon-settings-input-hdmi:before{content:"\f06a"}.icon-settings-input-svideo:before{content:"\f06b"}.icon-settings-overscan:before{content:"\f06c"}
+.icon-settings-phone:before{content:"\f06d"}.icon-settings-power:before{content:"\f06e"}.icon-settings-remote:before{content:"\f06f"}
+.icon-settings-voice:before{content:"\f070"}.icon-shop:before{content:"\f071"}.icon-shopping-basket:before{content:"\f072"}.icon-shopping-cart:before{
+content:"\f073"}.icon-shop-two:before{content:"\f074"}.icon-speaker-notes:before{content:"\f075"}.icon-spellcheck:before{content:"\f076"}
+.icon-star-rate:before{content:"\f077"}.icon-stars:before{content:"\f078"}.icon-store:before{content:"\f079"}.icon-subject:before{content:"\f07a"}
+.icon-swap-horiz:before{content:"\f07b"}.icon-swap-vert:before{content:"\f07c"}.icon-swap-vert-circle:before{content:"\f07d"}
+.icon-system-update-tv:before{content:"\f07e"}.icon-tab:before{content:"\f07f"}.icon-tab-unselected:before{content:"\f080"}.icon-theaters:before{
+content:"\f081"}.icon-thumb-down:before{content:"\f082"}.icon-thumbs-up-down:before{content:"\f083"}.icon-thumb-up:before{content:"\f084"}
+.icon-toc:before{content:"\f085"}.icon-today:before{content:"\f086"}.icon-track-changes:before{content:"\f087"}.icon-translate:before{content:"\f088"}
+.icon-trending-down:before{content:"\f089"}.icon-trending-neutral:before{content:"\f08a"}.icon-trending-up:before{content:"\f08b"}
+.icon-turned-in:before{content:"\f08c"}.icon-turned-in-not:before{content:"\f08d"}.icon-verified-user:before{content:"\f08e"}.icon-view-agenda:before{
+content:"\f08f"}.icon-view-array:before{content:"\f090"}.icon-view-carousel:before{content:"\f091"}.icon-view-column:before{content:"\f092"}
+.icon-view-day:before{content:"\f093"}.icon-view-headline:before{content:"\f094"}.icon-view-list:before{content:"\f095"}.icon-view-module:before{
+content:"\f096"}.icon-view-quilt:before{content:"\f097"}.icon-view-stream:before{content:"\f098"}.icon-view-week:before{content:"\f099"}
+.icon-visibility:before{content:"\f09a"}.icon-visibility-off:before{content:"\f09b"}.icon-wallet-giftcard:before{content:"\f09c"}
+.icon-wallet-membership:before{content:"\f09d"}.icon-wallet-travel:before{content:"\f09e"}.icon-work:before{content:"\f09f"}.icon-error:before{content
+:"\f0a0"}.icon-warning:before{content:"\f0a1"}.icon-album:before{content:"\f0a2"}.icon-av-timer:before{content:"\f0a3"}.icon-closed-caption:before{
+content:"\f0a4"}.icon-equalizer:before{content:"\f0a5"}.icon-explicit:before{content:"\f0a6"}.icon-fast-forward:before{content:"\f0a7"}
+.icon-fast-rewind:before{content:"\f0a8"}.icon-games:before{content:"\f0a9"}.icon-hearing:before{content:"\f0aa"}.icon-high-quality:before{content:
+"\f0ab"}.icon-loop:before{content:"\f0ac"}.icon-mic:before{content:"\f0ad"}.icon-mic-none:before{content:"\f0ae"}.icon-mic-off:before{content:"\f0af"}
+.icon-movie:before{content:"\f0b0"}.icon-my-library-add:before{content:"\f0b1"}.icon-my-library-books:before{content:"\f0b2"}
+.icon-my-library-music:before{content:"\f0b3"}.icon-new-releases:before{content:"\f0b4"}.icon-not-interested:before{content:"\f0b5"}.icon-pause:before
+{content:"\f0b6"}.icon-pause-circle-fill:before{content:"\f0b7"}.icon-pause-circle-outline:before{content:"\f0b8"}.icon-play-arrow:before{content:
+"\f0b9"}.icon-play-circle-fill:before{content:"\f0ba"}.icon-play-circle-outline:before{content:"\f0bb"}.icon-playlist-add:before{content:"\f0bc"}
+.icon-play-shopping-bag:before{content:"\f0bd"}.icon-queue:before{content:"\f0be"}.icon-queue-music:before{content:"\f0bf"}.icon-radio:before{content:
+"\f0c0"}.icon-recent-actors:before{content:"\f0c1"}.icon-repeat:before{content:"\f0c2"}.icon-repeat-one:before{content:"\f0c3"}.icon-replay:before{
+content:"\f0c4"}.icon-shuffle:before{content:"\f0c5"}.icon-skip-next:before{content:"\f0c6"}.icon-skip-previous:before{content:"\f0c7"}
+.icon-snooze:before{content:"\f0c8"}.icon-stop:before{content:"\f0c9"}.icon-subtitles:before{content:"\f0ca"}.icon-surround-sound:before{content:
+"\f0cb"}.icon-videocam:before{content:"\f0cc"}.icon-videocam-off:before{content:"\f0cd"}.icon-video-collection:before{content:"\f0ce"}
+.icon-volume-down:before{content:"\f0cf"}.icon-volume-mute:before{content:"\f0d0"}.icon-volume-off:before{content:"\f0d1"}.icon-volume-up:before{
+content:"\f0d2"}.icon-web:before{content:"\f0d3"}.icon-business:before{content:"\f0d4"}.icon-call:before{content:"\f0d5"}.icon-call-end:before{content
+:"\f0d6"}.icon-call-made:before{content:"\f0d7"}.icon-call-merge:before{content:"\f0d8"}.icon-call-missed:before{content:"\f0d9"}
+.icon-call-received:before{content:"\f0da"}.icon-call-split:before{content:"\f0db"}.icon-chat:before{content:"\f0dc"}.icon-clear-all:before{content:
+"\f0dd"}.icon-comment:before{content:"\f0de"}.icon-contacts:before{content:"\f0df"}.icon-dialer-sip:before{content:"\f0e0"}.icon-dialpad:before{
+content:"\f0e1"}.icon-dnd-on:before{content:"\f0e2"}.icon-email:before{content:"\f0e3"}.icon-forum:before{content:"\f0e4"}.icon-import-export:before{
+content:"\f0e5"}.icon-invert-colors-off:before{content:"\f0e6"}.icon-invert-colors-on:before{content:"\f0e7"}.icon-live-help:before{content:"\f0e8"}
+.icon-location-off:before{content:"\f0e9"}.icon-location-on:before{content:"\f0ea"}.icon-message:before{content:"\f0eb"}.icon-messenger:before{content
+:"\f0ec"}.icon-no-sim:before{content:"\f0ed"}.icon-phone:before{content:"\f0ee"}.icon-portable-wifi-off:before{content:"\f0ef"}
+.icon-quick-contacts-dialer:before{content:"\f0f0"}.icon-quick-contacts-mail:before{content:"\f0f1"}.icon-ring-volume:before{content:"\f0f2"}
+.icon-stay-current-landscape:before{content:"\f0f3"}.icon-stay-current-portrait:before{content:"\f0f4"}.icon-stay-primary-landscape:before{content:
+"\f0f5"}.icon-stay-primary-portrait:before{content:"\f0f6"}.icon-swap-calls:before{content:"\f0f7"}.icon-textsms:before{content:"\f0f8"}
+.icon-voicemail:before{content:"\f0f9"}.icon-vpn-key:before{content:"\f0fa"}.icon-add:before{content:"\f0fb"}.icon-add-box:before{content:"\f0fc"}
+.icon-add-circle:before{content:"\f0fd"}.icon-add-circle-outline:before{content:"\f0fe"}.icon-archive:before{content:"\f0ff"}.icon-backspace:before{
+content:"\f100"}.icon-block:before{content:"\f101"}.icon-clear:before{content:"\f102"}.icon-content-copy:before{content:"\f103"}
+.icon-content-cut:before{content:"\f104"}.icon-content-paste:before{content:"\f105"}.icon-create:before{content:"\f106"}.icon-drafts:before{content:
+"\f107"}.icon-filter-list:before{content:"\f108"}.icon-flag:before{content:"\f109"}.icon-forward:before{content:"\f10a"}.icon-gesture:before{content:
+"\f10b"}.icon-inbox:before{content:"\f10c"}.icon-link:before{content:"\f10d"}.icon-mail:before{content:"\f10e"}.icon-markunread:before{content:"\f10f"
+}.icon-redo:before{content:"\f110"}.icon-remove:before{content:"\f111"}.icon-remove-circle:before{content:"\f112"}.icon-remove-circle-outline:before{
+content:"\f113"}.icon-reply:before{content:"\f114"}.icon-reply-all:before{content:"\f115"}.icon-report:before{content:"\f116"}.icon-save:before{
+content:"\f117"}.icon-select-all:before{content:"\f118"}.icon-send:before{content:"\f119"}.icon-sort:before{content:"\f11a"}.icon-text-format:before{
+content:"\f11b"}.icon-undo:before{content:"\f11c"}.icon-access-alarm:before{content:"\f11d"}.icon-access-alarms:before{content:"\f11e"}
+.icon-access-time:before{content:"\f11f"}.icon-add-alarm:before{content:"\f120"}.icon-airplanemode-off:before{content:"\f121"}
+.icon-airplanemode-on:before{content:"\f122"}.icon-battery-20:before{content:"\f123"}.icon-battery-30:before{content:"\f124"}.icon-battery-50:before{
+content:"\f125"}.icon-battery-60:before{content:"\f126"}.icon-battery-80:before{content:"\f127"}.icon-battery-90:before{content:"\f128"}
+.icon-battery-alert:before{content:"\f129"}.icon-battery-charging-20:before{content:"\f12a"}.icon-battery-charging-30:before{content:"\f12b"}
+.icon-battery-charging-50:before{content:"\f12c"}.icon-battery-charging-60:before{content:"\f12d"}.icon-battery-charging-80:before{content:"\f12e"}
+.icon-battery-charging-90:before{content:"\f12f"}.icon-battery-charging-full:before{content:"\f130"}.icon-battery-full:before{content:"\f131"}
+.icon-battery-std:before{content:"\f132"}.icon-battery-unknown:before{content:"\f133"}.icon-bluetooth:before{content:"\f134"}
+.icon-bluetooth-connected:before{content:"\f135"}.icon-bluetooth-disabled:before{content:"\f136"}.icon-bluetooth-searching:before{content:"\f137"}
+.icon-brightness-auto:before{content:"\f138"}.icon-brightness-high:before{content:"\f139"}.icon-brightness-low:before{content:"\f13a"}
+.icon-brightness-medium:before{content:"\f13b"}.icon-data-usage:before{content:"\f13c"}.icon-developer-mode:before{content:"\f13d"}
+.icon-devices:before{content:"\f13e"}.icon-dvr:before{content:"\f13f"}.icon-gps-fixed:before{content:"\f140"}.icon-gps-not-fixed:before{content:
+"\f141"}.icon-gps-off:before{content:"\f142"}.icon-location-disabled:before{content:"\f143"}.icon-location-searching:before{content:"\f144"}
+.icon-multitrack-audio:before{content:"\f145"}.icon-network-cell:before{content:"\f146"}.icon-network-wifi:before{content:"\f147"}.icon-nfc:before{
+content:"\f148"}.icon-now-wallpaper:before{content:"\f149"}.icon-now-widgets:before{content:"\f14a"}.icon-screen-lock-landscape:before{content:"\f14b"
+}.icon-screen-lock-portrait:before{content:"\f14c"}.icon-screen-lock-rotation:before{content:"\f14d"}.icon-screen-rotation:before{content:"\f14e"}
+.icon-sd-storage:before{content:"\f14f"}.icon-settings-system-daydream:before{content:"\f150"}.icon-signal-cellular-0-bar:before{content:"\f151"}
+.icon-signal-cellular-1-bar:before{content:"\f152"}.icon-signal-cellular-2-bar:before{content:"\f153"}.icon-signal-cellular-3-bar:before{content:
+"\f154"}.icon-signal-cellular-4-bar:before{content:"\f155"}.icon-signal-cellular-connected-no-internet-0-bar:before{content:"\f156"}
+.icon-signal-cellular-connected-no-internet-1-bar:before{content:"\f157"}.icon-signal-cellular-connected-no-internet-2-bar:before{content:"\f158"}
+.icon-signal-cellular-connected-no-internet-3-bar:before{content:"\f159"}.icon-signal-cellular-connected-no-internet-4-bar:before{content:"\f15a"}
+.icon-signal-cellular-no-sim:before{content:"\f15b"}.icon-signal-cellular-null:before{content:"\f15c"}.icon-signal-cellular-off:before{content:"\f15d"
+}.icon-signal-wifi-0-bar:before{content:"\f15e"}.icon-signal-wifi-1-bar:before{content:"\f15f"}.icon-signal-wifi-2-bar:before{content:"\f160"}
+.icon-signal-wifi-3-bar:before{content:"\f161"}.icon-signal-wifi-4-bar:before{content:"\f162"}.icon-signal-wifi-off:before{content:"\f163"}
+.icon-storage:before{content:"\f164"}.icon-usb:before{content:"\f165"}.icon-wifi-lock:before{content:"\f166"}.icon-wifi-tethering:before{content:
+"\f167"}.icon-attach-file:before{content:"\f168"}.icon-attach-money:before{content:"\f169"}.icon-border-all:before{content:"\f16a"}
+.icon-border-bottom:before{content:"\f16b"}.icon-border-clear:before{content:"\f16c"}.icon-border-color:before{content:"\f16d"}
+.icon-border-horizontal:before{content:"\f16e"}.icon-border-inner:before{content:"\f16f"}.icon-border-left:before{content:"\f170"}
+.icon-border-outer:before{content:"\f171"}.icon-border-right:before{content:"\f172"}.icon-border-style:before{content:"\f173"}.icon-border-top:before{
+content:"\f174"}.icon-border-vertical:before{content:"\f175"}.icon-format-align-center:before{content:"\f176"}.icon-format-align-justify:before{
+content:"\f177"}.icon-format-align-left:before{content:"\f178"}.icon-format-align-right:before{content:"\f179"}.icon-format-bold:before{content:
+"\f17a"}.icon-format-clear:before{content:"\f17b"}.icon-format-color-fill:before{content:"\f17c"}.icon-format-color-reset:before{content:"\f17d"}
+.icon-format-color-text:before{content:"\f17e"}.icon-format-indent-decrease:before{content:"\f17f"}.icon-format-indent-increase:before{content:"\f180"
+}.icon-format-italic:before{content:"\f181"}.icon-format-line-spacing:before{content:"\f182"}.icon-format-list-bulleted:before{content:"\f183"}
+.icon-format-list-numbered:before{content:"\f184"}.icon-format-paint:before{content:"\f185"}.icon-format-quote:before{content:"\f186"}
+.icon-format-size:before{content:"\f187"}.icon-format-strikethrough:before{content:"\f188"}.icon-format-textdirection-l-to-r:before{content:"\f189"}
+.icon-format-textdirection-r-to-l:before{content:"\f18a"}.icon-format-underline:before{content:"\f18b"}.icon-functions:before{content:"\f18c"}
+.icon-insert-chart:before{content:"\f18d"}.icon-insert-comment:before{content:"\f18e"}.icon-insert-drive-file:before{content:"\f18f"}
+.icon-insert-emoticon:before{content:"\f190"}.icon-insert-invitation:before{content:"\f191"}.icon-insert-link:before{content:"\f192"}
+.icon-insert-photo:before{content:"\f193"}.icon-merge-type:before{content:"\f194"}.icon-mode-comment:before{content:"\f195"}.icon-mode-edit:before{
+content:"\f196"}.icon-publish:before{content:"\f197"}.icon-vertical-align-bottom:before{content:"\f198"}.icon-vertical-align-center:before{content:
+"\f199"}.icon-vertical-align-top:before{content:"\f19a"}.icon-wrap-text:before{content:"\f19b"}.icon-attachment:before{content:"\f19c"}
+.icon-cloud:before{content:"\f19d"}.icon-cloud-circle:before{content:"\f19e"}.icon-cloud-done:before{content:"\f19f"}.icon-cloud-download:before{
+content:"\f1a0"}.icon-cloud-off:before{content:"\f1a1"}.icon-cloud-queue:before{content:"\f1a2"}.icon-cloud-upload:before{content:"\f1a3"}
+.icon-file-download:before{content:"\f1a4"}.icon-file-upload:before{content:"\f1a5"}.icon-folder:before{content:"\f1a6"}.icon-folder-open:before{
+content:"\f1a7"}.icon-folder-shared:before{content:"\f1a8"}.icon-cast:before{content:"\f1a9"}.icon-cast-connected:before{content:"\f1aa"}
+.icon-computer:before{content:"\f1ab"}.icon-desktop-mac:before{content:"\f1ac"}.icon-desktop-windows:before{content:"\f1ad"}.icon-dock:before{content:
+"\f1ae"}.icon-gamepad:before{content:"\f1af"}.icon-headset:before{content:"\f1b0"}.icon-headset-mic:before{content:"\f1b1"}.icon-keyboard:before{
+content:"\f1b2"}.icon-keyboard-alt:before{content:"\f1b3"}.icon-keyboard-arrow-down:before{content:"\f1b4"}.icon-keyboard-arrow-left:before{content:
+"\f1b5"}.icon-keyboard-arrow-right:before{content:"\f1b6"}.icon-keyboard-arrow-up:before{content:"\f1b7"}.icon-keyboard-backspace:before{content:
+"\f1b8"}.icon-keyboard-capslock:before{content:"\f1b9"}.icon-keyboard-control:before{content:"\f1ba"}.icon-keyboard-hide:before{content:"\f1bb"}
+.icon-keyboard-return:before{content:"\f1bc"}.icon-keyboard-tab:before{content:"\f1bd"}.icon-keyboard-voice:before{content:"\f1be"}.icon-laptop:before
+{content:"\f1bf"}.icon-laptop-chromebook:before{content:"\f1c0"}.icon-laptop-mac:before{content:"\f1c1"}.icon-laptop-windows:before{content:"\f1c2"}
+.icon-memory:before{content:"\f1c3"}.icon-mouse:before{content:"\f1c4"}.icon-phone-android:before{content:"\f1c5"}.icon-phone-iphone:before{content:
+"\f1c6"}.icon-phonelink:before{content:"\f1c7"}.icon-phonelink-off:before{content:"\f1c8"}.icon-security:before{content:"\f1c9"}.icon-sim-card:before{
+content:"\f1ca"}.icon-smartphone:before{content:"\f1cb"}.icon-speaker:before{content:"\f1cc"}.icon-tablet:before{content:"\f1cd"}
+.icon-tablet-android:before{content:"\f1ce"}.icon-tablet-mac:before{content:"\f1cf"}.icon-tv:before{content:"\f1d0"}.icon-watch:before{content:"\f1d1"
+}.icon-add-to-photos:before{content:"\f1d2"}.icon-adjust:before{content:"\f1d3"}.icon-assistant-photo:before{content:"\f1d4"}.icon-audiotrack:before{
+content:"\f1d5"}.icon-blur-circular:before{content:"\f1d6"}.icon-blur-linear:before{content:"\f1d7"}.icon-blur-off:before{content:"\f1d8"}
+.icon-blur-on:before{content:"\f1d9"}.icon-brightness-1:before{content:"\f1da"}.icon-brightness-2:before{content:"\f1db"}.icon-brightness-3:before{
+content:"\f1dc"}.icon-brightness-4:before{content:"\f1dd"}.icon-brightness-5:before{content:"\f1de"}.icon-brightness-6:before{content:"\f1df"}
+.icon-brightness-7:before{content:"\f1e0"}.icon-brush:before{content:"\f1e1"}.icon-camera:before{content:"\f1e2"}.icon-camera-alt:before{content:
+"\f1e3"}.icon-camera-front:before{content:"\f1e4"}.icon-camera-rear:before{content:"\f1e5"}.icon-camera-roll:before{content:"\f1e6"}
+.icon-center-focus-strong:before{content:"\f1e7"}.icon-center-focus-weak:before{content:"\f1e8"}.icon-collections:before{content:"\f1e9"}
+.icon-colorize:before{content:"\f1ea"}.icon-color-lens:before{content:"\f1eb"}.icon-compare:before{content:"\f1ec"}.icon-control-point:before{content:
+"\f1ed"}.icon-control-point-duplicate:before{content:"\f1ee"}.icon-crop:before{content:"\f1ef"}.icon-crop-3-2:before{content:"\f1f0"}
+.icon-crop-5-4:before{content:"\f1f1"}.icon-crop-7-5:before{content:"\f1f2"}.icon-crop-16-9:before{content:"\f1f3"}.icon-crop-din:before{content:
+"\f1f4"}.icon-crop-free:before{content:"\f1f5"}.icon-crop-landscape:before{content:"\f1f6"}.icon-crop-original:before{content:"\f1f7"}
+.icon-crop-portrait:before{content:"\f1f8"}.icon-crop-square:before{content:"\f1f9"}.icon-dehaze:before{content:"\f1fa"}.icon-details:before{content:
+"\f1fb"}.icon-edit:before{content:"\f1fc"}.icon-exposure:before{content:"\f1fd"}.icon-exposure-minus-1:before{content:"\f1fe"}
+.icon-exposure-minus-2:before{content:"\f1ff"}.icon-exposure-zero:before{content:"\f200"}.icon-exposure-plus-1:before{content:"\f201"}
+.icon-exposure-plus-2:before{content:"\f202"}.icon-filter:before{content:"\f203"}.icon-filter-1:before{content:"\f204"}.icon-filter-2:before{content:
+"\f205"}.icon-filter-3:before{content:"\f206"}.icon-filter-4:before{content:"\f207"}.icon-filter-5:before{content:"\f208"}.icon-filter-6:before{
+content:"\f209"}.icon-filter-7:before{content:"\f20a"}.icon-filter-8:before{content:"\f20b"}.icon-filter-9:before{content:"\f20c"}
+.icon-filter-9-plus:before{content:"\f20d"}.icon-filter-b-and-w:before{content:"\f20e"}.icon-filter-center-focus:before{content:"\f20f"}
+.icon-filter-drama:before{content:"\f210"}.icon-filter-frames:before{content:"\f211"}.icon-filter-hdr:before{content:"\f212"}.icon-filter-none:before{
+content:"\f213"}.icon-filter-tilt-shift:before{content:"\f214"}.icon-filter-vintage:before{content:"\f215"}.icon-flare:before{content:"\f216"}
+.icon-flash-auto:before{content:"\f217"}.icon-flash-off:before{content:"\f218"}.icon-flash-on:before{content:"\f219"}.icon-flip:before{content:"\f21a"
+}.icon-gradient:before{content:"\f21b"}.icon-grain:before{content:"\f21c"}.icon-grid-off:before{content:"\f21d"}.icon-grid-on:before{content:"\f21e"}
+.icon-hdr-off:before{content:"\f21f"}.icon-hdr-on:before{content:"\f220"}.icon-hdr-strong:before{content:"\f221"}.icon-hdr-weak:before{content:"\f222"
+}.icon-healing:before{content:"\f223"}.icon-image:before{content:"\f224"}.icon-image-aspect-ratio:before{content:"\f225"}.icon-iso:before{content:
+"\f226"}.icon-landscape:before{content:"\f227"}.icon-leak-add:before{content:"\f228"}.icon-leak-remove:before{content:"\f229"}.icon-lens:before{
+content:"\f22a"}.icon-looks:before{content:"\f22b"}.icon-looks-1:before{content:"\f22c"}.icon-looks-2:before{content:"\f22d"}.icon-looks-3:before{
+content:"\f22e"}.icon-looks-4:before{content:"\f22f"}.icon-looks-5:before{content:"\f230"}.icon-looks-6:before{content:"\f231"}.icon-loupe:before{
+content:"\f232"}.icon-movie-creation:before{content:"\f233"}.icon-nature:before{content:"\f234"}.icon-nature-people:before{content:"\f235"}
+.icon-navigate-before:before{content:"\f236"}.icon-navigate-next:before{content:"\f237"}.icon-palette:before{content:"\f238"}.icon-panorama:before{
+content:"\f239"}.icon-panorama-fisheye:before{content:"\f23a"}.icon-panorama-horizontal:before{content:"\f23b"}.icon-panorama-vertical:before{content:
+"\f23c"}.icon-panorama-wide-angle:before{content:"\f23d"}.icon-photo:before{content:"\f23e"}.icon-photo-album:before{content:"\f23f"}
+.icon-photo-camera:before{content:"\f240"}.icon-photo-library:before{content:"\f241"}.icon-portrait:before{content:"\f242"}.icon-remove-red-eye:before
+{content:"\f243"}.icon-rotate-left:before{content:"\f244"}.icon-rotate-right:before{content:"\f245"}.icon-slideshow:before{content:"\f246"}
+.icon-straighten:before{content:"\f247"}.icon-style:before{content:"\f248"}.icon-switch-camera:before{content:"\f249"}.icon-switch-video:before{
+content:"\f24a"}.icon-tag-faces:before{content:"\f24b"}.icon-texture:before{content:"\f24c"}.icon-timelapse:before{content:"\f24d"}.icon-timer:before{
+content:"\f24e"}.icon-timer-3:before{content:"\f24f"}.icon-timer-10:before{content:"\f250"}.icon-timer-auto:before{content:"\f251"}
+.icon-timer-off:before{content:"\f252"}.icon-tonality:before{content:"\f253"}.icon-transform:before{content:"\f254"}.icon-tune:before{content:"\f255"}
+.icon-wb-auto:before{content:"\f256"}.icon-wb-cloudy:before{content:"\f257"}.icon-wb-incandescent:before{content:"\f258"}.icon-wb-irradescent:before{
+content:"\f259"}.icon-wb-sunny:before{content:"\f25a"}.icon-beenhere:before{content:"\f25b"}.icon-directions:before{content:"\f25c"}
+.icon-directions-bike:before{content:"\f25d"}.icon-directions-bus:before{content:"\f25e"}.icon-directions-car:before{content:"\f25f"}
+.icon-directions-ferry:before{content:"\f260"}.icon-directions-subway:before{content:"\f261"}.icon-directions-train:before{content:"\f262"}
+.icon-directions-transit:before{content:"\f263"}.icon-directions-walk:before{content:"\f264"}.icon-flight:before{content:"\f265"}.icon-hotel:before{
+content:"\f266"}.icon-layers:before{content:"\f267"}.icon-layers-clear:before{content:"\f268"}.icon-local-airport:before{content:"\f269"}
+.icon-local-atm:before{content:"\f26a"}.icon-local-attraction:before{content:"\f26b"}.icon-local-bar:before{content:"\f26c"}.icon-local-cafe:before{
+content:"\f26d"}.icon-local-car-wash:before{content:"\f26e"}.icon-local-convenience-store:before{content:"\f26f"}.icon-local-drink:before{content:
+"\f270"}.icon-local-florist:before{content:"\f271"}.icon-local-gas-station:before{content:"\f272"}.icon-local-grocery-store:before{content:"\f273"}
+.icon-local-hospital:before{content:"\f274"}.icon-local-hotel:before{content:"\f275"}.icon-local-laundry-service:before{content:"\f276"}
+.icon-local-library:before{content:"\f277"}.icon-local-mall:before{content:"\f278"}.icon-local-movies:before{content:"\f279"}.icon-local-offer:before{
+content:"\f27a"}.icon-local-parking:before{content:"\f27b"}.icon-local-pharmacy:before{content:"\f27c"}.icon-local-phone:before{content:"\f27d"}
+.icon-local-pizza:before{content:"\f27e"}.icon-local-play:before{content:"\f27f"}.icon-local-post-office:before{content:"\f280"}
+.icon-local-print-shop:before{content:"\f281"}.icon-local-restaurant:before{content:"\f282"}.icon-local-see:before{content:"\f283"}
+.icon-local-shipping:before{content:"\f284"}.icon-local-taxi:before{content:"\f285"}.icon-location-history:before{content:"\f286"}.icon-map:before{
+content:"\f287"}.icon-my-location:before{content:"\f288"}.icon-navigation:before{content:"\f289"}.icon-pin-drop:before{content:"\f28a"}
+.icon-place:before{content:"\f28b"}.icon-rate-review:before{content:"\f28c"}.icon-restaurant-menu:before{content:"\f28d"}.icon-satellite:before{
+content:"\f28e"}.icon-store-mall-directory:before{content:"\f28f"}.icon-terrain:before{content:"\f290"}.icon-traffic:before{content:"\f291"}
+.icon-apps:before{content:"\f292"}.icon-cancel:before{content:"\f293"}.icon-arrow-drop-down-circle:before{content:"\f294"}.icon-arrow-drop-down:before
+{content:"\f295"}.icon-arrow-drop-up:before{content:"\f296"}.icon-arrow-back:before{content:"\f297"}.icon-arrow-forward:before{content:"\f298"}
+.icon-check:before{content:"\f299"}.icon-close:before{content:"\f29a"}.icon-chevron-left:before{content:"\f29b"}.icon-chevron-right:before{content:
+"\f29c"}.icon-expand-less:before{content:"\f29d"}.icon-expand-more:before{content:"\f29e"}.icon-fullscreen:before{content:"\f29f"}
+.icon-fullscreen-exit:before{content:"\f2a0"}.icon-menu:before{content:"\f2a1"}.icon-more-horiz:before{content:"\f2a2"}.icon-more-vert:before{content:
+"\f2a3"}.icon-refresh:before{content:"\f2a4"}.icon-unfold-less:before{content:"\f2a5"}.icon-unfold-more:before{content:"\f2a6"}.icon-adb:before{
+content:"\f2a7"}.icon-bluetooth-audio:before{content:"\f2a8"}.icon-disc-full:before{content:"\f2a9"}.icon-dnd-forwardslash:before{content:"\f2aa"}
+.icon-do-not-disturb:before{content:"\f2ab"}.icon-drive-eta:before{content:"\f2ac"}.icon-event-available:before{content:"\f2ad"}
+.icon-event-busy:before{content:"\f2ae"}.icon-event-note:before{content:"\f2af"}.icon-folder-special:before{content:"\f2b0"}.icon-mms:before{content:
+"\f2b1"}.icon-more:before{content:"\f2b2"}.icon-network-locked:before{content:"\f2b3"}.icon-phone-bluetooth-speaker:before{content:"\f2b4"}
+.icon-phone-forwarded:before{content:"\f2b5"}.icon-phone-in-talk:before{content:"\f2b6"}.icon-phone-locked:before{content:"\f2b7"}
+.icon-phone-missed:before{content:"\f2b8"}.icon-phone-paused:before{content:"\f2b9"}.icon-play-download:before{content:"\f2ba"}
+.icon-play-install:before{content:"\f2bb"}.icon-sd-card:before{content:"\f2bc"}.icon-sim-card-alert:before{content:"\f2bd"}.icon-sms:before{content:
+"\f2be"}.icon-sms-failed:before{content:"\f2bf"}.icon-sync:before{content:"\f2c0"}.icon-sync-disabled:before{content:"\f2c1"}.icon-sync-problem:before
+{content:"\f2c2"}.icon-system-update:before{content:"\f2c3"}.icon-tap-and-play:before{content:"\f2c4"}.icon-time-to-leave:before{content:"\f2c5"}
+.icon-vibration:before{content:"\f2c6"}.icon-voice-chat:before{content:"\f2c7"}.icon-vpn-lock:before{content:"\f2c8"}.icon-cake:before{content:"\f2c9"
+}.icon-domain:before{content:"\f2ca"}.icon-location-city:before{content:"\f2cb"}.icon-mood:before{content:"\f2cc"}.icon-notifications-none:before{
+content:"\f2cd"}.icon-notifications:before{content:"\f2ce"}.icon-notifications-off:before{content:"\f2cf"}.icon-notifications-on:before{content:
+"\f2d0"}.icon-notifications-paused:before{content:"\f2d1"}.icon-pages:before{content:"\f2d2"}.icon-party-mode:before{content:"\f2d3"}
+.icon-group:before{content:"\f2d4"}.icon-group-add:before{content:"\f2d5"}.icon-people:before{content:"\f2d6"}.icon-people-outline:before{content:
+"\f2d7"}.icon-person:before{content:"\f2d8"}.icon-person-add:before{content:"\f2d9"}.icon-person-outline:before{content:"\f2da"}.icon-plus-one:before{
+content:"\f2db"}.icon-poll:before{content:"\f2dc"}.icon-public:before{content:"\f2dd"}.icon-school:before{content:"\f2de"}.icon-share:before{content:
+"\f2df"}.icon-whatshot:before{content:"\f2e0"}.icon-check-box:before{content:"\f2e1"}.icon-check-box-outline-blank:before{content:"\f2e2"}
+.icon-radio-button-off:before{content:"\f2e3"}.icon-radio-button-on:before{content:"\f2e4"}.icon-star:before{content:"\f2e5"}.icon-star-half:before{
+content:"\f2e6"}.icon-star-outline:before{content:"\f2e7"}.waves-button,.waves-circle{-webkit-transform:translateZ(0);-ms-transform:translateZ(0);
+transform:translateZ(0)}.waves-effect{overflow:hidden;position:relative;-webkit-tap-highlight-color:transparent}.waves-effect .waves-ripple{
+background-color:rgba(0,0,0,.1);background-image:
+-webkit-radial-gradient(rgba(0,0,0,.1) 0,rgba(0,0,0,.2) 30%,rgba(0,0,0,.3) 40%,rgba(0,0,0,.4) 50%,rgba(255,255,255,0) 60%);background-image:
+radial-gradient(rgba(0,0,0,.1) 0,rgba(0,0,0,.2) 30%,rgba(0,0,0,.3) 40%,rgba(0,0,0,.4) 50%,rgba(255,255,255,0) 60%);border-radius:50%;height:100px;
+margin-top:-50px;margin-left:-50px;opacity:0;pointer-events:none;position:absolute;width:100px;-webkit-transition-property:-webkit-transform,opacity;
+transition-property:transform,opacity;-webkit-transform:scale(0);-ms-transform:scale(0);transform:scale(0);-webkit-transition:all .3s 
+cubic-bezier(.4,0,.2,1);transition:all .3s cubic-bezier(.4,0,.2,1);-webkit-transition-property:opacity,-webkit-transform;transition-property:opacity,
+transform}.waves-effect.waves-light .waves-ripple{background-color:rgba(255,255,255,.4);background-image:
+-webkit-radial-gradient(rgba(255,255,255,.1) 0,rgba(255,255,255,.2) 30%,rgba(255,255,255,.3) 40%,rgba(255,255,255,.4) 50%,rgba(255,255,255,0) 60%);
+background-image:
+radial-gradient(rgba(255,255,255,.1) 0,rgba(255,255,255,.2) 30%,rgba(255,255,255,.3) 40%,rgba(255,255,255,.4) 50%,rgba(255,255,255,0) 60%)}
+.waves-effect.waves-color-alt .waves-ripple{background-color:#27e3fd;background-image:-webkit-radial-gradient(rgba(1,121,138,.1) 0,#01798a 100%);
+background-image:radial-gradient(rgba(1,121,138,.1) 0,#01798a 100%)}.waves-effect.waves-color-blue .waves-ripple{background-color:#bbdefb;
+background-image:-webkit-radial-gradient(rgba(33,150,243,.1) 0,#2196f3 100%);background-image:radial-gradient(rgba(33,150,243,.1) 0,#2196f3 100%)}
+.waves-effect.waves-color-green .waves-ripple{background-color:#dcedc8;background-image:-webkit-radial-gradient(rgba(139,195,74,.1) 0,#8bc34a 100%);
+background-image:radial-gradient(rgba(139,195,74,.1) 0,#8bc34a 100%)}.waves-effect.waves-color-purple .waves-ripple{background-color:#e1bee7;
+background-image:-webkit-radial-gradient(rgba(156,39,176,.1) 0,#9c27b0 100%);background-image:radial-gradient(rgba(156,39,176,.1) 0,#9c27b0 100%)}
+.waves-effect.waves-color-red .waves-ripple{background-color:#ffcdd2;background-image:-webkit-radial-gradient(rgba(244,67,54,.1) 0,#f44336 100%);
+background-image:radial-gradient(rgba(244,67,54,.1) 0,#f44336 100%)}.waves-effect.waves-color-yellow .waves-ripple{background-color:#ffecb3;
+background-image:-webkit-radial-gradient(rgba(255,193,7,.1) 0,#ffc107 100%);background-image:radial-gradient(rgba(255,193,7,.1) 0,#ffc107 100%)}
+.waves-notransition{-webkit-transition:none!important;transition:none!important}code,kbd,pre,samp{font-family:Monaco,Menlo,Consolas,"Courier New",
+monospace}code{background-color:#f5f5f5;border:1px solid #e0e0e0;border-radius:4px;color:#b71c1c;font-size:75%;line-height:1;padding:2px 4px}kbd{
+background-color:#212121;border-radius:4px;color:#fff;font-size:75%;padding:2px 4px}kbd kbd{font-size:100%;font-weight:700;padding:0}pre{
+background-color:#f5f5f5;border:1px solid #e0e0e0;border-radius:2px;color:#212121;display:block;font-size:12px;line-height:20px;margin:12px 0;padding:
+6px 8px;overflow-x:auto;word-wrap:break-word;white-space:pre}pre code{background-color:transparent;border-radius:0;color:inherit;font-size:inherit;
+padding:0}.col-lg-1,.col-lg-10,.col-lg-11,.col-lg-12,.col-lg-2,.col-lg-3,.col-lg-4,.col-lg-5,.col-lg-6,.col-lg-7,.col-lg-8,.col-lg-9,.col-md-1,
+.col-md-10,.col-md-11,.col-md-12,.col-md-2,.col-md-3,.col-md-4,.col-md-5,.col-md-6,.col-md-7,.col-md-8,.col-md-9,.col-sm-1,.col-sm-10,.col-sm-11,
+.col-sm-12,.col-sm-2,.col-sm-3,.col-sm-4,.col-sm-5,.col-sm-6,.col-sm-7,.col-sm-8,.col-sm-9,.col-xs-1,.col-xs-10,.col-xs-11,.col-xs-12,.col-xs-2,
+.col-xs-3,.col-xs-4,.col-xs-5,.col-xs-6,.col-xs-7,.col-xs-8,.col-xs-9,.col-xx-1,.col-xx-10,.col-xx-11,.col-xx-12,.col-xx-2,.col-xx-3,.col-xx-4,
+.col-xx-5,.col-xx-6,.col-xx-7,.col-xx-8,.col-xx-9{min-height:1px;position:relative;padding-left:16px;padding-right:16px}.col-xx-1,.col-xx-10,
+.col-xx-11,.col-xx-12,.col-xx-2,.col-xx-3,.col-xx-4,.col-xx-5,.col-xx-6,.col-xx-7,.col-xx-8,.col-xx-9{float:left}.col-xx-1{width:8.3333333333%}
+.col-xx-2{width:16.6666666667%}.col-xx-3{width:25%}.col-xx-4{width:33.3333333333%}.col-xx-5{width:41.6666666667%}.col-xx-6{width:50%}.col-xx-7{width:
+58.3333333333%}.col-xx-8{width:66.6666666667%}.col-xx-9{width:75%}.col-xx-10{width:83.3333333333%}.col-xx-11{width:91.6666666667%}.col-xx-12{width:
+100%}.col-xx-offset-0{margin-left:0}.col-xx-offset-1{margin-left:8.3333333333%}.col-xx-offset-2{margin-left:16.6666666667%}.col-xx-offset-3{
+margin-left:25%}.col-xx-offset-4{margin-left:33.3333333333%}.col-xx-offset-5{margin-left:41.6666666667%}.col-xx-offset-6{margin-left:50%}
+.col-xx-offset-7{margin-left:58.3333333333%}.col-xx-offset-8{margin-left:66.6666666667%}.col-xx-offset-9{margin-left:75%}.col-xx-offset-10{margin-left
+:83.3333333333%}.col-xx-offset-11{margin-left:91.6666666667%}.col-xx-offset-12{margin-left:100%}.col-xx-pull-0{right:0}.col-xx-pull-1{right:
+8.3333333333%}.col-xx-pull-2{right:16.6666666667%}.col-xx-pull-3{right:25%}.col-xx-pull-4{right:33.3333333333%}.col-xx-pull-5{right:41.6666666667%}
+.col-xx-pull-6{right:50%}.col-xx-pull-7{right:58.3333333333%}.col-xx-pull-8{right:66.6666666667%}.col-xx-pull-9{right:75%}.col-xx-pull-10{right:
+83.3333333333%}.col-xx-pull-11{right:91.6666666667%}.col-xx-pull-12{right:100%}.col-xx-push-0{left:0}.col-xx-push-1{left:8.3333333333%}.col-xx-push-2{
+left:16.6666666667%}.col-xx-push-3{left:25%}.col-xx-push-4{left:33.3333333333%}.col-xx-push-5{left:41.6666666667%}.col-xx-push-6{left:50%}
+.col-xx-push-7{left:58.3333333333%}.col-xx-push-8{left:66.6666666667%}.col-xx-push-9{left:75%}.col-xx-push-10{left:83.3333333333%}.col-xx-push-11{left
+:91.6666666667%}.col-xx-push-12{left:100%}@media only screen and (min-width:480px){.col-xs-1,.col-xs-10,.col-xs-11,.col-xs-12,.col-xs-2,.col-xs-3,
+.col-xs-4,.col-xs-5,.col-xs-6,.col-xs-7,.col-xs-8,.col-xs-9{float:left}.col-xs-1{width:8.3333333333%}.col-xs-2{width:16.6666666667%}.col-xs-3{width:
+25%}.col-xs-4{width:33.3333333333%}.col-xs-5{width:41.6666666667%}.col-xs-6{width:50%}.col-xs-7{width:58.3333333333%}.col-xs-8{width:66.6666666667%}
+.col-xs-9{width:75%}.col-xs-10{width:83.3333333333%}.col-xs-11{width:91.6666666667%}.col-xs-12{width:100%}.col-xs-offset-0{margin-left:0}
+.col-xs-offset-1{margin-left:8.3333333333%}.col-xs-offset-2{margin-left:16.6666666667%}.col-xs-offset-3{margin-left:25%}.col-xs-offset-4{margin-left:
+33.3333333333%}.col-xs-offset-5{margin-left:41.6666666667%}.col-xs-offset-6{margin-left:50%}.col-xs-offset-7{margin-left:58.3333333333%}
+.col-xs-offset-8{margin-left:66.6666666667%}.col-xs-offset-9{margin-left:75%}.col-xs-offset-10{margin-left:83.3333333333%}.col-xs-offset-11{
+margin-left:91.6666666667%}.col-xs-offset-12{margin-left:100%}.col-xs-pull-0{right:0}.col-xs-pull-1{right:8.3333333333%}.col-xs-pull-2{right:
+16.6666666667%}.col-xs-pull-3{right:25%}.col-xs-pull-4{right:33.3333333333%}.col-xs-pull-5{right:41.6666666667%}.col-xs-pull-6{right:50%}
+.col-xs-pull-7{right:58.3333333333%}.col-xs-pull-8{right:66.6666666667%}.col-xs-pull-9{right:75%}.col-xs-pull-10{right:83.3333333333%}.col-xs-pull-11{
+right:91.6666666667%}.col-xs-pull-12{right:100%}.col-xs-push-0{left:0}.col-xs-push-1{left:8.3333333333%}.col-xs-push-2{left:16.6666666667%}
+.col-xs-push-3{left:25%}.col-xs-push-4{left:33.3333333333%}.col-xs-push-5{left:41.6666666667%}.col-xs-push-6{left:50%}.col-xs-push-7{left:
+58.3333333333%}.col-xs-push-8{left:66.6666666667%}.col-xs-push-9{left:75%}.col-xs-push-10{left:83.3333333333%}.col-xs-push-11{left:91.6666666667%}
+.col-xs-push-12{left:100%}}@media only screen and (min-width:768px){.col-sm-1,.col-sm-10,.col-sm-11,.col-sm-12,.col-sm-2,.col-sm-3,.col-sm-4,.col-sm-5
+,.col-sm-6,.col-sm-7,.col-sm-8,.col-sm-9{float:left}.col-sm-1{width:8.3333333333%}.col-sm-2{width:16.6666666667%}.col-sm-3{width:25%}.col-sm-4{width:
+33.3333333333%}.col-sm-5{width:41.6666666667%}.col-sm-6{width:50%}.col-sm-7{width:58.3333333333%}.col-sm-8{width:66.6666666667%}.col-sm-9{width:75%}
+.col-sm-10{width:83.3333333333%}.col-sm-11{width:91.6666666667%}.col-sm-12{width:100%}.col-sm-offset-0{margin-left:0}.col-sm-offset-1{margin-left:
+8.3333333333%}.col-sm-offset-2{margin-left:16.6666666667%}.col-sm-offset-3{margin-left:25%}.col-sm-offset-4{margin-left:33.3333333333%}
+.col-sm-offset-5{margin-left:41.6666666667%}.col-sm-offset-6{margin-left:50%}.col-sm-offset-7{margin-left:58.3333333333%}.col-sm-offset-8{margin-left:
+66.6666666667%}.col-sm-offset-9{margin-left:75%}.col-sm-offset-10{margin-left:83.3333333333%}.col-sm-offset-11{margin-left:91.6666666667%}
+.col-sm-offset-12{margin-left:100%}.col-sm-pull-0{right:0}.col-sm-pull-1{right:8.3333333333%}.col-sm-pull-2{right:16.6666666667%}.col-sm-pull-3{right:
+25%}.col-sm-pull-4{right:33.3333333333%}.col-sm-pull-5{right:41.6666666667%}.col-sm-pull-6{right:50%}.col-sm-pull-7{right:58.3333333333%}
+.col-sm-pull-8{right:66.6666666667%}.col-sm-pull-9{right:75%}.col-sm-pull-10{right:83.3333333333%}.col-sm-pull-11{right:91.6666666667%}.col-sm-pull-12
+{right:100%}.col-sm-push-0{left:0}.col-sm-push-1{left:8.3333333333%}.col-sm-push-2{left:16.6666666667%}.col-sm-push-3{left:25%}.col-sm-push-4{left:
+33.3333333333%}.col-sm-push-5{left:41.6666666667%}.col-sm-push-6{left:50%}.col-sm-push-7{left:58.3333333333%}.col-sm-push-8{left:66.6666666667%}
+.col-sm-push-9{left:75%}.col-sm-push-10{left:83.3333333333%}.col-sm-push-11{left:91.6666666667%}.col-sm-push-12{left:100%}}
+@media only screen and (min-width:992px){.col-md-1,.col-md-10,.col-md-11,.col-md-12,.col-md-2,.col-md-3,.col-md-4,.col-md-5,.col-md-6,.col-md-7,
+.col-md-8,.col-md-9{float:left}.col-md-1{width:8.3333333333%}.col-md-2{width:16.6666666667%}.col-md-3{width:25%}.col-md-4{width:33.3333333333%}
+.col-md-5{width:41.6666666667%}.col-md-6{width:50%}.col-md-7{width:58.3333333333%}.col-md-8{width:66.6666666667%}.col-md-9{width:75%}.col-md-10{width:
+83.3333333333%}.col-md-11{width:91.6666666667%}.col-md-12{width:100%}.col-md-offset-0{margin-left:0}.col-md-offset-1{margin-left:8.3333333333%}
+.col-md-offset-2{margin-left:16.6666666667%}.col-md-offset-3{margin-left:25%}.col-md-offset-4{margin-left:33.3333333333%}.col-md-offset-5{margin-left:
+41.6666666667%}.col-md-offset-6{margin-left:50%}.col-md-offset-7{margin-left:58.3333333333%}.col-md-offset-8{margin-left:66.6666666667%}
+.col-md-offset-9{margin-left:75%}.col-md-offset-10{margin-left:83.3333333333%}.col-md-offset-11{margin-left:91.6666666667%}.col-md-offset-12{
+margin-left:100%}.col-md-pull-0{right:0}.col-md-pull-1{right:8.3333333333%}.col-md-pull-2{right:16.6666666667%}.col-md-pull-3{right:25%}.col-md-pull-4
+{right:33.3333333333%}.col-md-pull-5{right:41.6666666667%}.col-md-pull-6{right:50%}.col-md-pull-7{right:58.3333333333%}.col-md-pull-8{right:
+66.6666666667%}.col-md-pull-9{right:75%}.col-md-pull-10{right:83.3333333333%}.col-md-pull-11{right:91.6666666667%}.col-md-pull-12{right:100%}
+.col-md-push-0{left:0}.col-md-push-1{left:8.3333333333%}.col-md-push-2{left:16.6666666667%}.col-md-push-3{left:25%}.col-md-push-4{left:33.3333333333%}
+.col-md-push-5{left:41.6666666667%}.col-md-push-6{left:50%}.col-md-push-7{left:58.3333333333%}.col-md-push-8{left:66.6666666667%}.col-md-push-9{left:
+75%}.col-md-push-10{left:83.3333333333%}.col-md-push-11{left:91.6666666667%}.col-md-push-12{left:100%}}@media only screen and (min-width:1440px){
+.col-lg-1,.col-lg-10,.col-lg-11,.col-lg-12,.col-lg-2,.col-lg-3,.col-lg-4,.col-lg-5,.col-lg-6,.col-lg-7,.col-lg-8,.col-lg-9{float:left}.col-lg-1{width:
+8.3333333333%}.col-lg-2{width:16.6666666667%}.col-lg-3{width:25%}.col-lg-4{width:33.3333333333%}.col-lg-5{width:41.6666666667%}.col-lg-6{width:50%}
+.col-lg-7{width:58.3333333333%}.col-lg-8{width:66.6666666667%}.col-lg-9{width:75%}.col-lg-10{width:83.3333333333%}.col-lg-11{width:91.6666666667%}
+.col-lg-12{width:100%}.col-lg-offset-0{margin-left:0}.col-lg-offset-1{margin-left:8.3333333333%}.col-lg-offset-2{margin-left:16.6666666667%}
+.col-lg-offset-3{margin-left:25%}.col-lg-offset-4{margin-left:33.3333333333%}.col-lg-offset-5{margin-left:41.6666666667%}.col-lg-offset-6{margin-left:
+50%}.col-lg-offset-7{margin-left:58.3333333333%}.col-lg-offset-8{margin-left:66.6666666667%}.col-lg-offset-9{margin-left:75%}.col-lg-offset-10{
+margin-left:83.3333333333%}.col-lg-offset-11{margin-left:91.6666666667%}.col-lg-offset-12{margin-left:100%}.col-lg-pull-0{right:0}.col-lg-pull-1{right
+:8.3333333333%}.col-lg-pull-2{right:16.6666666667%}.col-lg-pull-3{right:25%}.col-lg-pull-4{right:33.3333333333%}.col-lg-pull-5{right:41.6666666667%}
+.col-lg-pull-6{right:50%}.col-lg-pull-7{right:58.3333333333%}.col-lg-pull-8{right:66.6666666667%}.col-lg-pull-9{right:75%}.col-lg-pull-10{right:
+83.3333333333%}.col-lg-pull-11{right:91.6666666667%}.col-lg-pull-12{right:100%}.col-lg-push-0{left:0}.col-lg-push-1{left:8.3333333333%}.col-lg-push-2{
+left:16.6666666667%}.col-lg-push-3{left:25%}.col-lg-push-4{left:33.3333333333%}.col-lg-push-5{left:41.6666666667%}.col-lg-push-6{left:50%}
+.col-lg-push-7{left:58.3333333333%}.col-lg-push-8{left:66.6666666667%}.col-lg-push-9{left:75%}.col-lg-push-10{left:83.3333333333%}.col-lg-push-11{left
+:91.6666666667%}.col-lg-push-12{left:100%}}.col-between{margin-left:-16px;position:absolute;top:0;text-align:center;width:32px}.container{margin-right
+:auto;margin-left:auto;padding-right:16px;padding-left:16px}.container:after,.container:before{content:"";display:table;line-height:0}.container:after
+{clear:both}@media only screen and (min-width:992px){.container{max-width:960px}}@media only screen and (min-width:1440px){.container{max-width:1408px
+}}.container-full{max-width:none}.row{margin-right:-16px;margin-left:-16px}.row:after,.row:before{content:"";display:table;line-height:0}.row:after{
+clear:both}@media only screen and (min-width:480px) and (max-width:767px){.row-clear>.col-xs-2:nth-child(6n+1),.row-clear>.col-xs-3:nth-child(4n+1),
+.row-clear>.col-xs-4:nth-child(3n+1),.row-clear>.col-xs-6:nth-child(2n+1){clear:left}}@media only screen and (min-width:768px) and (max-width:991px){
+.row-clear>.col-sm-2:nth-child(6n+1),.row-clear>.col-sm-3:nth-child(4n+1),.row-clear>.col-sm-4:nth-child(3n+1),.row-clear>.col-sm-6:nth-child(2n+1){
+clear:left}}@media only screen and (min-width:992px) and (max-width:1439px){.row-clear>.col-md-2:nth-child(6n+1),.row-clear>.col-md-3:nth-child(4n+1),
+.row-clear>.col-md-4:nth-child(3n+1),.row-clear>.col-md-6:nth-child(2n+1){clear:left}}@media only screen and (min-width:1440px){
+.row-clear>.col-lg-2:nth-child(6n+1),.row-clear>.col-lg-3:nth-child(4n+1),.row-clear>.col-lg-4:nth-child(3n+1),.row-clear>.col-lg-6:nth-child(2n+1){
+clear:left}}.row-relative{position:relative}@media print{*,:after,:before{background:0 0!important;box-shadow:none!important;text-shadow:
+none!important}a,a:visited{text-decoration:underline}a[href]:after{content:" (" attr(href) ")"}a[href^="#"]:after,a[href^="javascript:"]:after{content
+:""}abbr[title]:after{content:" (" attr(title) ")"}blockquote,pre{border:1px solid #9e9e9e;page-break-inside:avoid}img,tr{page-break-inside:avoid}img{
+max-width:100%!important}h2,h3,p{orphans:3;widows:3}h2,h3{page-break-after:avoid}thead{display:table-header-group}.card,.card-img,.card-side{
+border-radius:0!important}.card,.tile{border:1px solid #9e9e9e}.fbtn-container,.menu,.menu-toggle{display:none!important}.footer{page-break-after:
+always}.header a{color:#2196f3}.tab-nav .nav>li.active>a{border-bottom:3px solid #212121;padding-bottom:9px}}.visible-print-block{display:
+none!important}@media print{.visible-print-block{display:block!important}}.visible-print-inline{display:none!important}@media print{
+.visible-print-inline{display:inline!important}}.visible-print-inline-block{display:none!important}@media print{.visible-print-inline-block{display:
+inline-block!important}}@media print{.hidden-print{display:none!important}}.a{background-color:transparent;border:0;display:inline;color:#2196f3;
+-webkit-appearance:none}.a:focus,.a:hover{color:#0d47a1;outline:0;text-decoration:underline}.access-hide{border:0;clip:rect(0,0,0,0);height:1px;margin
+:-1px;overflow:hidden;padding:0;position:absolute;width:1px}.access-hide.focusable:active,.access-hide.focusable:focus{clip:auto;height:auto;margin:0;
+overflow:visible;position:static;width:auto}.avoid-fout,.el-loading{position:relative}body.avoid-fout,body.el-loading{position:static}
+.avoid-fout-indicator,.el-loading-indicator{font-family:sans-serif!important;height:0;min-height:4px;overflow:hidden;position:absolute;top:0;left:0;
+text-align:center;width:0;z-index:2}.avoid-fout>.avoid-fout-indicator,.el-loading>.el-loading-indicator{background-color:#fff;height:100%;padding:24px
+ 16px;width:100%;-webkit-box-shadow:0 -1px 0 #e0e0e0,0 0 2px rgba(0,0,0,.1),0 2px 4px rgba(0,0,0,.15);box-shadow:0 -1px 0 #e0e0e0,0 0 2px 
+rgba(0,0,0,.1),0 2px 4px rgba(0,0,0,.15);opacity:1}.avoid-fout-done>.avoid-fout-indicator,.el-loading-done>.el-loading-indicator{height:0;padding:0;
+width:0;opacity:0;-webkit-transition:height 0s .3s,opacity .3s cubic-bezier(.4,0,.2,1),padding 0s .3s,width 0s .3s;transition:height 0s .3s,opacity 
+.3s cubic-bezier(.4,0,.2,1),padding 0s .3s,width 0s .3s}.avoid-fout-indicator-fixed,.el-loading-indicator-fixed{position:fixed;z-index:41}
+.avoid-fout-indicator-linear,.el-loading-indicator-linear{padding:0!important}.clearfix:after,.clearfix:before{content:"";display:table;line-height:0}
+.clearfix:after{clear:both}.collapse{display:none}.collapse.in{display:block}.collapsed-hide{display:inline}.collapsed .collapsed-hide{display:none}
+.collapsed-show{display:none}.collapsed .collapsed-show{display:inline}.collapsible-region{overflow:hidden}.collapsing{height:0;overflow:hidden;
+position:relative;-webkit-transition:height .3s cubic-bezier(.4,0,.2,1);transition:height .3s cubic-bezier(.4,0,.2,1)}.fade{opacity:0;
+-webkit-transition:opacity .3s cubic-bezier(.4,0,.2,1);transition:opacity .3s cubic-bezier(.4,0,.2,1)}.fade.in{opacity:1}.iframe-seamless{border:0;
+display:block;height:100%;margin:0;padding:0;width:100%}.img-responsive{display:block;height:auto;max-width:100%}.list-clear,.list-inline{list-style:
+none;padding-left:0}.list-inline{margin-left:-8px}.list-inline>li{display:inline-block;padding-right:8px;padding-left:8px}.margin-bottom{margin-bottom
+:24px!important}.margin-bottom-half{margin-bottom:12px!important}.margin-left{margin-left:16px!important}.margin-left-half{margin-left:8px!important}
+.margin-no{margin:0!important}.margin-no-bottom{margin-bottom:0!important}.margin-no-left{margin-left:0!important}.margin-no-right{margin-right:
+0!important}.margin-no-top{margin-top:0!important}.margin-right{margin-right:16px!important}.margin-right-half{margin-right:8px!important}.margin-top{
+margin-top:24px!important}.margin-top-half{margin-top:12px!important}.media,.media-inner{overflow:hidden}.media-object.pull-left{margin-right:16px}
+.media-object.pull-right{margin-left:16px}.modal-scrollbar-measure{height:50px;overflow:scroll;position:absolute;top:-99999px;width:50px}.no-overflow{
+overflow:hidden}.para{display:block;margin-top:24px;margin-bottom:24px}.pull-left{float:left}.pull-none{float:none!important}.pull-right{float:right}
+.text-break{word-break:break-all;-webkit-hyphens:auto;-moz-hyphens:auto;-ms-hyphens:auto;hyphens:auto}.text-lead{font-size:16px;font-weight:300;
+line-height:24px}.text-overflow{display:block;line-height:inherit;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.text-nowrap{white-space:
+nowrap}.text-center{text-align:center}.text-left{text-align:left}.text-right{text-align:right}.text-bg{color:#e0e0e0}.text-black{color:#000}
+.text-default{color:#212121}.text-hint{color:#9e9e9e}.text-sec{color:#616161}.text-white{color:#fff}.text-alt{color:#01798a}.text-blue{color:#2196f3}
+.text-green{color:#8bc34a}.text-purple{color:#9c27b0}.text-red{color:#f44336}.text-yellow{color:#ffc107}.visible-lg-block,.visible-lg-inline,
+.visible-lg-inline-block,.visible-md-block,.visible-md-inline,.visible-md-inline-block,.visible-sm-block,.visible-sm-inline,.visible-sm-inline-block,
+.visible-xs-block,.visible-xs-inline,.visible-xs-inline-block,.visible-xx-block,.visible-xx-inline,.visible-xx-inline-block{display:none!important}
+@media only screen and (max-width:479px){.hidden-xx{display:none!important}.visible-xx-block{display:block!important}.visible-xx-inline{display:
+inline!important}.visible-xx-inline-block{display:inline-block!important}}@media only screen and (min-width:480px) and (max-width:767px){.hidden-xs{
+display:none!important}.visible-xs-block{display:block!important}.visible-xs-inline{display:inline!important}.visible-xs-inline-block{display:
+inline-block!important}}@media only screen and (min-width:768px) and (max-width:991px){.hidden-sm{display:none!important}.visible-sm-block{display:
+block!important}.visible-sm-inline{display:inline!important}.visible-sm-inline-block{display:inline-block!important}}
+@media only screen and (min-width:992px) and (max-width:1439px){.hidden-md{display:none!important}.visible-md-block{display:block!important}
+.visible-md-inline{display:inline!important}.visible-md-inline-block{display:inline-block!important}}@media only screen and (min-width:1440px){
+.hidden-lg{display:none!important}.visible-lg-block{display:block!important}.visible-lg-inline{display:inline!important}.visible-lg-inline-block{
+display:inline-block!important}}.anchorjs-link,.anchorjs-link:hover{color:#01798a;font-size:80%}.avatar{background-color:#e0e0e0;border-radius:50%;
+color:#212121;display:block;height:48px;line-height:48px;text-align:center;width:48px}.avatar:focus,.avatar:hover{text-decoration:none}
+.avatar.pull-left{margin-right:16px}.avatar.pull-right{margin-left:16px}.avatar img{border-radius:50%;height:100%;vertical-align:top;width:100%}
+.avatar .fa{display:block;height:100%;line-height:inherit;text-align:center}.avatar .fa-text{font-family:inherit}.avatar-alt{background-color:#01798a;
+color:#fff}.avatar-blue{background-color:#2196f3;color:#fff}.avatar-green{background-color:#8bc34a;color:#fff}.avatar-purple{background-color:#9c27b0;
+color:#fff}.avatar-red{background-color:#f44336;color:#fff}.avatar-yellow{background-color:#ffc107;color:#fff}.avatar-inline{display:inline-block}
+.avatar-lg{height:96px;line-height:96px;width:96px}.avatar-sm{height:36px;line-height:36px;margin-top:-6px;margin-bottom:-6px;width:36px}
+.avatar-transparent{background-color:transparent}.breadcrumb{list-style:none;margin:24px 0;padding-left:0}.breadcrumb:after,.breadcrumb:before{content
+:"";display:table;line-height:0}.breadcrumb:after{clear:both}.breadcrumb>li{display:block;float:left}.breadcrumb>li+li:before{color:#9e9e9e;content:
+"\f29c";display:inline-block;line-height:24px;margin-left:.4em}.breadcrumb>.active{color:#212121}.breadcrumb>.active>.a,.breadcrumb>.active>a{color:
+#212121;cursor:text;text-decoration:none}.breadcrumb-categories{list-style:none;margin:24px 0;padding-left:0}.breadcrumb-categories:after,
+.breadcrumb-categories:before{content:"";display:table;line-height:0}.breadcrumb-categories:after{clear:both}.breadcrumb-categories>li{display:block;
+float:left;padding-right:10px}.breadcrumb-categories>li+li.category:before{color:#9e9e9e;display:inline-block;line-height:24px;margin-left:.4em}
+.breadcrumbs{padding:12px 0}.body{max-width:1000px}.btn{background-color:#fff;background-image:none;background-position:50% 50%;background-size:100% 
+100%;border:1px solid transparent;border-radius:2px;color:#212121;cursor:pointer;display:inline-block;font-size:16px;font-weight:400;line-height:24px;
+margin-bottom:0;max-width:100%;padding:5px 15px;position:relative;text-align:center;vertical-align:middle;white-space:nowrap;-webkit-box-shadow:0 1px 
+5px rgba(0,0,0,.15),0 1px 5px 1px rgba(0,0,0,.15);box-shadow:0 1px 5px rgba(0,0,0,.15),0 1px 5px 1px rgba(0,0,0,.15);-webkit-transition:
+background-color .3s cubic-bezier(.4,0,.2,1),box-shadow .3s cubic-bezier(.4,0,.2,1);transition:background-color .3s cubic-bezier(.4,0,.2,1),box-shadow
+ .3s cubic-bezier(.4,0,.2,1);-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.btn:active,.btn:focus,.btn:hover{
+color:#212121;outline:0;text-decoration:none;-webkit-box-shadow:0 1px 5px rgba(0,0,0,.15),0 5px 10px 1px rgba(0,0,0,.3),0 10px 30px rgba(0,0,0,.15);
+box-shadow:0 1px 5px rgba(0,0,0,.15),0 5px 10px 1px rgba(0,0,0,.3),0 10px 30px rgba(0,0,0,.15)}.btn[disabled],fieldset[disabled] .btn{cursor:
+not-allowed;opacity:.5}.btn.waves-effect{border:0;padding:6px 16px}.btn-alt{background-color:#01798a;color:#fff}.btn-alt:active,.btn-alt:focus,
+.btn-alt:hover{color:#fff}.btn-alt[disabled],fieldset[disabled] .btn-alt{background-color:#01798a}.btn-blue{background-color:#2196f3;color:#fff}
+.btn-blue:active,.btn-blue:focus,.btn-blue:hover{color:#fff}.btn-blue[disabled],fieldset[disabled] .btn-blue{background-color:#2196f3}.btn-green{
+background-color:#8bc34a;color:#fff}.btn-green:active,.btn-green:focus,.btn-green:hover{color:#fff}.btn-green[disabled],fieldset[disabled] .btn-green{
+background-color:#8bc34a}.btn-purple{background-color:#9c27b0;color:#fff}.btn-purple:active,.btn-purple:focus,.btn-purple:hover{color:#fff}
+.btn-purple[disabled],fieldset[disabled] .btn-purple{background-color:#9c27b0}.btn-red{background-color:#f44336;color:#fff}.btn-red:active,
+.btn-red:focus,.btn-red:hover{color:#fff}.btn-red[disabled],fieldset[disabled] .btn-red{background-color:#f44336}.btn-yellow{background-color:#ffc107;
+color:#fff}.btn-yellow:active,.btn-yellow:focus,.btn-yellow:hover{color:#fff}.btn-yellow[disabled],fieldset[disabled] .btn-yellow{background-color:
+#ffc107}.btn-sm{font-size:8px;line-height:22px;padding:0 7px}.btn-sm.waves-effect{padding:1px 8px}.btn-block{display:block;white-space:normal;width:
+100%}.btn-flat{background-color:transparent;-webkit-box-shadow:none;box-shadow:none}.btn-flat:active,.btn-flat:focus,.btn-flat:hover{background-color:
+#e0e0e0;-webkit-box-shadow:none;box-shadow:none}.btn-flat[disabled],fieldset[disabled] .btn-flat{color:#212121}.btn-flat.btn-alt{color:#01798a}
+.btn-flat.btn-alt:active,.btn-flat.btn-alt:focus,.btn-flat.btn-alt:hover{background-color:#27e3fd}.btn-flat.btn-alt[disabled],
+fieldset[disabled] .btn-flat.btn-alt{color:#01798a}.btn-flat.btn-blue{color:#2196f3}.btn-flat.btn-blue:active,.btn-flat.btn-blue:focus,
+.btn-flat.btn-blue:hover{background-color:#bbdefb}.btn-flat.btn-blue[disabled],fieldset[disabled] .btn-flat.btn-blue{color:#2196f3}.btn-flat.btn-green
+{color:#8bc34a}.btn-flat.btn-green:active,.btn-flat.btn-green:focus,.btn-flat.btn-green:hover{background-color:#dcedc8}.btn-flat.btn-green[disabled],
+fieldset[disabled] .btn-flat.btn-green{color:#8bc34a}.btn-flat.btn-purple{color:#9c27b0}.btn-flat.btn-purple:active,.btn-flat.btn-purple:focus,
+.btn-flat.btn-purple:hover{background-color:#e1bee7}.btn-flat.btn-purple[disabled],fieldset[disabled] .btn-flat.btn-purple{color:#9c27b0}
+.btn-flat.btn-red{color:#f44336}.btn-flat.btn-red:active,.btn-flat.btn-red:focus,.btn-flat.btn-red:hover{background-color:#ffcdd2}
+.btn-flat.btn-red[disabled],fieldset[disabled] .btn-flat.btn-red{color:#f44336}.btn-flat.btn-yellow{color:#ffc107}.btn-flat.btn-yellow:active,
+.btn-flat.btn-yellow:focus,.btn-flat.btn-yellow:hover{background-color:#ffecb3}.btn-flat.btn-yellow[disabled],fieldset[disabled] .btn-flat.btn-yellow{
+color:#ffc107}.btn-text{color:#212121;display:inline-block;font-size:16px;font-weight:400;line-height:24px;padding:6px 0}.fbtn{background-color:
+#e0e0e0;border-radius:50%;clear:both;color:#212121;cursor:pointer;display:block;font-size:24px;margin:12px auto;padding:12px 0;position:relative;
+text-align:center;width:48px;-webkit-box-shadow:0 3px 10px rgba(0,0,0,.5);box-shadow:0 3px 10px rgba(0,0,0,.5);-webkit-transition:all .3s 
+cubic-bezier(.4,0,.2,1);transition:all .3s cubic-bezier(.4,0,.2,1);-webkit-transition-property:box-shadow,opacity,-webkit-transform;
+transition-property:box-shadow,opacity,transform}a.fbtn:focus,a.fbtn:hover{color:#212121;-webkit-box-shadow:0 3px 10px rgba(0,0,0,.5),0 3px 15px 
+rgba(0,0,0,.5);box-shadow:0 3px 10px rgba(0,0,0,.5),0 3px 15px rgba(0,0,0,.5)}.fbtn-alt{background-color:#01798a;color:#fff!important}.fbtn-blue{
+background-color:#2196f3;color:#fff!important}.fbtn-green{background-color:#8bc34a;color:#fff!important}.fbtn-purple{background-color:#9c27b0;color:
+#fff!important}.fbtn-red{background-color:#f44336;color:#fff!important}.fbtn-yellow{background-color:#ffc107;color:#fff!important}.fbtn-lg{padding:
+18px 0;width:60px}.fbtn-lg .fbtn-sub{top:18px}.fbtn-lg~.fbtn-dropdown{min-width:92px}.fbtn-container{position:fixed;right:16px;bottom:12px;z-index:21;
+-webkit-backface-visibility:hidden;backface-visibility:hidden;-webkit-transition:margin-bottom .3s cubic-bezier(.4,0,.2,1),right .3s 
+cubic-bezier(.4,0,.2,1);transition:margin-bottom .3s cubic-bezier(.4,0,.2,1),right .3s cubic-bezier(.4,0,.2,1)}.fbtn-dropdown{max-height:0;overflow:
+hidden;padding-right:16px;padding-left:16px;position:absolute;right:-16px;bottom:100%;-webkit-transition:max-height 0s .5s;transition:max-height 0s 
+.5s}.fbtn-inner.open .fbtn-dropdown{max-height:99999px;overflow:visible;-webkit-transition:max-height 0s;transition:max-height 0s}.fbtn-dropdown .fbtn
+{opacity:0;-webkit-transform:scale(.5);-ms-transform:scale(.5);transform:scale(.5)}.fbtn-dropdown .fbtn:nth-last-child(1){-webkit-transition-delay:.3s
+;transition-delay:.3s}.fbtn-dropdown .fbtn:nth-last-child(2){-webkit-transition-delay:250ms;transition-delay:250ms}
+.fbtn-dropdown .fbtn:nth-last-child(3){-webkit-transition-delay:.2s;transition-delay:.2s}.fbtn-dropdown .fbtn:nth-last-child(4){
+-webkit-transition-delay:150ms;transition-delay:150ms}.fbtn-dropdown .fbtn:nth-last-child(5){-webkit-transition-delay:.1s;transition-delay:.1s}
+.fbtn-dropdown .fbtn:nth-last-child(6){-webkit-transition-delay:50ms;transition-delay:50ms}.fbtn-inner.open .fbtn-dropdown .fbtn{opacity:1;
+-webkit-transform:scale(1);-ms-transform:scale(1);transform:scale(1);-webkit-transition-delay:.3s;transition-delay:.3s}
+.fbtn-inner.open .fbtn-dropdown .fbtn:nth-last-child(1){-webkit-transition-delay:0s;transition-delay:0s}
+.fbtn-inner.open .fbtn-dropdown .fbtn:nth-last-child(2){-webkit-transition-delay:50ms;transition-delay:50ms}
+.fbtn-inner.open .fbtn-dropdown .fbtn:nth-last-child(3){-webkit-transition-delay:.1s;transition-delay:.1s}
+.fbtn-inner.open .fbtn-dropdown .fbtn:nth-last-child(4){-webkit-transition-delay:150ms;transition-delay:150ms}
+.fbtn-inner.open .fbtn-dropdown .fbtn:nth-last-child(5){-webkit-transition-delay:.2s;transition-delay:.2s}
+.fbtn-inner.open .fbtn-dropdown .fbtn:nth-last-child(6){-webkit-transition-delay:250ms;transition-delay:250ms}.fbtn-ori,.fbtn-sub{-webkit-transition:
+all .3s cubic-bezier(.4,0,.2,1);transition:all .3s cubic-bezier(.4,0,.2,1);-webkit-transition-property:opacity,-webkit-transform;transition-property:
+opacity,transform}.fbtn-inner.open .fbtn-ori{opacity:0;-webkit-transform:rotate(225deg);-ms-transform:rotate(225deg);transform:rotate(225deg)}
+.fbtn-rotate{-webkit-transition:all .3s cubic-bezier(.4,0,.2,1);transition:all .3s cubic-bezier(.4,0,.2,1);-webkit-transition-property:opacity,
+-webkit-transform;transition-property:opacity,transform}.fbtn-inner.open .fbtn-rotate{-webkit-transform:rotate(225deg);-ms-transform:rotate(225deg);
+transform:rotate(225deg)}.fbtn-sub{position:absolute;top:12px;left:0;text-align:center;width:100%;opacity:0;-webkit-transform:rotate(-225deg);
+-ms-transform:rotate(-225deg);transform:rotate(-225deg)}.fbtn-inner.open .fbtn-sub{opacity:1;-webkit-transform:rotate(0);-ms-transform:rotate(0);
+transform:rotate(0)}.fbtn-text{background-color:#212121;background-color:rgba(0,0,0,.8);border-radius:2px;color:#fff;font-size:8px;height:0;margin-top
+:-12px;margin-right:16px;overflow:hidden;padding-right:8px;padding-left:8px;position:absolute;top:50%;right:100%;white-space:nowrap;width:0;opacity:0;
+-webkit-transition:opacity .3s cubic-bezier(.4,0,.2,1);transition:opacity .3s cubic-bezier(.4,0,.2,1)}.no-touch .fbtn:hover .fbtn-text{height:auto;
+width:auto;opacity:1}.no-touch .fbtn-dropdown .fbtn:hover .fbtn-text{height:0;width:0;opacity:0}
+.no-touch .fbtn-inner.open .fbtn-dropdown .fbtn:hover .fbtn-text{height:auto;width:auto;opacity:1}.touch .fbtn-text{display:none;height:auto;width:
+auto;opacity:1}.touch .fbtn-inner.open .fbtn-text{display:block}.card{background-color:#fff;border-radius:2px;display:block;display:-webkit-box;
+display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex;margin-bottom:24px;position:relative;-webkit-box-shadow:0 1px 6px 
+rgba(0,0,0,.3);box-shadow:0 1px 6px rgba(0,0,0,.3);-webkit-transition:box-shadow .3s cubic-bezier(.4,0,.2,1);transition:box-shadow .3s 
+cubic-bezier(.4,0,.2,1)}.card[class*="-bg"]{color:#fff}.no-boxshadow .card{border:1px solid #e0e0e0}.card-offwhite{background-color:#f5f5f5}.card-alt,
+.card-alt-bg{-webkit-box-shadow:0 0 2px rgba(0,0,0,.3),0 1px 6px rgba(1,121,138,.3);box-shadow:0 0 2px rgba(0,0,0,.3),0 1px 6px rgba(1,121,138,.3)}
+.no-boxshadow .card-alt,.no-boxshadow .card-alt-bg{border-color:#27e3fd}.card-alt-bg{background-color:#01798a}.card-blue,.card-blue-bg{
+-webkit-box-shadow:0 0 2px rgba(0,0,0,.3),0 1px 6px rgba(33,150,243,.3);box-shadow:0 0 2px rgba(0,0,0,.3),0 1px 6px rgba(33,150,243,.3)}
+.no-boxshadow .card-blue,.no-boxshadow .card-blue-bg{border-color:#bbdefb}.card-blue-bg{background-color:#2196f3}.card-green,.card-green-bg{
+-webkit-box-shadow:0 0 2px rgba(0,0,0,.3),0 1px 6px rgba(139,195,74,.3);box-shadow:0 0 2px rgba(0,0,0,.3),0 1px 6px rgba(139,195,74,.3)}
+.no-boxshadow .card-green,.no-boxshadow .card-green-bg{border-color:#dcedc8}.card-green-bg{background-color:#8bc34a}.card-purple,.card-purple-bg{
+-webkit-box-shadow:0 0 2px rgba(0,0,0,.3),0 1px 6px rgba(156,39,176,.3);box-shadow:0 0 2px rgba(0,0,0,.3),0 1px 6px rgba(156,39,176,.3)}
+.no-boxshadow .card-purple,.no-boxshadow .card-purple-bg{border-color:#e1bee7}.card-purple-bg{background-color:#9c27b0}.card-red,.card-red-bg{
+-webkit-box-shadow:0 0 2px rgba(0,0,0,.3),0 1px 6px rgba(244,67,54,.3);box-shadow:0 0 2px rgba(0,0,0,.3),0 1px 6px rgba(244,67,54,.3)}
+.no-boxshadow .card-red,.no-boxshadow .card-red-bg{border-color:#ffcdd2}.card-red-bg{background-color:#f44336}.card-yellow,.card-yellow-bg{
+-webkit-box-shadow:0 0 2px rgba(0,0,0,.3),0 1px 6px rgba(255,193,7,.3);box-shadow:0 0 2px rgba(0,0,0,.3),0 1px 6px rgba(255,193,7,.3)}
+.no-boxshadow .card-yellow,.no-boxshadow .card-yellow-bg{border-color:#ffecb3}.card-yellow-bg{background-color:#ffc107}.card-action,.tile-action{
+border-top:1px solid #e0e0e0;position:relative}.card-action:after,.card-action:before,.tile-action:after,.tile-action:before{content:"";display:table;
+line-height:0}.card-action:after,.tile-action:after{clear:both}.card-action:first-child,.tile-action:first-child{border-top:0}.card-action .nav,
+.tile-action .nav{margin-top:0;margin-bottom:0}.card-action .nav>li>.a,.card-action .nav>li>a,.tile-action .nav>li>.a,.tile-action .nav>li>a{color:
+#616161}.card-action .nav>li>.a:focus,.card-action .nav>li>.a:hover,.card-action .nav>li>a:focus,.card-action .nav>li>a:hover,
+.tile-action .nav>li>.a:focus,.tile-action .nav>li>.a:hover,.tile-action .nav>li>a:focus,.tile-action .nav>li>a:hover{color:#2196f3}
+.card[class*="-bg"] .card-action .nav>li>.a,.card[class*="-bg"] .card-action .nav>li>a,.card[class*="-bg"] .tile-action .nav>li>.a,
+.card[class*="-bg"] .tile-action .nav>li>a{color:#fff}.card-action .nav>li.active>.a,.card-action .nav>li.active>a,.tile-action .nav>li.active>.a,
+.tile-action .nav>li.active>a{color:#2196f3}.card-action .nav>li.open>.a,.card-action .nav>li.open>a,.tile-action .nav>li.open>.a,
+.tile-action .nav>li.open>a{color:#212121}.card-alt .card-action,.card-alt .tile-action,.card-alt-bg .card-action,.card-alt-bg .tile-action{
+border-top-color:#27e3fd}.card-alt-bg .card-action,.card-alt-bg .tile-action{border-top-color:#00363e}.card-blue .card-action,.card-blue .tile-action,
+.card-blue-bg .card-action,.card-blue-bg .tile-action{border-top-color:#bbdefb}.card-blue-bg .card-action,.card-blue-bg .tile-action{border-top-color:
+#1976d2}.card-green .card-action,.card-green .tile-action,.card-green-bg .card-action,.card-green-bg .tile-action{border-top-color:#dcedc8}
+.card-green-bg .card-action,.card-green-bg .tile-action{border-top-color:#689f38}.card-purple .card-action,.card-purple .tile-action,
+.card-purple-bg .card-action,.card-purple-bg .tile-action{border-top-color:#e1bee7}.card-purple-bg .card-action,.card-purple-bg .tile-action{
+border-top-color:#7b1fa2}.card-red .card-action,.card-red .tile-action,.card-red-bg .card-action,.card-red-bg .tile-action{border-top-color:#ffcdd2}
+.card-red-bg .card-action,.card-red-bg .tile-action{border-top-color:#d32f2f}.card-yellow .card-action,.card-yellow .tile-action,
+.card-yellow-bg .card-action,.card-yellow-bg .tile-action{border-top-color:#ffecb3}.card-yellow-bg .card-action,.card-yellow-bg .tile-action{
+border-top-color:#ffa000}.card-header{padding-top:6px;padding-bottom:6px;position:relative}.card-header:after,.card-header:before{content:"";display:
+table;line-height:0}.card-header:after{clear:both}.card-header:before{border-bottom:1px solid #e0e0e0;content:"";display:block;position:absolute;
+bottom:0;left:0;width:100%}.card-heading{display:block;font-size:16px;line-height:24px;margin-top:24px;margin-bottom:24px}.card-header .card-heading{
+margin-top:0;margin-bottom:0}.card-img{overflow:hidden;position:relative}.card-img:first-child{border-radius:2px 2px 0 0}.card-img:last-child{
+border-radius:0 0 2px 2px}.card-img img{display:block;height:auto;width:100%}.card-img-heading{background-image:
+linear-gradient(to bottom,rgba(0,0,0,0),rgba(0,0,0,.5));color:#fff;font-size:16px;line-height:24px;margin:0;padding:12px 16px;position:absolute;bottom
+:0;left:0;width:100%}.card-inner{padding-right:16px;padding-left:16px;position:relative;z-index:1}.card-header .card-inner{padding-top:12px;
+padding-bottom:12px}.card-inner-side~.card-inner,.tile-side~.card-inner{overflow:hidden}.card-inner-side,.tile-side{padding-top:12px;padding-bottom:
+12px}.card-inner-side.pull-left,.pull-left.tile-side{padding-left:16px}.card-inner-side.pull-right,.pull-right.tile-side{padding-right:16px}.card-main
+{-webkit-box-flex:1;-moz-box-flex:1;-webkit-flex:1;-ms-flex:1;flex:1}.card-alt-bg .card-main a{color:#27e3fd}.card-blue-bg .card-main a{color:#bbdefb}
+.card-green-bg .card-main a{color:#dcedc8}.card-purple-bg .card-main a{color:#e1bee7}.card-red-bg .card-main a{color:#ffcdd2}
+.card-yellow-bg .card-main a{color:#ffecb3}.card-side{background-color:#f5f5f5;border-radius:2px 0 0 2px;max-width:33.33333%;padding-right:16px;
+padding-left:16px}.card-side[href]{color:#212121}.card-side[href]:focus,.card-side[href]:hover{background-color:#eee;text-decoration:none}
+.card-side.card-side-img{overflow:hidden;padding-right:0;padding-left:0}.card-side.card-side-right{border-radius:0 2px 2px 0;-webkit-box-ordinal-group
+:2;-moz-box-ordinal-group:2;-ms-flex-order:2;-webkit-order:2;order:2}.card-offwhite .card-side{background-color:#eee}.card-alt .card-side,
+.card-alt-bg .card-side{background-color:#01798a;color:#fff}.card-alt .card-side[href]:focus,.card-alt .card-side[href]:hover,
+.card-alt-bg .card-side[href]:focus,.card-alt-bg .card-side[href]:hover{background-color:#00363e}.card-alt-bg .card-side{background-color:#00363e}
+.card-alt-bg .card-side[href]:focus,.card-alt-bg .card-side[href]:hover{background-color:#000}.card-blue .card-side,.card-blue-bg .card-side{
+background-color:#2196f3;color:#fff}.card-blue .card-side[href]:focus,.card-blue .card-side[href]:hover,.card-blue-bg .card-side[href]:focus,
+.card-blue-bg .card-side[href]:hover{background-color:#1976d2}.card-blue-bg .card-side{background-color:#1976d2}.card-blue-bg .card-side[href]:focus,
+.card-blue-bg .card-side[href]:hover{background-color:#0d47a1}.card-green .card-side,.card-green-bg .card-side{background-color:#8bc34a;color:#fff}
+.card-green .card-side[href]:focus,.card-green .card-side[href]:hover,.card-green-bg .card-side[href]:focus,.card-green-bg .card-side[href]:hover{
+background-color:#689f38}.card-green-bg .card-side{background-color:#689f38}.card-green-bg .card-side[href]:focus,
+.card-green-bg .card-side[href]:hover{background-color:#33691e}.card-purple .card-side,.card-purple-bg .card-side{background-color:#9c27b0;color:#fff}
+.card-purple .card-side[href]:focus,.card-purple .card-side[href]:hover,.card-purple-bg .card-side[href]:focus,.card-purple-bg .card-side[href]:hover{
+background-color:#7b1fa2}.card-purple-bg .card-side{background-color:#7b1fa2}.card-purple-bg .card-side[href]:focus,
+.card-purple-bg .card-side[href]:hover{background-color:#4a148c}.card-red .card-side,.card-red-bg .card-side{background-color:#f44336;color:#fff}
+.card-red .card-side[href]:focus,.card-red .card-side[href]:hover,.card-red-bg .card-side[href]:focus,.card-red-bg .card-side[href]:hover{
+background-color:#d32f2f}.card-red-bg .card-side{background-color:#d32f2f}.card-red-bg .card-side[href]:focus,.card-red-bg .card-side[href]:hover{
+background-color:#b71c1c}.card-yellow .card-side,.card-yellow-bg .card-side{background-color:#ffc107;color:#fff}.card-yellow .card-side[href]:focus,
+.card-yellow .card-side[href]:hover,.card-yellow-bg .card-side[href]:focus,.card-yellow-bg .card-side[href]:hover{background-color:#ffa000}
+.card-yellow-bg .card-side{background-color:#ffa000}.card-yellow-bg .card-side[href]:focus,.card-yellow-bg .card-side[href]:hover{background-color:
+#ff6f00}.card-wrap{margin-top:24px}.dropdown{position:relative;-webkit-transition:z-index 0s .3s;transition:z-index 0s .3s}.dropdown.open{z-index:21;
+-webkit-transition:z-index 0s;transition:z-index 0s}.dropdown [data-toggle=dropdown]{cursor:pointer}.dropdown-inline{display:inline-block}
+.dropdown-menu{background-color:#fff;border:1px solid #9e9e9e;border-radius:0 2px 2px 2px;list-style:none;margin:-1px 0 0!important;min-width:100%;
+padding-top:12px!important;padding-right:0;padding-bottom:12px!important;padding-left:0;position:absolute;top:100%;left:0;-webkit-box-shadow:0 5px 
+10px rgba(0,0,0,.3),0 10px 30px rgba(0,0,0,.15);box-shadow:0 5px 10px rgba(0,0,0,.3),0 10px 30px rgba(0,0,0,.15);opacity:0;-webkit-transform:
+scale(.25,0);-ms-transform:scale(.25,0);transform:scale(.25,0);-webkit-transform-origin:0 0;transform-origin:0 0;-webkit-transition:all .3s 
+cubic-bezier(.4,0,.2,1);transition:all .3s cubic-bezier(.4,0,.2,1);-webkit-transition-property:opacity,-webkit-transform;transition-property:opacity,
+transform}.dropdown.open .dropdown-menu{opacity:1;-webkit-transform:scale(1,1);-ms-transform:scale(1,1);transform:scale(1,1)}
+.dropdown-menu.dropdown-menu-right,.dropdown.pull-right .dropdown-menu,.nav.pull-right .dropdown-menu{border-radius:2px 0 2px 2px;right:0;left:auto;
+-webkit-transform-origin:100% 0;transform-origin:100% 0}.dropdown-menu .a,.dropdown-menu a{color:#212121;display:block;padding:12px 16px;overflow:
+hidden;position:relative;text-align:left;text-overflow:ellipsis;white-space:nowrap}.dropdown-menu .a:focus,.dropdown-menu .a:hover,
+.dropdown-menu a:focus,.dropdown-menu a:hover{background-color:#f5f5f5;text-decoration:none}.dropdown-menu .active>.a,.dropdown-menu .active>a{
+background-color:#f5f5f5}.dropdown-menu li{display:block;position:relative}.no-csstransforms .dropdown-menu{display:none}
+.no-csstransforms .dropdown.open .dropdown-menu{display:block}.dropdown-toggle{-webkit-transition:background-color .3s cubic-bezier(.4,0,.2,1);
+transition:background-color .3s cubic-bezier(.4,0,.2,1)}.dropdown.open .dropdown-toggle{background-color:#e0e0e0;border-radius:2px 2px 0 0}
+.dropdown.open .dropdown-toggle-alt{background-color:#000}.dropdown.open .dropdown-toggle-blue{background-color:#0d47a1}
+.dropdown.open .dropdown-toggle-green{background-color:#33691e}.dropdown.open .dropdown-toggle-purple{background-color:#4a148c}
+.dropdown.open .dropdown-toggle-red{background-color:#b71c1c}.dropdown.open .dropdown-toggle-yellow{background-color:#ff6f00}.dropdown-toggle-btn{
+position:relative;z-index:1}.dropdown.open .dropdown-toggle-btn{background-color:#fff;color:#212121;-webkit-box-shadow:none;box-shadow:none}
+.dropdown-toggle-btn~.dropdown-menu{min-width:101%;min-width:calc(100% + 2px);padding-top:48px!important;top:-12px;left:-1px;-webkit-transform:
+scale(1,0);-ms-transform:scale(1,0);transform:scale(1,0)}.dropdown-toggle-btn~.dropdown-menu.dropdown-menu-right,
+.dropdown.pull-right .dropdown-toggle-btn~.dropdown-menu,.nav.pull-right .dropdown-toggle-btn~.dropdown-menu{right:-1px;left:auto}.dropdown-wrap{
+margin-top:24px;margin-bottom:24px}.dropdown-wrap:after,.dropdown-wrap:before{content:"";display:table;line-height:0}.dropdown-wrap:after{clear:both}
+legend[class*=col-xx-]{padding-left:8px}@media only screen and (min-width:480px){legend[class*=col-xs-]{padding-left:8px}}
+@media only screen and (min-width:768px){legend[class*=col-sm-]{padding-left:8px}}@media only screen and (min-width:992px){legend[class*=col-md-]{
+padding-left:8px}}@media only screen and (min-width:1440px){legend[class*=col-lg-]{padding-left:8px}}.checkbox,.radio{display:block;position:relative}
+.form-group .checkbox,.form-group .radio{margin-top:6px;padding-bottom:6px}.checkbox label,.radio label{cursor:pointer;margin:0;min-height:16px;
+padding-left:24px}.checkbox.disabled label,.radio.disabled label,fieldset[disabled] .checkbox label,fieldset[disabled] .radio label{color:#9e9e9e;
+cursor:not-allowed}.checkbox input[type=checkbox],.radio input[type=radio]{margin-left:-24px;position:absolute}.checkbox-inline,.radio-inline{display:
+inline-block;margin-right:16px}.form{margin-top:24px;margin-bottom:24px}.form-control,.picker__select--month,.picker__select--year{background-color:
+transparent;background-image:none;border:0;border-bottom:1px solid #9e9e9e;border-radius:0;color:#212121;display:block;font-size:16px;height:36px;
+line-height:24px;padding:6px 0 5px;width:100%;-webkit-transition:border-bottom-color .15s cubic-bezier(.4,0,.2,1);transition:border-bottom-color .15s 
+cubic-bezier(.4,0,.2,1)}.form-control:-ms-input-placeholder,.picker__select--month:-ms-input-placeholder,.picker__select--year:-ms-input-placeholder{
+color:#9e9e9e}.form-control::-moz-placeholder,.picker__select--month::-moz-placeholder,.picker__select--year::-moz-placeholder{color:#9e9e9e;opacity:1
+}.form-control::-webkit-input-placeholder,.picker__select--month::-webkit-input-placeholder,.picker__select--year::-webkit-input-placeholder{color:
+#9e9e9e}.form-control:focus,.picker__select--month:focus,.picker__select--year:focus{border-color:#2196f3;border-bottom-width:2px;outline:0;
+padding-bottom:4px}.form-control[disabled],.form-control[readonly],[disabled].picker__select--month,[disabled].picker__select--year,
+[readonly].picker__select--month,[readonly].picker__select--year,fieldset[disabled] .form-control,fieldset[disabled] .picker__select--month,
+fieldset[disabled] .picker__select--year{border-style:dashed;color:#9e9e9e;cursor:not-allowed;opacity:1}.form-control-inline.picker__select--month,
+.form-control-inline.picker__select--year,.form-control.form-control-inline{display:inline-block;vertical-align:middle;width:auto}
+.form-control-default .form-control,.form-control-default .picker__select--month,.form-control-default .picker__select--year,
+.form-control-default.picker__select--month,.form-control-default.picker__select--year,.form-control.form-control-default{border:1px solid #9e9e9e;
+padding:5px 8px;-webkit-transition:none;transition:none}.form-control-default .form-control:focus,.form-control-default .picker__select--month:focus,
+.form-control-default .picker__select--year:focus,.form-control-default.picker__select--month:focus,.form-control-default.picker__select--year:focus,
+.form-control.form-control-default:focus{border:1px solid #2196f3;padding:5px 8px}.form-control-default .form-control[disabled],
+.form-control-default .form-control[readonly],.form-control-default [disabled].picker__select--month,
+.form-control-default [disabled].picker__select--year,.form-control-default [readonly].picker__select--month,
+.form-control-default [readonly].picker__select--year,.form-control-default[disabled].picker__select--month,
+.form-control-default[disabled].picker__select--year,.form-control-default[readonly].picker__select--month,
+.form-control-default[readonly].picker__select--year,.form-control.form-control-default[disabled],.form-control.form-control-default[readonly],
+fieldset[disabled] .form-control-default .form-control,fieldset[disabled] .form-control-default .picker__select--month,
+fieldset[disabled] .form-control-default .picker__select--year,fieldset[disabled] .form-control-default.picker__select--month,
+fieldset[disabled] .form-control-default.picker__select--year,fieldset[disabled] .form-control.form-control-default{background-color:#eee}
+.form-group-alt .form-control,.form-group-alt .form-control:focus,.form-group-alt .picker__select--month,.form-group-alt .picker__select--month:focus,
+.form-group-alt .picker__select--year,.form-group-alt .picker__select--year:focus{border-color:#01798a}.form-group-blue .form-control,
+.form-group-blue .form-control:focus,.form-group-blue .picker__select--month,.form-group-blue .picker__select--month:focus,
+.form-group-blue .picker__select--year,.form-group-blue .picker__select--year:focus{border-color:#2196f3}.form-group-green .form-control,
+.form-group-green .form-control:focus,.form-group-green .picker__select--month,.form-group-green .picker__select--month:focus,
+.form-group-green .picker__select--year,.form-group-green .picker__select--year:focus{border-color:#8bc34a}.form-group-purple .form-control,
+.form-group-purple .form-control:focus,.form-group-purple .picker__select--month,.form-group-purple .picker__select--month:focus,
+.form-group-purple .picker__select--year,.form-group-purple .picker__select--year:focus{border-color:#9c27b0}.form-group-red .form-control,
+.form-group-red .form-control:focus,.form-group-red .picker__select--month,.form-group-red .picker__select--month:focus,
+.form-group-red .picker__select--year,.form-group-red .picker__select--year:focus{border-color:#f44336}.form-group-yellow .form-control,
+.form-group-yellow .form-control:focus,.form-group-yellow .picker__select--month,.form-group-yellow .picker__select--month:focus,
+.form-group-yellow .picker__select--year,.form-group-yellow .picker__select--year:focus{border-color:#ffc107}.form-control-default input[type=color],
+input[type=color].form-control-default{min-width:42px}.form-control-default label+.form-control,.form-control-default label+.picker__select--month,
+.form-control-default label+.picker__select--year,label+.form-control-default.picker__select--month,label+.form-control-default.picker__select--year,
+label+.form-control.form-control-default{margin-top:6px}.form-control-default label.access-hide+.form-control,
+.form-control-default label.access-hide+.picker__select--month,.form-control-default label.access-hide+.picker__select--year,
+label.access-hide+.form-control-default.picker__select--month,label.access-hide+.form-control-default.picker__select--year,
+label.access-hide+.form-control.form-control-default{margin-top:0}select.form-control,select.picker__select--month,select.picker__select--year{
+-webkit-appearance:none}@media only screen and (-webkit-min-device-pixel-ratio:0){select.form-control,select.picker__select--month,
+select.picker__select--year{background-image:
+url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABoAAAAkCAMAAACg5NohAAAAZlBMVEUAAABlZWXLy8vg4OB6enrX19fg4OCdnZ2KiopsbGzn5+dzc3Pt7e3GxsbPz89ubm7u7u5ycnLY2NiJiYmGhoZoaGjq6up/f3+WlpaGhoaZmZllZWVhYWFYWFhaWlpdXV1bW1tWVlaZeqNTAAAAHHRSTlMA+WVC31BEqMzyNekpcGDpKNxJzcjkL9CjwZ/yNlWBeQAAALBJREFUKM/NztkWwiAMRdFQoNparR2cGf//J8UFNdXEd8/rXrkAq9rLoIGt3Vkn9A8xJoiaSqeSJGskuXlJNs2sFRPjWo7lptzVVEoO7VyEWofvoEn8NTUUxuZo2KyCPjo2+wB9m7ZM01zB/9feN2zXEVS0bLEHZQ1b6EE2jhNvDsBbMBWkampepJtizNpi4UPyGrEimBbhLT4L2nLnzR6+ksnIGm7iGjXv8xq14bSWJwymLjvMk/6KAAAAAElFTkSuQmCC)
+;background-position:100% 11px;background-repeat:no-repeat;background-size:auto 12px;padding-right:12px}select.form-control[multiple],
+select.form-control[size],select[multiple].picker__select--month,select[multiple].picker__select--year,select[size].picker__select--month,
+select[size].picker__select--year{background-image:none;padding-right:0}}@media only screen and (-webkit-min-device-pixel-ratio:0){
+.form-control-default select,select.form-control-default{background-position:99% 11px;background-position:calc(100% - 8px) 11px;padding-right:24px}
+.form-control-default select[multiple],.form-control-default select[size],select.form-control-default[multiple],select.form-control-default[size]{
+padding-right:8px}}textarea.form-control,textarea.picker__select--month,textarea.picker__select--year{height:auto}.form-control-inverse{color:#fff}
+.form-control-inverse:-ms-input-placeholder{color:#f5f5f5}.form-control-inverse::-moz-placeholder{color:#f5f5f5;opacity:1}
+.form-control-inverse::-webkit-input-placeholder{color:#f5f5f5}.form-control-static{border-bottom:1px solid #9e9e9e;display:block;font-size:16px;
+font-weight:400;line-height:24px;margin-top:0;margin-bottom:0;padding-top:6px;padding-bottom:5px}.form-control-static.form-control-default{padding-top
+:5px}.form-group{margin-top:24px;margin-bottom:24px}legend+.form-group{margin-top:0}.form-group-btn{margin-bottom:24px}.form-group-btn .btn{margin-top
+:24px;margin-right:16px}.form-help{display:block;font-size:8px;font-weight:400;margin-top:12px;margin-bottom:12px;position:relative}.form-help-icon{
+position:absolute;top:8px;right:0}.form-help-msg{padding-right:1.2857142857em}.form-label{display:block}@media only screen and (min-width:480px){
+[class*=col-xs]>.form-label{padding-top:6px;padding-bottom:6px;text-align:right}}@media only screen and (min-width:768px){[class*=col-sm]>.form-label{
+padding-top:6px;padding-bottom:6px;text-align:right}}@media only screen and (min-width:992px){[class*=col-md]>.form-label{padding-top:6px;
+padding-bottom:6px;text-align:right}}@media only screen and (min-width:1440px){[class*=col-lg]>.form-label{padding-top:6px;padding-bottom:6px;
+text-align:right}}.form-group-alt .form-label{color:#01798a}.form-group-blue .form-label{color:#2196f3}.form-group-green .form-label{color:#8bc34a}
+.form-group-purple .form-label{color:#9c27b0}.form-group-red .form-label{color:#f44336}.form-group-yellow .form-label{color:#ffc107}.label{
+margin-bottom:12px}.checkbox-adv,.radio-adv{font-size:16px;line-height:24px}.checkbox-adv [class^=circle],.radio-adv [class^=circle]{display:block;
+height:16px;position:absolute;top:3px;left:0;width:16px}.checkbox-adv .circle,.radio-adv .circle{border:2px solid #616161;-webkit-transition:
+border-color .3s cubic-bezier(.4,0,.2,1);transition:border-color .3s cubic-bezier(.4,0,.2,1)}.checkbox-adv.disabled .circle,
+.disabled.radio-adv .circle,fieldset[disabled] .checkbox-adv .circle,fieldset[disabled] .radio-adv .circle{border-color:#9e9e9e!important}
+.checkbox-adv input.access-hide:focus~.circle,.radio-adv input.access-hide:focus~.circle{border-color:#212121}
+.checkbox-adv input.access-hide:checked~.circle,.radio-adv input.access-hide:checked~.circle{border-color:#01798a}.checkbox-adv .circle-check,
+.radio-adv .circle-check{background-color:transparent;-webkit-transform:scale(0);-ms-transform:scale(0);transform:scale(0);-webkit-transition:all .3s 
+cubic-bezier(.4,0,.2,1);transition:all .3s cubic-bezier(.4,0,.2,1);-webkit-transition-property:background-color,-webkit-transform;transition-property:
+background-color,transform}.checkbox-adv .circle-check:after,.radio-adv .circle-check:after{background-color:#01798a;border-radius:50%;content:"";
+display:block;height:80px;position:absolute;top:-32px;left:-32px;width:80px;opacity:0}.checkbox-adv.disabled .circle-check:after,
+.disabled.radio-adv .circle-check:after,fieldset[disabled] .checkbox-adv .circle-check:after,fieldset[disabled] .radio-adv .circle-check:after{
+background-color:#9e9e9e}.checkbox-adv input.access-hide:checked~.circle-check,.radio-adv input.access-hide:checked~.circle-check{-webkit-transform:
+scale(.5);-ms-transform:scale(.5);transform:scale(.5)}.checkbox-adv input.access-hide:checked~.circle-check:after,
+.radio-adv input.access-hide:checked~.circle-check:after{-webkit-animation:circle-check .6s;animation:circle-check .6s}.checkbox-adv .circle-icon,
+.radio-adv .circle-icon{background-color:transparent;color:transparent;-webkit-transform:scale(.5);-ms-transform:scale(.5);transform:scale(.5);
+-webkit-transition:all .3s cubic-bezier(.4,0,.2,1);transition:all .3s cubic-bezier(.4,0,.2,1);-webkit-transition-property:background-color,color,
+-webkit-transform;transition-property:background-color,color,transform}.checkbox-adv .circle-icon:before,.radio-adv .circle-icon:before{top:auto}
+.checkbox-adv input.access-hide:checked~.circle-icon,.radio-adv input.access-hide:checked~.circle-icon{background-color:#01798a;color:#fff;
+-webkit-transform:scale(1);-ms-transform:scale(1);transform:scale(1)}.checkbox-adv.disabled input.access-hide:checked~.circle-icon,
+.disabled.radio-adv input.access-hide:checked~.circle-icon,fieldset[disabled] .checkbox-adv input.access-hide:checked~.circle-icon,
+fieldset[disabled] .radio-adv input.access-hide:checked~.circle-icon{background-color:#9e9e9e}.radio-adv [class^=circle]{border-radius:50%}
+.radio-adv input.access-hide:checked~.circle-check{background-color:#01798a}.radio-adv.disabled input.access-hide:checked~.circle-check,
+fieldset[disabled] .radio-adv input.access-hide:checked~.circle-check{background-color:#9e9e9e}@-webkit-keyframes circle-check{0%{opacity:0}25%{
+opacity:.25}100%{opacity:0}}@keyframes circle-check{0%{opacity:0}25%{opacity:.25}100%{opacity:0}}.picker{position:absolute;z-index:40;
+-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.picker__box{background-clip:padding-box;background-color:#fff;
+border-radius:4px;outline:0;overflow:hidden;vertical-align:middle;-webkit-box-shadow:0 1px 30px rgba(0,0,0,.5);box-shadow:0 1px 30px rgba(0,0,0,.5)}
+.picker__box:after,.picker__box:before{content:"";display:table;line-height:0}.picker__box:after{clear:both}.picker__date-display{background-color:
+#01798a;border-radius:4px 4px 0 0;color:#fff}@media only screen and (min-width:992px){.picker__date-display{border-radius:4px 0 0 0;float:left;width:
+50%}}.picker__day{border-radius:50%;display:inline-block;height:36px;padding:6px 0;width:36px}.picker__day:focus,.picker__day:hover{color:#2196f3;
+cursor:pointer}.picker__day.picker__day--selected{background-color:#01798a;color:#fff!important}.picker__day.picker__day--today{color:#01798a}
+.picker__day-display{font-size:60px;line-height:72px;padding:0 16px}@media only screen and (min-width:992px){.picker__day-display div{font-size:2em}}
+.picker__day--outfocus{color:#eee}.picker__footer{clear:both;padding:12px 8px}.picker__footer button{margin-left:8px}
+.picker__footer button:first-child{margin-left:0}@media only screen and (min-width:480px){.picker__footer{text-align:right}}.picker__frame{display:
+inline-block;margin:48px auto;max-width:268px;vertical-align:middle;white-space:normal;-webkit-transform:scale(0,0);-ms-transform:scale(0,0);transform
+:scale(0,0);-webkit-transition:all .3s cubic-bezier(.4,0,.2,1);transition:all .3s cubic-bezier(.4,0,.2,1);-webkit-transition-property:
+-webkit-transform;transition-property:transform}.picker--opened .picker__frame{-webkit-transform:scale(1,1);-ms-transform:scale(1,1);transform:
+scale(1,1)}@media only screen and (min-width:480px){.picker__frame{max-width:310px}}@media only screen and (min-width:992px){.picker__frame{max-width:
+536px}}.picker__header{margin:12px 8px 6px;position:relative}@media only screen and (min-width:992px){.picker__header{float:left;margin-top:6px;
+margin-right:0;margin-left:0;width:50%}}.picker__holder{overflow-x:hidden;overflow-y:auto;position:fixed;top:100%;right:0;bottom:0;left:0;text-align:
+center;white-space:nowrap;width:100%;-webkit-overflow-scrolling:touch;-ms-overflow-style:-ms-autohiding-scrollbar;-webkit-backface-visibility:hidden;
+backface-visibility:hidden;-webkit-transition:background-color .3s cubic-bezier(.4,0,.2,1),top 0s linear .3s;transition:background-color .3s 
+cubic-bezier(.4,0,.2,1),top 0s linear .3s}.picker__holder:after{content:"";display:inline-block;height:100%;vertical-align:middle;width:1px}
+.picker--opened .picker__holder{background-color:rgba(0,0,0,.5);top:0;-webkit-transition:background-color .3s cubic-bezier(.4,0,.2,1),top 0s linear 0s
+;transition:background-color .3s cubic-bezier(.4,0,.2,1),top 0s linear 0s}.picker__input{background-color:transparent!important;border-bottom-style:
+solid!important;color:#212121!important;cursor:text!important}.picker__input.picker__input--active{border-color:#2196f3;border-bottom-width:2px}
+.picker__input.picker__input--active.form-control-default{border-bottom-width:1px}.picker__month,.picker__year{display:inline;margin-left:16px}
+.picker__month:first-child,.picker__year:first-child{margin-left:0}.picker__month-display{font-size:20px;font-weight:300;line-height:28px;padding:12px
+ 16px 0;text-transform:uppercase}@media only screen and (min-width:992px){.picker__month-display{padding-top:24px;padding-bottom:32px}}
+.picker__nav--next,.picker__nav--prev{cursor:pointer;line-height:24px;margin-top:-12px;padding:0 16px;position:absolute;top:50%}
+.picker__nav--next:focus,.picker__nav--next:hover,.picker__nav--prev:focus,.picker__nav--prev:hover{color:#2196f3}.picker__nav--next{right:0}
+.picker__nav--prev{left:0}.picker__select--month,.picker__select--year{border-bottom:0;display:inline-block;height:24px;margin-left:16px;padding-top:0
+;padding-bottom:0;width:auto}.picker__select--month:first-child,.picker__select--year:first-child{margin-left:0}
+@media only screen and (-webkit-min-device-pixel-ratio:0){select.picker__select--month,select.picker__select--year{background-position:100% 50%}}
+.picker__table{border-collapse:collapse;border-spacing:0;margin:0 8px;table-layout:fixed}@media only screen and (min-width:992px){.picker__table{float
+:left;margin:0;width:50%}}.picker__table td,.picker__table th{border:0;font-size:14px;line-height:24px;margin:0;padding:0;text-align:center;
+vertical-align:middle;width:36px}@media only screen and (min-width:480px){.picker__table td,.picker__table th{width:42px}}
+@media only screen and (min-width:992px){.picker__table td,.picker__table th{width:36px}.picker__table td:first-child,.picker__table th:first-child{
+padding-left:8px;width:44px}.picker__table td:last-child,.picker__table th:last-child{padding-right:8px;width:44px}}.picker__weekday{color:#9e9e9e;
+font-weight:300}.picker__weekday-display{background-color:#00363e;border-radius:4px 4px 0 0;padding:6px 16px}.picker__year-display{color:#27e3fd;
+font-size:20px;font-weight:300;line-height:28px;padding:0 16px 12px}@media only screen and (min-width:992px){.picker__year-display{padding-top:32px;
+padding-bottom:24px}}.floating-label{color:#9e9e9e;cursor:text;font-size:16px;line-height:1;margin:0;padding:0;position:absolute;top:10px;left:0;
+-webkit-transition:color .3s cubic-bezier(.4,0,.2,1),font-size .3s cubic-bezier(.4,0,.2,1),top .3s cubic-bezier(.4,0,.2,1);transition:color .3s 
+cubic-bezier(.4,0,.2,1),font-size .3s cubic-bezier(.4,0,.2,1),top .3s cubic-bezier(.4,0,.2,1)}.form-group-label [class*=col-] .floating-label{left:
+16px}.form-group-label.control-focus .floating-label,.form-group-label.control-highlight .floating-label{color:#616161;font-size:12px;top:-12px}
+.form-group-label.control-focus .floating-label{color:#2196f3}.form-group-label{margin-top:36px;margin-bottom:36px;position:relative}
+.form-group-label .form-control,.form-group-label .picker__select--month,.form-group-label .picker__select--year{position:relative;z-index:1}
+.form-group-label .form-control:-ms-input-placeholder,.form-group-label .picker__select--month:-ms-input-placeholder,
+.form-group-label .picker__select--year:-ms-input-placeholder{color:transparent}.form-group-label .form-control::-moz-placeholder,
+.form-group-label .picker__select--month::-moz-placeholder,.form-group-label .picker__select--year::-moz-placeholder{color:transparent;opacity:1}
+.form-group-label .form-control::-webkit-input-placeholder,.form-group-label .picker__select--month::-webkit-input-placeholder,
+.form-group-label .picker__select--year::-webkit-input-placeholder{color:transparent}.form-group-label.form-group-alt .floating-label{color:#01798a}
+.form-group-label.form-group-blue .floating-label{color:#2196f3}.form-group-label.form-group-green .floating-label{color:#8bc34a}
+.form-group-label.form-group-purple .floating-label{color:#9c27b0}.form-group-label.form-group-red .floating-label{color:#f44336}
+.form-group-label.form-group-yellow .floating-label{color:#ffc107}.form-icon-label{cursor:pointer;display:block;padding:6px 0}
+.form-group-icon.control-focus .form-icon-label{color:#2196f3}.form-group-icon.form-group-alt .form-icon-label{color:#01798a}
+.form-group-icon.form-group-blue .form-icon-label{color:#2196f3}.form-group-icon.form-group-green .form-icon-label{color:#8bc34a}
+.form-group-icon.form-group-purple .form-icon-label{color:#9c27b0}.form-group-icon.form-group-red .form-icon-label{color:#f44336}
+.form-group-icon.form-group-yellow .form-icon-label{color:#ffc107}.switch{position:relative}.switch.checkbox label,.switch.radio label{padding-left:
+40px}.switch-toggle{background-color:#9e9e9e;border-radius:4px;cursor:pointer;display:inline-block;height:8px;margin-right:8px;position:relative;
+vertical-align:middle;width:32px;-webkit-transition:background-color .3s cubic-bezier(.4,0,.2,1);transition:background-color .3s 
+cubic-bezier(.4,0,.2,1)}.switch-toggle:after{background-color:#fff;border-radius:50%;content:"";display:block;height:16px;position:absolute;top:-4px;
+left:0;width:16px;-webkit-box-shadow:0 1px 3px 1px rgba(0,0,0,.25);box-shadow:0 1px 3px 1px rgba(0,0,0,.25);-webkit-transition:background-color .3s 
+cubic-bezier(.4,0,.2,1),box-shadow .15s cubic-bezier(.4,0,.2,1),left .3s cubic-bezier(.4,0,.2,1);transition:background-color .3s 
+cubic-bezier(.4,0,.2,1),box-shadow .15s cubic-bezier(.4,0,.2,1),left .3s cubic-bezier(.4,0,.2,1)}input[type=checkbox]:checked+.switch-toggle,
+input[type=radio]:checked+.switch-toggle{background-color:#02bcd6}input[type=checkbox]:checked+.switch-toggle:after,
+input[type=radio]:checked+.switch-toggle:after{background-color:#01798a;left:16px}.checkbox.switch .switch-toggle,.radio.switch .switch-toggle{
+position:absolute;top:8px;left:0}.no-touch .switch-toggle:active:after{-webkit-box-shadow:0 1px 3px 1px rgba(0,0,0,.25),0 0 0 16px rgba(0,0,0,.1);
+box-shadow:0 1px 3px 1px rgba(0,0,0,.25),0 0 0 16px rgba(0,0,0,.1)}.no-touch input[type=checkbox]:checked+.switch-toggle:active:after,
+.no-touch input[type=radio]:checked+.switch-toggle:active:after{-webkit-box-shadow:0 1px 3px 1px rgba(0,0,0,.25),0 0 0 16px rgba(1,121,138,.25);
+box-shadow:0 1px 3px 1px rgba(0,0,0,.25),0 0 0 16px rgba(1,121,138,.25)}.touch .switch-toggle{-webkit-transition:background-color .3s 
+cubic-bezier(.4,0,.2,1) .15s;transition:background-color .3s cubic-bezier(.4,0,.2,1) .15s}.touch .switch-toggle:after{-webkit-transition:
+background-color .3s cubic-bezier(.4,0,.2,1) .15s,box-shadow .15s cubic-bezier(.4,0,.2,1),left .3s cubic-bezier(.4,0,.2,1) .15s;transition:
+background-color .3s cubic-bezier(.4,0,.2,1) .15s,box-shadow .15s cubic-bezier(.4,0,.2,1),left .3s cubic-bezier(.4,0,.2,1) .15s}
+.touch .switch-toggle.switch-toggle-on:after{-webkit-box-shadow:0 1px 3px 1px rgba(0,0,0,.25),0 0 0 16px rgba(1,121,138,.25);box-shadow:0 1px 3px 1px 
+rgba(0,0,0,.25),0 0 0 16px rgba(1,121,138,.25)}.touch input[type=checkbox]:checked+.switch-toggle.switch-toggle-on:after,
+.touch input[type=radio]:checked+.switch-toggle.switch-toggle-on:after{-webkit-box-shadow:0 1px 3px 1px rgba(0,0,0,.25),0 0 0 16px rgba(0,0,0,.1);
+box-shadow:0 1px 3px 1px rgba(0,0,0,.25),0 0 0 16px rgba(0,0,0,.1)}.textarea-autosize{min-height:36px;overflow-x:hidden}.label{background-color:
+#616161;border-radius:2px;color:#fff;display:inline;font-size:75%;font-style:normal;font-weight:400;line-height:1;padding:.2em .6em;vertical-align:
+baseline;white-space:nowrap}.label-alt{background-color:#01798a}.label-blue{background-color:#2196f3}.label-green{background-color:#8bc34a}
+.label-purple{background-color:#9c27b0}.label-red{background-color:#f44336}.label-yellow{background-color:#ffc107}.modal{display:none;overflow:hidden;
+outline:0;position:fixed;top:0;right:0;bottom:0;left:0;z-index:40;-webkit-overflow-scrolling:touch;-ms-overflow-style:-ms-autohiding-scrollbar;
+-webkit-backface-visibility:hidden;backface-visibility:hidden}.modal-open .modal{overflow-x:hidden;overflow-y:auto}.modal-backdrop{background-color:
+#000;position:fixed;top:0;right:0;bottom:0;left:0;z-index:39;-webkit-backface-visibility:hidden;backface-visibility:hidden;opacity:0;
+-webkit-transition:opacity .3s cubic-bezier(.4,0,.2,1);transition:opacity .3s cubic-bezier(.4,0,.2,1)}.modal-backdrop.fade.in{opacity:.5}.modal-close{
+color:#616161;cursor:pointer;display:block;float:right;font-size:16px;line-height:24px;margin-right:-8px;padding-right:8px;padding-left:8px}
+.modal-close:focus,.modal-close:hover{color:#2196f3;text-decoration:none}.modal-content{background-clip:padding-box;background-color:#fff;border:1px 
+solid transparent;border-radius:4px;outline:0;position:relative;-webkit-box-shadow:0 1px 30px rgba(0,0,0,.5);box-shadow:0 1px 30px rgba(0,0,0,.5)}
+.modal-uploader .modal-content{height:100%}.modal-dialog{margin-right:auto;margin-left:auto;padding:48px 16px;position:relative}
+.modal-dialog.modal-full{height:100%}.modal-dialog.modal-full .modal-content{height:100%;overflow-x:hidden;overflow-y:auto;-webkit-overflow-scrolling:
+touch;-ms-overflow-style:-ms-autohiding-scrollbar}.modal.fade .modal-dialog{-webkit-transform:scale(0,0);-ms-transform:scale(0,0);transform:scale(0,0)
+;-webkit-transition:all .3s cubic-bezier(.4,0,.2,1);transition:all .3s cubic-bezier(.4,0,.2,1);-webkit-transition-property:-webkit-transform;
+transition-property:transform}.modal.fade.in .modal-dialog{-webkit-transform:scale(1,1);-ms-transform:scale(1,1);transform:scale(1,1)}
+@media only screen and (min-width:480px){.modal-dialog.modal-xs{width:480px}}@media only screen and (min-width:992px){.modal-dialog{width:960px}}
+@media only screen and (min-width:1440px){.modal-dialog{width:1408px}}.modal-footer{padding-right:32px;padding-left:32px}.modal-footer .btn+.btn{
+margin-left:16px}.modal-heading{padding-top:24px;padding-right:32px;padding-left:32px;position:relative}.modal-inner{padding-right:32px;padding-left:
+32px}.modal-open{overflow:hidden}.modal-title{font-size:16px;line-height:24px;margin-top:0;margin-right:28px;margin-bottom:24px}.nav{list-style:none;
+margin:24px 0;padding:0;position:relative}.nav:after,.nav:before{content:"";display:table;line-height:0}.nav:after{clear:both}.nav .a,.nav a{display:
+block;padding:4px 8px;position:relative}.nav .a:focus,.nav .a:hover,.nav a:focus,.nav a:hover{text-decoration:none}.nav li{display:block;position:
+relative}.nav ul{margin:0;padding:0}.nav-justified{width:100%}.nav-justified>li{display:table-cell!important;float:none!important;width:1%!important}
+.nav-justified>li>a{text-align:center}.nav-list>li{float:left}.load-bar{float:right;height:100%;overflow:hidden;width:50%}.load-bar:first-child{float:
+left}.load-bar-base{background-color:#2196f3;float:left;height:100%;overflow:hidden;width:100%;-webkit-animation:load-bar-right-in 1s 
+cubic-bezier(.4,0,.2,1) 1 forwards;animation:load-bar-right-in 1s cubic-bezier(.4,0,.2,1) 1 forwards;-webkit-transform:translate3d(-100%,0,0);
+-ms-transform:translate3d(-100%,0,0);transform:translate3d(-100%,0,0);-webkit-transform-origin:top right;transform-origin:top right}
+.load-bar:first-child .load-bar-base{-webkit-animation:load-bar-left-in 1s cubic-bezier(.4,0,.2,1) 1 forwards;animation:load-bar-left-in 1s 
+cubic-bezier(.4,0,.2,1) 1 forwards;-webkit-transform:translate3d(100%,0,0);-ms-transform:translate3d(100%,0,0);transform:translate3d(100%,0,0);
+-webkit-transform-origin:top left;transform-origin:top left}@-webkit-keyframes load-bar-left-in{0%{-webkit-transform:translate(100%,0);-ms-transform:
+translate(100%,0);transform:translate(100%,0);-webkit-transform:translate3d(100%,0,0);-ms-transform:translate3d(100%,0,0);transform:
+translate3d(100%,0,0)}100%{-webkit-transform:translate(0,0);-ms-transform:translate(0,0);transform:translate(0,0);-webkit-transform:translate3d(0,0,0)
+;-ms-transform:translate3d(0,0,0);transform:translate3d(0,0,0)}}@keyframes load-bar-left-in{0%{-webkit-transform:translate(100%,0);-ms-transform:
+translate(100%,0);transform:translate(100%,0);-webkit-transform:translate3d(100%,0,0);-ms-transform:translate3d(100%,0,0);transform:
+translate3d(100%,0,0)}100%{-webkit-transform:translate(0,0);-ms-transform:translate(0,0);transform:translate(0,0);-webkit-transform:translate3d(0,0,0)
+;-ms-transform:translate3d(0,0,0);transform:translate3d(0,0,0)}}@-webkit-keyframes load-bar-right-in{0%{-webkit-transform:translate(-100%,0);
+-ms-transform:translate(-100%,0);transform:translate(-100%,0);-webkit-transform:translate3d(-100%,0,0);-ms-transform:translate3d(-100%,0,0);transform:
+translate3d(-100%,0,0)}100%{-webkit-transform:translate(0,0);-ms-transform:translate(0,0);transform:translate(0,0);-webkit-transform:
+translate3d(0,0,0);-ms-transform:translate3d(0,0,0);transform:translate3d(0,0,0)}}@keyframes load-bar-right-in{0%{-webkit-transform:translate(-100%,0)
+;-ms-transform:translate(-100%,0);transform:translate(-100%,0);-webkit-transform:translate3d(-100%,0,0);-ms-transform:translate3d(-100%,0,0);transform
+:translate3d(-100%,0,0)}100%{-webkit-transform:translate(0,0);-ms-transform:translate(0,0);transform:translate(0,0);-webkit-transform:
+translate3d(0,0,0);-ms-transform:translate3d(0,0,0);transform:translate3d(0,0,0)}}.load-bar-content{float:left;height:100%;position:relative;width:
+400%;-webkit-animation:load-bar-right 4s linear infinite forwards;animation:load-bar-right 4s linear infinite forwards;-webkit-animation-delay:1s;
+animation-delay:1s;-webkit-transform-origin:top center;transform-origin:top center}.load-bar:first-child .load-bar-content{-webkit-animation:
+load-bar-left 4s linear infinite forwards;animation:load-bar-left 4s linear infinite forwards;-webkit-animation-delay:1s;animation-delay:1s}
+@-webkit-keyframes load-bar-left{0%{-webkit-transform:translate(0,0);-ms-transform:translate(0,0);transform:translate(0,0);-webkit-transform:
+translate3d(0,0,0);-ms-transform:translate3d(0,0,0);transform:translate3d(0,0,0)}100%{-webkit-transform:translate(-100%,0);-ms-transform:
+translate(-100%,0);transform:translate(-100%,0);-webkit-transform:translate3d(-100%,0,0);-ms-transform:translate3d(-100%,0,0);transform:
+translate3d(-100%,0,0)}}@keyframes load-bar-left{0%{-webkit-transform:translate(0,0);-ms-transform:translate(0,0);transform:translate(0,0);
+-webkit-transform:translate3d(0,0,0);-ms-transform:translate3d(0,0,0);transform:translate3d(0,0,0)}100%{-webkit-transform:translate(-100%,0);
+-ms-transform:translate(-100%,0);transform:translate(-100%,0);-webkit-transform:translate3d(-100%,0,0);-ms-transform:translate3d(-100%,0,0);transform:
+translate3d(-100%,0,0)}}@-webkit-keyframes load-bar-right{0%{-webkit-transform:translate(-100%,0);-ms-transform:translate(-100%,0);transform:
+translate(-100%,0);-webkit-transform:translate3d(-100%,0,0);-ms-transform:translate3d(-100%,0,0);transform:translate3d(-100%,0,0)}100%{
+-webkit-transform:translate(0,0);-ms-transform:translate(0,0);transform:translate(0,0);-webkit-transform:translate3d(0,0,0);-ms-transform:
+translate3d(0,0,0);transform:translate3d(0,0,0)}}@keyframes load-bar-right{0%{-webkit-transform:translate(-100%,0);-ms-transform:translate(-100%,0);
+transform:translate(-100%,0);-webkit-transform:translate3d(-100%,0,0);-ms-transform:translate3d(-100%,0,0);transform:translate3d(-100%,0,0)}100%{
+-webkit-transform:translate(0,0);-ms-transform:translate(0,0);transform:translate(0,0);-webkit-transform:translate3d(0,0,0);-ms-transform:
+translate3d(0,0,0);transform:translate3d(0,0,0)}}.load-bar-progress{background-color:transparent;float:left;height:100%;width:25%}
+.load-bar-progress-alt{background-color:#01798a}.load-bar-progress-blue{background-color:#2196f3}.load-bar-progress-green{background-color:#8bc34a}
+.load-bar-progress-purple{background-color:#9c27b0}.load-bar-progress-red{background-color:#f44336}.load-bar-progress-yellow{background-color:#ffc107}
+.progress{background-color:#b2dbfb;height:4px;margin-top:22px;margin-bottom:22px;overflow:hidden;position:relative}.progress-bar{background-color:
+#2196f3;border-radius:0 1px 1px 0;height:100%;position:absolute;top:0;left:0;-webkit-transition:width .3s cubic-bezier(.4,0,.2,1);transition:width .3s
+ cubic-bezier(.4,0,.2,1)}.progress-alt{background-color:#27e3fd}.progress-alt .progress-bar{background-color:#01798a}.progress-blue{background-color:
+#bbdefb}.progress-blue .progress-bar{background-color:#2196f3}.progress-green{background-color:#dcedc8}.progress-green .progress-bar{background-color:
+#8bc34a}.progress-purple{background-color:#e1bee7}.progress-purple .progress-bar{background-color:#9c27b0}.progress-red{background-color:#ffcdd2}
+.progress-red .progress-bar{background-color:#f44336}.progress-yellow{background-color:#ffecb3}.progress-yellow .progress-bar{background-color:#ffc107
+}.progress-bar-indeterminate{background-color:#2196f3}.progress-bar-indeterminate:after,.progress-bar-indeterminate:before{background-color:inherit;
+border-radius:1px;content:'';display:block;position:absolute;top:0;bottom:0;left:0;will-change:left,right}.progress-bar-indeterminate:after{
+-webkit-animation:pbar-indeterminate-one 3s cubic-bezier(.6,.8,.6,.4) infinite;animation:pbar-indeterminate-one 3s cubic-bezier(.6,.8,.6,.4) infinite}
+.progress-bar-indeterminate:before{-webkit-animation:pbar-indeterminate-two 3s cubic-bezier(.2,.8,.2,.8) infinite;animation:pbar-indeterminate-two 3s 
+cubic-bezier(.2,.8,.2,.8) infinite;-webkit-animation-delay:1.5s;animation-delay:1.5s}@-webkit-keyframes pbar-indeterminate-one{0%{right:100%;left:-35%
+}60%{right:-90%;left:100%}100%{right:-90%;left:100%}}@keyframes pbar-indeterminate-one{0%{right:100%;left:-35%}60%{right:-90%;left:100%}100%{right:
+-90%;left:100%}}@-webkit-keyframes pbar-indeterminate-two{0%{right:100%;left:-150%}60%{right:-35%;left:135%}100%{right:-35%;left:135%}}
+@keyframes pbar-indeterminate-two{0%{right:100%;left:-150%}60%{right:-35%;left:135%}100%{right:-35%;left:135%}}.progress-circular{height:48px;
+margin-top:24px;margin-bottom:24px;overflow:hidden;position:relative;width:48px}.progress-circular-center{margin-right:auto;margin-left:auto}
+.progress-circular-gap{border-top:4px solid #2196f3;position:absolute;top:0;right:23px;bottom:0;left:23px}
+.progress-circular-alt .progress-circular-gap{border-top-color:#01798a}.progress-circular-blue .progress-circular-gap{border-top-color:#2196f3}
+.progress-circular-green .progress-circular-gap{border-top-color:#8bc34a}.progress-circular-purple .progress-circular-gap{border-top-color:#9c27b0}
+.progress-circular-red .progress-circular-gap{border-top-color:#f44336}.progress-circular-yellow .progress-circular-gap{border-top-color:#ffc107}
+.progress-circular-inline{display:inline-block;margin-right:16px;margin-left:16px}.progress-circular-inner{height:48px;position:relative;width:48px;
+-webkit-animation:cbar-inner-rotate 5.25s cubic-bezier(.35,0,.25,1) infinite;animation:cbar-inner-rotate 5.25s cubic-bezier(.35,0,.25,1) infinite}
+.progress-circular-left,.progress-circular-right{height:48px;overflow:hidden;position:absolute;top:0;width:24px}.progress-circular-left{left:0}
+.progress-circular-right{right:0}.progress-circular-spinner{border:4px solid #2196f3;border-bottom-color:transparent;border-radius:50%;height:48px;
+position:absolute;top:0;width:48px}.progress-circular-left .progress-circular-spinner{border-right-color:transparent;left:0;-webkit-animation:
+cbar-spinner-left 1.3125s cubic-bezier(.35,0,.25,1) infinite;animation:cbar-spinner-left 1.3125s cubic-bezier(.35,0,.25,1) infinite}
+.progress-circular-right .progress-circular-spinner{border-left-color:transparent;right:0;-webkit-animation:cbar-spinner-right 1.3125s 
+cubic-bezier(.35,0,.25,1) infinite;animation:cbar-spinner-right 1.3125s cubic-bezier(.35,0,.25,1) infinite}
+.progress-circular-alt .progress-circular-spinner{border-top-color:#01798a}.progress-circular-alt .progress-circular-left .progress-circular-spinner{
+border-left-color:#01798a}.progress-circular-alt .progress-circular-right .progress-circular-spinner{border-right-color:#01798a}
+.progress-circular-blue .progress-circular-spinner{border-top-color:#2196f3}.progress-circular-blue .progress-circular-left .progress-circular-spinner
+{border-left-color:#2196f3}.progress-circular-blue .progress-circular-right .progress-circular-spinner{border-right-color:#2196f3}
+.progress-circular-green .progress-circular-spinner{border-top-color:#8bc34a}
+.progress-circular-green .progress-circular-left .progress-circular-spinner{border-left-color:#8bc34a}
+.progress-circular-green .progress-circular-right .progress-circular-spinner{border-right-color:#8bc34a}
+.progress-circular-purple .progress-circular-spinner{border-top-color:#9c27b0}
+.progress-circular-purple .progress-circular-left .progress-circular-spinner{border-left-color:#9c27b0}
+.progress-circular-purple .progress-circular-right .progress-circular-spinner{border-right-color:#9c27b0}
+.progress-circular-red .progress-circular-spinner{border-top-color:#f44336}.progress-circular-red .progress-circular-left .progress-circular-spinner{
+border-left-color:#f44336}.progress-circular-red .progress-circular-right .progress-circular-spinner{border-right-color:#f44336}
+.progress-circular-yellow .progress-circular-spinner{border-top-color:#ffc107}
+.progress-circular-yellow .progress-circular-left .progress-circular-spinner{border-left-color:#ffc107}
+.progress-circular-yellow .progress-circular-right .progress-circular-spinner{border-right-color:#ffc107}.progress-circular-wrapper{-webkit-animation:
+cbar-wrapper-rotate 2.91667s linear infinite;animation:cbar-wrapper-rotate 2.91667s linear infinite}@-webkit-keyframes cbar-inner-rotate{12.5%{
+-webkit-transform:rotate(135deg);-ms-transform:rotate(135deg);transform:rotate(135deg)}25%{-webkit-transform:rotate(270deg);-ms-transform:
+rotate(270deg);transform:rotate(270deg)}37.5%{-webkit-transform:rotate(405deg);-ms-transform:rotate(405deg);transform:rotate(405deg)}50%{
+-webkit-transform:rotate(540deg);-ms-transform:rotate(540deg);transform:rotate(540deg)}62.5%{-webkit-transform:rotate(675deg);-ms-transform:
+rotate(675deg);transform:rotate(675deg)}75%{-webkit-transform:rotate(810deg);-ms-transform:rotate(810deg);transform:rotate(810deg)}87.5%{
+-webkit-transform:rotate(945deg);-ms-transform:rotate(945deg);transform:rotate(945deg)}100%{-webkit-transform:rotate(1080deg);-ms-transform:
+rotate(1080deg);transform:rotate(1080deg)}}@keyframes cbar-inner-rotate{12.5%{-webkit-transform:rotate(135deg);-ms-transform:rotate(135deg);transform:
+rotate(135deg)}25%{-webkit-transform:rotate(270deg);-ms-transform:rotate(270deg);transform:rotate(270deg)}37.5%{-webkit-transform:rotate(405deg);
+-ms-transform:rotate(405deg);transform:rotate(405deg)}50%{-webkit-transform:rotate(540deg);-ms-transform:rotate(540deg);transform:rotate(540deg)}62.5%
+{-webkit-transform:rotate(675deg);-ms-transform:rotate(675deg);transform:rotate(675deg)}75%{-webkit-transform:rotate(810deg);-ms-transform:
+rotate(810deg);transform:rotate(810deg)}87.5%{-webkit-transform:rotate(945deg);-ms-transform:rotate(945deg);transform:rotate(945deg)}100%{
+-webkit-transform:rotate(1080deg);-ms-transform:rotate(1080deg);transform:rotate(1080deg)}}@-webkit-keyframes cbar-spinner-left{0%,100%{
+-webkit-transform:rotate(130deg);-ms-transform:rotate(130deg);transform:rotate(130deg)}50%{-webkit-transform:rotate(-5deg);-ms-transform:rotate(-5deg)
+;transform:rotate(-5deg)}}@keyframes cbar-spinner-left{0%,100%{-webkit-transform:rotate(130deg);-ms-transform:rotate(130deg);transform:rotate(130deg)}
+50%{-webkit-transform:rotate(-5deg);-ms-transform:rotate(-5deg);transform:rotate(-5deg)}}@-webkit-keyframes cbar-spinner-right{0%,100%{
+-webkit-transform:rotate(-130deg);-ms-transform:rotate(-130deg);transform:rotate(-130deg)}50%{-webkit-transform:rotate(5deg);-ms-transform:
+rotate(5deg);transform:rotate(5deg)}}@keyframes cbar-spinner-right{0%,100%{-webkit-transform:rotate(-130deg);-ms-transform:rotate(-130deg);transform:
+rotate(-130deg)}50%{-webkit-transform:rotate(5deg);-ms-transform:rotate(5deg);transform:rotate(5deg)}}@-webkit-keyframes cbar-wrapper-rotate{100%{
+-webkit-transform:rotate(360deg);-ms-transform:rotate(360deg);transform:rotate(360deg)}}@keyframes cbar-wrapper-rotate{100%{-webkit-transform:
+rotate(360deg);-ms-transform:rotate(360deg);transform:rotate(360deg)}}.progress-position-absolute-bottom,.progress-position-absolute-top,
+.progress-position-fixed-bottom,.progress-position-fixed-top{margin:0;left:0;width:100%}.progress-position-absolute-bottom,
+.progress-position-absolute-top{position:absolute}.progress-position-absolute-bottom,.progress-position-fixed-bottom{bottom:0}
+.progress-position-absolute-top,.progress-position-fixed-top{top:0}.progress-position-fixed-bottom,.progress-position-fixed-top{position:fixed}
+.sortable-ghost{opacity:.5}.sortable-handle{cursor:move;cursor:-webkit-grab}.tab-nav{border-bottom:1px solid #9e9e9e;margin-top:24px;margin-bottom:
+24px;position:relative}.tab-nav .nav{margin-top:0;margin-bottom:-1px}.tab-nav .nav>li{vertical-align:bottom}.tab-nav .nav>li>a{color:#212121;
+padding-right:8px;padding-left:8px;text-transform:uppercase;-webkit-transition:border-bottom 0s,padding-bottom 0s;transition:border-bottom 0s,
+padding-bottom 0s}.tab-nav .nav>li>a:focus,.tab-nav .nav>li>a:hover{color:#2196f3}.tab-nav .nav>li.active>a{border-bottom:3px solid #2196f3;color:
+#2196f3;padding-bottom:9px;-webkit-transition:border-bottom 0s .45s,padding-bottom 0s .45s;transition:border-bottom 0s .45s,padding-bottom 0s .45s}
+.tab-nav-indicator{background-color:#2196f3;height:3px;position:absolute;bottom:-1px;-webkit-transition:left .3s cubic-bezier(.4,0,.2,1) .15s,right 
+.3s cubic-bezier(.4,0,.2,1);transition:left .3s cubic-bezier(.4,0,.2,1) .15s,right .3s cubic-bezier(.4,0,.2,1)}.tab-nav-indicator.reverse{
+-webkit-transition:left .3s cubic-bezier(.4,0,.2,1),right .3s cubic-bezier(.4,0,.2,1) .15s;transition:left .3s cubic-bezier(.4,0,.2,1),right .3s 
+cubic-bezier(.4,0,.2,1) .15s}.tab-nav-alt .nav>li>a:focus,.tab-nav-alt .nav>li>a:hover{color:#01798a}.tab-nav-alt .nav>li.active>a{border-bottom-color
+:#01798a;color:#01798a}.tab-nav-alt .tab-nav-indicator{background-color:#01798a}.tab-nav-blue .nav>li>a:focus,.tab-nav-blue .nav>li>a:hover{color:
+#2196f3}.tab-nav-blue .nav>li.active>a{border-bottom-color:#2196f3;color:#2196f3}.tab-nav-blue .tab-nav-indicator{background-color:#2196f3}
+.tab-nav-green .nav>li>a:focus,.tab-nav-green .nav>li>a:hover{color:#8bc34a}.tab-nav-green .nav>li.active>a{border-bottom-color:#8bc34a;color:#8bc34a}
+.tab-nav-green .tab-nav-indicator{background-color:#8bc34a}.tab-nav-purple .nav>li>a:focus,.tab-nav-purple .nav>li>a:hover{color:#9c27b0}
+.tab-nav-purple .nav>li.active>a{border-bottom-color:#9c27b0;color:#9c27b0}.tab-nav-purple .tab-nav-indicator{background-color:#9c27b0}
+.tab-nav-red .nav>li>a:focus,.tab-nav-red .nav>li>a:hover{color:#f44336}.tab-nav-red .nav>li.active>a{border-bottom-color:#f44336;color:#f44336}
+.tab-nav-red .tab-nav-indicator{background-color:#f44336}.tab-nav-yellow .nav>li>a:focus,.tab-nav-yellow .nav>li>a:hover{color:#ffc107}
+.tab-nav-yellow .nav>li.active>a{border-bottom-color:#ffc107;color:#ffc107}.tab-nav-yellow .tab-nav-indicator{background-color:#ffc107}.tab-pane{
+display:none;visibility:hidden}.tab-pane.active{display:block;visibility:visible}.body table,.table{background-color:#fff;margin-top:24px;
+margin-bottom:24px;width:100%}.body table td,.body table th,.table td,.table th{border:1px solid #e0e0e0;line-height:24px;padding:6px 16px 5px;
+vertical-align:top}.body table td.nowrap,.body table th.nowrap,.table td.nowrap,.table th.nowrap{white-space:nowrap;width:1%}.body table>thead td,
+.body table>thead th,.table>thead td,.table>thead th{background-color:#f5f5f5;color:#616161;vertical-align:bottom}
+.table-stripe>tbody>tr:nth-child(odd){background-color:#fafafa}.table-hover>tbody>tr:hover{background-color:#eee}.table-responsive{margin-top:24px;
+margin-bottom:24px;min-height:.01%;overflow-x:auto;overflow-y:hidden;-webkit-overflow-scrolling:touch;-ms-overflow-style:-ms-autohiding-scrollbar}
+.table-responsive .table{margin-top:0;margin-bottom:0}.table-responsive .table td>p:first-of-type{margin-top:0}.tile{background-color:#fff;display:
+block;position:relative;-webkit-box-shadow:0 -1px 0 #e0e0e0,0 0 2px rgba(0,0,0,.1),0 2px 4px rgba(0,0,0,.15);box-shadow:0 -1px 0 #e0e0e0,0 0 2px 
+rgba(0,0,0,.1),0 2px 4px rgba(0,0,0,.15)}.tile:after,.tile:before{content:"";display:table;line-height:0}.tile:after{clear:both}.tile[href]{color:
+#212121}.tile[href]:focus,.tile[href]:hover{color:#2196f3;text-decoration:none}.tile.active{margin-top:24px!important;margin-bottom:24px!important}
+.tile-wrap-animation .tile{opacity:0;-webkit-transform:translate(0,100%);-ms-transform:translate(0,100%);transform:translate(0,100%);
+-webkit-transition:all .6s cubic-bezier(.4,0,.2,1);transition:all .6s cubic-bezier(.4,0,.2,1);-webkit-transition-property:opacity,-webkit-transform;
+transition-property:opacity,transform}.tile-wrap-animation.isinview .tile{opacity:1;-webkit-transform:translate(0,0)!important;-ms-transform:
+translate(0,0)!important;transform:translate(0,0)!important}.no-boxshadow .tile{border:1px solid #e0e0e0}.no-boxshadow .tile+.tile{margin-top:-1px}
+.tile-offwhite{background-color:#f5f5f5}.tile-alt{background-color:#01798a;color:#fff}.tile-alt a{color:#27e3fd}.tile-blue{background-color:#2196f3;
+color:#fff}.tile-blue a{color:#bbdefb}.tile-green{background-color:#8bc34a;color:#fff}.tile-green a{color:#dcedc8}.tile-purple{background-color:
+#9c27b0;color:#fff}.tile-purple a{color:#e1bee7}.tile-red{background-color:#f44336;color:#fff}.tile-red a{color:#ffcdd2}.tile-yellow{background-color:
+#ffc107;color:#fff}.tile-yellow a{color:#ffecb3}.tile-action{border-top:0;float:right;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:
+none;user-select:none}.no-touch .tile-action,.touch .tile-collapse .tile-action{display:none}.no-touch .tile:hover .tile-action,
+.tile-collapse.active .tile-action{display:block}.tile-action-show{display:block!important}.tile-active-show{-webkit-transition:height .15s linear;
+transition:height .15s linear}.tile-collapse{-webkit-transition:margin .15s linear;transition:margin .15s linear}.tile-collapse.active{margin-right:
+-15px;margin-left:-15px}.tile-wrap-animation .tile-collapse{-webkit-transition:all .6s cubic-bezier(.4,0,.2,1),margin .15s linear;transition:all .6s 
+cubic-bezier(.4,0,.2,1),margin .15s linear;-webkit-transition-property:margin,opacity,-webkit-transform;transition-property:margin,opacity,transform}
+@media only screen and (min-width:1056px) and (max-width:1439px){.tile-collapse-full.active{margin-right:-63px;margin-left:-63px}}
+@media only screen and (min-width:1504px){.tile-collapse-full.active{margin-right:-63px;margin-left:-63px}}.tile-footer{background-color:#f5f5f5;
+border-top:1px solid #e0e0e0;position:relative}.tile-footer:after,.tile-footer:before{content:"";display:table;line-height:0}.tile-footer:after{clear:
+both}.tile-footer:first-child{border-top:0}.tile-footer .nav{margin-top:0;margin-bottom:0}.tile-offwhite .tile-footer{background-color:#eee}
+.tile-alt .tile-footer{background-color:#00363e;border-top-color:#00363e}.tile-alt .tile-footer .nav>li>.a,.tile-alt .tile-footer .nav>li>a{color:#fff
+}.tile-blue .tile-footer{background-color:#1976d2;border-top-color:#1976d2}.tile-blue .tile-footer .nav>li>.a,.tile-blue .tile-footer .nav>li>a{color:
+#fff}.tile-green .tile-footer{background-color:#689f38;border-top-color:#689f38}.tile-green .tile-footer .nav>li>.a,.tile-green .tile-footer .nav>li>a
+{color:#fff}.tile-purple .tile-footer{background-color:#7b1fa2;border-top-color:#7b1fa2}.tile-purple .tile-footer .nav>li>.a,
+.tile-purple .tile-footer .nav>li>a{color:#fff}.tile-red .tile-footer{background-color:#d32f2f;border-top-color:#d32f2f}
+.tile-red .tile-footer .nav>li>.a,.tile-red .tile-footer .nav>li>a{color:#fff}.tile-yellow .tile-footer{background-color:#ffa000;border-top-color:
+#ffa000}.tile-yellow .tile-footer .nav>li>.a,.tile-yellow .tile-footer .nav>li>a{color:#fff}.tile-inner{padding:12px 16px;position:relative}
+.tile-action~.tile-inner,.tile-side~.tile-inner{overflow:hidden}.tile-side-container{padding:0!important}.tile-sub{display:inline-block;padding-right:
+16px;padding-left:16px;position:relative;width:100%}.tile-sub:before{border-top:1px solid #e0e0e0;content:"";display:block;position:absolute;top:0;
+left:0;width:100%}.tile-alt .tile-sub:before{border-top-color:#00363e}.tile-blue .tile-sub:before{border-top-color:#1976d2}
+.tile-green .tile-sub:before{border-top-color:#689f38}.tile-purple .tile-sub:before{border-top-color:#7b1fa2}.tile-red .tile-sub:before{
+border-top-color:#d32f2f}.tile-yellow .tile-sub:before{border-top-color:#ffa000}.tile-toggle{cursor:pointer}.tile-toggle:after,.tile-toggle:before{
+content:"";display:table;line-height:0}.tile-toggle:after{clear:both}.tile-wrap{margin-top:24px;margin-bottom:24px;position:relative}.toast{position:
+fixed;right:0;bottom:0;left:0;z-index:21}.toast a{color:#b2dbfb;cursor:pointer}.toast a:focus,.toast a:hover{color:#6ab8f7;text-decoration:none}
+.toast .tooltip{position:static!important}@media only screen and (min-width:768px){.toast{margin-right:80px;right:auto;bottom:24px;left:16px!important
+}}.toast-inner{background-color:#212121;color:#fff;font-size:14px;padding:12px 16px;-webkit-backface-visibility:hidden;backface-visibility:hidden;
+-webkit-box-shadow:0 1px 10px rgba(0,0,0,.5);box-shadow:0 1px 10px rgba(0,0,0,.5);-webkit-transform:translate3d(0,200%,0);-ms-transform:
+translate3d(0,200%,0);transform:translate3d(0,200%,0);-webkit-transition:all .3s cubic-bezier(.4,0,.2,1);transition:all .3s cubic-bezier(.4,0,.2,1);
+-webkit-transition-property:-webkit-transform;transition-property:transform}.toast-inner:after,.toast-inner:before{content:"";display:table;
+line-height:0}.toast-inner:after{clear:both}.toast-show .toast-inner{-webkit-transform:translate3d(0,0,0);-ms-transform:translate3d(0,0,0);transform:
+translate3d(0,0,0)}@media only screen and (min-width:768px){.toast-inner{border-radius:2px;float:left}}.no-csstransforms3d .toast-inner{opacity:0}
+.no-csstransforms3d .toast-show .toast-inner{opacity:1}.toast-text{overflow:hidden}[data-dismiss=toast]{cursor:pointer;float:right;font-weight:700;
+margin-left:16px;text-transform:uppercase}.twitter-typeahead{display:block!important}.twitter-typeahead .tt-menu{margin-top:24px;width:100%}
+.twitter-typeahead .tt-menu .tt-suggestion{padding:3px}.twitter-typeahead .tt-menu .tt-cursor{background-color:#bbdefb}
+.twitter-typeahead .tt-menu.tt-open{cursor:pointer}.content{padding-bottom:24px}.searching .content{display:none}.content-fix-scroll{margin-right:
+-16px;margin-left:-16px;overflow:hidden;padding-right:16px;padding-left:16px}.content-fix.fixed .content-fix-scroll{position:fixed;top:48px;bottom:0;
+-webkit-backface-visibility:hidden;backface-visibility:hidden}.content-fix.fixed .content-fix-wrap{overflow-x:hidden;overflow-y:auto;padding-right:
+32px;padding-left:32px;position:absolute;top:0;right:-16px;bottom:0;left:-16px;-webkit-overflow-scrolling:touch;-ms-overflow-style:none}
+.content-heading{background-color:#01798a;color:#fff;overflow:hidden;padding-top:36px;position:relative;z-index:1;-webkit-transition:background-color 
+.3s cubic-bezier(.4,0,.2,1),color .3s cubic-bezier(.4,0,.2,1);transition:background-color .3s cubic-bezier(.4,0,.2,1),color .3s 
+cubic-bezier(.4,0,.2,1)}.page-alt .content-heading{background-color:#01798a}.page-blue .content-heading{background-color:#2196f3}
+.page-green .content-heading{background-color:#8bc34a}.page-purple .content-heading{background-color:#9c27b0}.page-red .content-heading{
+background-color:#f44336}.page-yellow .content-heading{background-color:#ffc107}.content-heading .heading{font-weight:300}h2,h3,h4,h5,h6{color:#01798a
+}.body h2:first-of-type{margin-top:0}.row-fix{position:relative}.argument,.attribute{font-weight:600;color:#01798a}fieldset#-lucee-debug{padding-left:
+300px}a.missing-link{text-decoration:underline red}.tile-toolbar{text-align:right}.arguments TH,.attributes TH{font-weight:400}.footer{
+background-color:#fafafa;border-top:1px solid #e0e0e0;color:#9e9e9e;text-align:center;position:absolute;bottom:0;right:0;left:0}.footer a{color:
+#9e9e9e}.footer a:focus,.footer a:hover{color:#212121}.header{background-color:#01798a;color:#fff;position:fixed;top:0;right:0;left:0;z-index:30;
+-webkit-backface-visibility:hidden;backface-visibility:hidden;-webkit-transition:background-color .3s cubic-bezier(.4,0,.2,1),box-shadow .15s linear;
+transition:background-color .3s cubic-bezier(.4,0,.2,1),box-shadow .15s linear}.header:after,.header:before{content:"";display:table;line-height:0}
+.header:after{clear:both}.header.fixed,.header.open,.menu-open .header{background-color:#00363e;-webkit-box-shadow:0 1px 10px rgba(0,0,0,.5);
+box-shadow:0 1px 10px rgba(0,0,0,.5)}.page-alt .header{background-color:#01798a}.page-alt .header.fixed,.page-alt .header.open{background-color:
+#00363e}.menu-open.page-alt .header{background-color:#00363e}.page-blue .header{background-color:#2196f3}.page-blue .header.fixed,
+.page-blue .header.open{background-color:#1976d2}.menu-open.page-blue .header{background-color:#1976d2}.page-green .header{background-color:#8bc34a}
+.page-green .header.fixed,.page-green .header.open{background-color:#689f38}.menu-open.page-green .header{background-color:#689f38}
+.page-purple .header{background-color:#9c27b0}.page-purple .header.fixed,.page-purple .header.open{background-color:#7b1fa2}
+.menu-open.page-purple .header{background-color:#7b1fa2}.page-red .header{background-color:#f44336}.page-red .header.fixed,.page-red .header.open{
+background-color:#d32f2f}.menu-open.page-red .header{background-color:#d32f2f}.page-yellow .header{background-color:#ffc107}.page-yellow .header.fixed
+,.page-yellow .header.open{background-color:#ffa000}.menu-open.page-yellow .header{background-color:#ffa000}.header a{color:#fff}.header .breadcrumb{
+color:#fff;margin-top:0;margin-bottom:0;max-height:48px;overflow:hidden;padding-right:16px;padding-left:16px}.header .breadcrumb .a,
+.header .breadcrumb a{text-decoration:none}.header .breadcrumb>.active{color:#fff;font-weight:300}.header .breadcrumb>.active>.a,
+.header .breadcrumb>.active>a{color:#fff}@media only screen and (max-width:767px){.header .breadcrumb>li{display:none}.header .breadcrumb>.active{
+display:block}.header .breadcrumb>.active:before{display:none}}.header .dropdown-menu{border-radius:2px}.header .dropdown-menu a{color:#212121}
+.header .dropdown-toggle{z-index:1}.header .dropdown-toggle:after{background-color:#01798a;border-radius:50%;content:"";display:block;height:36px;
+position:absolute;top:6px;right:6px;bottom:6px;left:6px;z-index:-1;-webkit-transform:scale(0);-ms-transform:scale(0);transform:scale(0);
+-webkit-transition:all .3s cubic-bezier(.4,0,.2,1);transition:all .3s cubic-bezier(.4,0,.2,1);-webkit-transition-property:background-color,
+-webkit-transform;transition-property:background-color,transform}.page-alt .header .dropdown-toggle:after{background-color:#01798a}
+.page-blue .header .dropdown-toggle:after{background-color:#2196f3}.page-green .header .dropdown-toggle:after{background-color:#8bc34a}
+.page-purple .header .dropdown-toggle:after{background-color:#9c27b0}.page-red .header .dropdown-toggle:after{background-color:#f44336}
+.page-yellow .header .dropdown-toggle:after{background-color:#ffc107}.no-csstransforms .header .dropdown-toggle:after{display:none}
+.header .dropdown.open .dropdown-toggle{background-color:transparent}.header .dropdown.open .dropdown-toggle:after{-webkit-transform:scale(1);
+-ms-transform:scale(1);transform:scale(1)}.no-csstransforms .header .dropdown.open .dropdown-toggle:after{display:block}.header .nav{margin:0}
+.header .nav>li>a .avatar,.header .nav>li>a .breadcrumb>li+li:before,.header .nav>li>a .fa,.header .nav>li>a .icon{-webkit-transition:all .3s 
+cubic-bezier(.4,0,.2,1);transition:all .3s cubic-bezier(.4,0,.2,1);-webkit-transition-property:opacity,-webkit-transform;transition-property:opacity,
+transform}.header .nav>li>a .header-close{position:absolute;top:16px;left:0;text-align:center;width:100%;opacity:0;-webkit-transform:rotate(-225deg);
+-ms-transform:rotate(-225deg);transform:rotate(-225deg)}.header .nav>li>a .header-close:after{background-color:#01798a;border-radius:50%;content:"";
+display:block;height:36px;margin-top:-18px;margin-left:-18px;position:absolute;top:50%;left:50%;width:36px;-webkit-transform:scale(0);-ms-transform:
+scale(0);transform:scale(0);-webkit-transition:all .3s cubic-bezier(.4,0,.2,1);transition:all .3s cubic-bezier(.4,0,.2,1);-webkit-transition-property:
+-webkit-transform;transition-property:transform}.page-alt .header .nav>li>a .header-close:after{background-color:#01798a}
+.page-blue .header .nav>li>a .header-close:after{background-color:#2196f3}.page-green .header .nav>li>a .header-close:after{background-color:#8bc34a}
+.page-purple .header .nav>li>a .header-close:after{background-color:#9c27b0}.page-red .header .nav>li>a .header-close:after{background-color:#f44336}
+.page-yellow .header .nav>li>a .header-close:after{background-color:#ffc107}.header .nav>li>a .header-close:before{position:relative;z-index:1}
+.header .nav>li.active>a .avatar,.header .nav>li.active>a .breadcrumb>li+li:before,.header .nav>li.active>a .fa,.header .nav>li.active>a .icon{opacity
+:0;-webkit-transform:rotate(225deg);-ms-transform:rotate(225deg);transform:rotate(225deg)}.header .nav>li.active>a .header-close{opacity:1;
+-webkit-transform:rotate(0);-ms-transform:rotate(0);transform:rotate(0)}.header .nav>li.active>a .header-close:after{-webkit-transform:scale(1);
+-ms-transform:scale(1);transform:scale(1)}.header-btn{display:block;float:left;height:48px;padding:12px 16px;text-align:center}.header-btn:focus,
+.header-btn:hover{text-decoration:none}.header.fixed .header-fix-hide{display:none!important}.header-fix-show{display:none!important}
+.header.fixed .header-fix-show{display:block!important}.header-logo,.header-text,.nav-drawer-logo{display:block;float:left;font-weight:300;height:48px
+;line-height:24px;margin:0;padding:12px 16px}.header-logo:focus,.header-logo:hover,.header-text:focus,.header-text:hover,.nav-drawer-logo:focus,
+.nav-drawer-logo:hover{text-decoration:none}.header-logo,.nav-drawer-logo{font-size:20px}.header-logo img,.nav-drawer-logo img{display:block;
+max-height:24px;width:auto}.header-nav-scroll{height:48px;overflow:hidden;position:relative}.header-nav-scroll.pull-down{position:absolute;top:100%;
+left:0;width:100%;-webkit-transition:opacity .15s cubic-bezier(.4,0,.2,1) .15s,top .3s cubic-bezier(.4,0,.2,1);transition:opacity .15s 
+cubic-bezier(.4,0,.2,1) .15s,top .3s cubic-bezier(.4,0,.2,1)}.header.fixed .header-nav-scroll.pull-down,.header.open .header-nav-scroll.pull-down,
+.menu-open .header-nav-scroll.pull-down{top:0;z-index:-1;opacity:0;-webkit-transition:opacity .15s cubic-bezier(.4,0,.2,1),top .3s 
+cubic-bezier(.4,0,.2,1);transition:opacity .15s cubic-bezier(.4,0,.2,1),top .3s cubic-bezier(.4,0,.2,1)}.header-nav-wrap{height:150%;overflow-x:auto;
+overflow-y:hidden;padding-bottom:24px;position:absolute;top:0;left:0;white-space:nowrap;width:100%;-webkit-overflow-scrolling:touch;-ms-overflow-style
+:none}.header-nav-wrap .nav>li{display:inline-block;float:none}.menu{position:fixed;top:48px;bottom:0;left:-100%;width:100%;z-index:29;
+-webkit-backface-visibility:hidden;backface-visibility:hidden;-webkit-transition:all .1s cubic-bezier(.4,0,.2,1);transition:all .1s 
+cubic-bezier(.4,0,.2,1);-webkit-transition-property:box-shadow,-webkit-transform;transition-property:box-shadow,transform}.menu.open{left:0;
+-webkit-box-shadow:0 0 10px rgba(0,0,0,.5);box-shadow:0 0 10px rgba(0,0,0,.5);-webkit-transition:all .1s cubic-bezier(.4,0,.2,1);transition:all .1s 
+cubic-bezier(.4,0,.2,1)}@media only screen and (min-width:480px){.menu{left:-320px;width:320px}}.menu.menu-right{right:-100%;left:auto}
+.menu.menu-right.open{right:0}@media only screen and (min-width:480px){.menu.menu-right{right:-320px}.no-touch .menu.menu-right.open~.fbtn-container{
+right:336px}}.menu-backdrop{display:none}.nav-drawer~.menu-backdrop,.touch .menu-backdrop{background-color:#000;display:block;height:0;position:fixed;
+top:0;left:0;width:0;z-index:28;-webkit-backface-visibility:hidden;backface-visibility:hidden;opacity:0;-webkit-transition:height 0s .3s,opacity .3s 
+cubic-bezier(.4,0,.2,1),width 0s .3s,z-index 0s .3s;transition:height 0s .3s,opacity .3s cubic-bezier(.4,0,.2,1),width 0s .3s,z-index 0s .3s}
+.nav-drawer.open~.menu-backdrop,.touch .menu.open~.menu-backdrop{height:100%;width:100%;opacity:.5;-webkit-transition:opacity .3s 
+cubic-bezier(.4,0,.2,1);transition:opacity .3s cubic-bezier(.4,0,.2,1)}.nav-drawer.open~.menu-backdrop{z-index:30}
+@media only screen and (min-width:1440px){.nav-drawer.open~.menu-backdrop{height:0;width:0;opacity:0;-webkit-transition:none;transition:none}}
+.menu-collapse-toggle{background-color:transparent!important;cursor:pointer;display:block;float:right;padding:4px 8px;position:absolute;top:0;right:0;
+z-index:1}.menu-collapse-toggle:hover{color:#2196f3!important}.nav .menu-toggle{padding-top:12px}.header .menu-toggle{padding-top:4.8px}
+.header .menu-toggle-sidebar{padding-top:12px}.menu-collapse-toggle-close{position:absolute;top:6px;left:0;text-align:center;width:100%;opacity:1;
+-webkit-transform:rotate(0);-ms-transform:rotate(0);transform:rotate(0);-webkit-transition:all .3s cubic-bezier(.4,0,.2,1);transition:all .3s 
+cubic-bezier(.4,0,.2,1);-webkit-transition-property:opacity,-webkit-transform;transition-property:opacity,transform}
+.menu-collapse-toggle.collapsed .menu-collapse-toggle-close{opacity:0;-webkit-transform:rotate(-225deg);-ms-transform:rotate(-225deg);transform:
+rotate(-225deg)}.menu-collapse-toggle-default{opacity:0;-webkit-transform:rotate(225deg);-ms-transform:rotate(225deg);transform:rotate(225deg);
+-webkit-transition:all .3s cubic-bezier(.4,0,.2,1);transition:all .3s cubic-bezier(.4,0,.2,1);-webkit-transition-property:opacity,-webkit-transform;
+transition-property:opacity,transform}.menu-collapse-toggle.collapsed .menu-collapse-toggle-default{opacity:1;-webkit-transform:rotate(0);
+-ms-transform:rotate(0);transform:rotate(0)}.menu-content{padding-top:12px;padding-bottom:12px}.menu-content hr{border-top-color:#e0e0e0;margin-top:
+12px;margin-bottom:12px}.menu-content .nav{margin-top:0;margin-bottom:0}.menu-content .nav .a,.menu-content .nav a{color:#616161;font-weight:600;
+overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.menu-content .nav .a:focus,.menu-content .nav .a:hover,.menu-content .nav a:focus,
+.menu-content .nav a:hover{background-color:#f5f5f5}.menu-content .nav .a .breadcrumb>li+li:before,.menu-content .nav .a .fa,
+.menu-content .nav .a .icon,.menu-content .nav a .breadcrumb>li+li:before,.menu-content .nav a .fa,.menu-content .nav a .icon{margin-right:16px}
+.menu-content .nav li.active>.a,.menu-content .nav li.active>a{color:#01798a}.page-blue .menu-content .nav li.active>.a,
+.page-blue .menu-content .nav li.active>a{color:#2196f3}.page-green .menu-content .nav li.active>.a,.page-green .menu-content .nav li.active>a{color:
+#8bc34a}.page-purple .menu-content .nav li.active>.a,.page-purple .menu-content .nav li.active>a{color:#9c27b0}
+.page-red .menu-content .nav li.active>.a,.page-red .menu-content .nav li.active>a{color:#f44336}.page-yellow .menu-content .nav li.active>.a,
+.page-yellow .menu-content .nav li.active>a{color:#ffc107}.menu-content .nav ul .a,.menu-content .nav ul a{font-weight:400;padding-left:8px}
+.menu-content .nav ul ul .a,.menu-content .nav ul ul a{font-size:90%;font-weight:300;padding-top:6px;padding-bottom:6px;padding-left:48px}
+@media only screen and (min-width:480px){.menu-content{width:320px}}.no-boxshadow .menu-content .nav{margin-right:1px}
+.no-boxshadow .menu.menu-right .menu-content .nav{margin-right:0;margin-left:1px}.menu-content-inner{padding-right:16px;padding-left:16px}
+.touch .menu-open{overflow:hidden}.menu-scroll{background-color:#fff;height:100%;overflow:hidden;position:absolute;top:0;left:0;width:100%;z-index:1}
+.no-boxshadow .menu-scroll:after{background-color:#e0e0e0;content:"";display:block;height:100%;position:absolute;top:0;right:0;width:1px}
+.no-boxshadow .menu.menu-right .menu-scroll:after{right:auto;left:0}.menu-top{background-color:#00363e;color:#f5f5f5;position:relative;z-index:1}
+.menu-top a{color:#f5f5f5;text-decoration:none}.menu-top a:focus,.menu-top a:hover{color:#fff}@media only screen and (min-width:480px){.menu-top{width
+:320px}}.page-alt .menu-top{background-color:#00363e}.page-blue .menu-top{background-color:#1976d2}.page-green .menu-top{background-color:#689f38}
+.page-purple .menu-top{background-color:#7b1fa2}.page-red .menu-top{background-color:#d32f2f}.page-yellow .menu-top{background-color:#ffa000}
+.menu-top-form{margin-top:6px;margin-bottom:6px}.menu-top-img{display:-webkit-box;display:-moz-box;display:-ms-flexbox;display:-webkit-flex;display:
+flex;height:100%;justify-content:center;overflow:hidden;position:absolute;top:0;left:0;width:100%;-webkit-align-items:center;align-items:center}
+.menu-top-img img{min-height:100%;width:100%;opacity:.5}.menu-top-info{padding:36px 16px;position:relative}.menu-top-user{display:-webkit-box;display:
+-moz-box;display:-ms-flexbox;display:-webkit-flex;display:flex;-webkit-align-items:center;align-items:center}.menu-top-user:after,
+.menu-top-user:before{content:"";display:table;line-height:0}.menu-top-user:after{clear:both}.menu-wrap{overflow-x:hidden;overflow-y:auto;position:
+absolute;top:0;right:0;bottom:0;left:0;-webkit-overflow-scrolling:touch;-ms-overflow-style:none}@media only screen and (min-width:480px){.menu-wrap{
+padding-right:32px;right:-32px}}.nav-drawer{max-width:85%;max-width:calc(100% - 64px);top:0;left:-320px;width:320px;z-index:31}
+.nav-drawer .menu-content{padding-top:0}@media only screen and (min-width:1440px){.nav-drawer{left:0;width:240px;-webkit-box-shadow:0 0 10px 
+rgba(0,0,0,.5);box-shadow:0 0 10px rgba(0,0,0,.5)}.nav-drawer .menu-content,.nav-drawer .menu-top{width:240px}.nav-drawer.menu-left~.content{
+margin-left:240px}.nav-drawer.menu-left~.content .content-heading,.nav-drawer.menu-left~.content .content-inner{padding-left:16px}
+.nav-drawer.menu-left~.footer,.nav-drawer.menu-left~.header{padding-left:16px;left:240px}.nav-drawer.menu-right{right:0}
+.nav-drawer.menu-right~.content{margin-right:240px}.nav-drawer.menu-right~.content .content-heading,.nav-drawer.menu-right~.content .content-inner{
+padding-right:16px}.nav-drawer.menu-right~.footer,.nav-drawer.menu-right~.header{padding-right:16px;right:240px}}.nav-drawer-logo{border-bottom:1px 
+solid #e0e0e0;color:#212121;float:none;margin-bottom:12px}.nav-drawer-logo:focus,.nav-drawer-logo:hover{text-decoration:none}.nav-drawer-open{overflow
+:hidden}@media only screen and (min-width:1440px){.nav-drawer-open{overflow:auto}}.doc-editor LABEL{padding:2px 5px}.doc-editor INPUT{margin:2px 5px}
+.doc-editor .list-group{margin-right:5px}.doc-editor .property{padding:3px 5px}.doc-editor .property-item{min-width:100px;font-weight:bolder}
+.doc-editor .btn{margin-left:15px}.doc-editor textarea{word-break:break-all;padding:0}.panel-footer,.panel-heading{padding:8px;color:#fff;
+background-color:#01798a}.doc-editor .list-group{margin-left:20px}.panel-error{color:red}.panel{border:#01798a 1px solid}.content TEXTAREA{min-height:
+200px;box-sizing:border-box;max-height:800px}div.oembedall-githubrepos{border:1px solid #ddd;border-radius:4px 4px 4px 4px;list-style-type:none;margin
+:0 0 10px;padding:8px 10px 0;font:13.34px/1.4 helvetica,arial,freesans,clean,sans-serif;width:452px;background-color:#fff}
+div.oembedall-githubrepos .oembedall-body{background:-moz-linear-gradient(center top,#fafafa,#efefef) repeat scroll 0 0 transparent;background:
+-webkit-gradient(linear,left top,left bottom,from(#fafafa),to(#efefef));border-bottom-left-radius:4px;border-bottom-right-radius:4px;border-top:1px 
+solid #eee;margin-left:-10px;margin-top:8px;padding:5px 10px;width:100%}div.oembedall-githubrepos h3{font-size:14px;margin:0;padding-left:18px;
+white-space:nowrap}div.oembedall-githubrepos p.oembedall-description{color:#444;font-size:12px;margin:0 0 3px}
+div.oembedall-githubrepos p.oembedall-updated-at{color:#888;font-size:11px;margin:0}div.oembedall-githubrepos ul.oembedall-repo-stats{border:medium 
+none;float:right;font-size:11px;font-weight:700;padding-left:15px;position:relative;z-index:5;margin:0}
+div.oembedall-githubrepos ul.oembedall-repo-stats li{border:medium none;color:#666;display:inline-block;list-style-type:none;margin:0!important}
+div.oembedall-githubrepos ul.oembedall-repo-stats li a{background-color:transparent;background-position:5px -2px;border:medium none;color:
+#666!important;background-position:5px -2px;background-repeat:no-repeat;border-left:1px solid #ddd;display:inline-block;height:21px;line-height:21px;
+padding:0 5px 0 23px}div.oembedall-githubrepos ul.oembedall-repo-stats li:first-child a{border-left:medium none;margin-right:-3px}
+div.oembedall-githubrepos ul.oembedall-repo-stats li a:hover{background:none no-repeat scroll 5px -27px #4183c4;color:#fff!important;text-decoration:
+none}div.oembedall-githubrepos ul.oembedall-repo-stats li:first-child a:hover{border-bottom-left-radius:3px;border-top-left-radius:3px}
+ul.oembedall-repo-stats li:last-child a:hover{border-bottom-right-radius:3px;border-top-right-radius:3px}span.oembedall-closehide{background-color:
+#aaa;border-radius:2px;cursor:pointer;margin-right:3px}div.oembedall-container{margin-top:5px;text-align:left}.oembedall-ljuser{font-weight:700}
+.oembedall-ljuser img{vertical-align:bottom;border:0;padding-right:1px}.oembedall-stoqembed{border-bottom:1px dotted #999;float:left;overflow:hidden;
+padding:11px 0;width:730px;line-height:1;background:none repeat scroll 0 0 #fff;color:#000;font-family:Arial,Liberation Sans,DejaVu Sans,sans-serif;
+font-size:80%;text-align:left;margin:0;padding:0}.oembedall-stoqembed a{color:#07c;text-decoration:none;margin:0;padding:0}
+.oembedall-stoqembed a:hover{text-decoration:underline}.oembedall-stoqembed a:visited{color:#4a6b82}.oembedall-stoqembed h3{font-family:Trebuchet MS,
+Liberation Sans,DejaVu Sans,sans-serif;font-size:130%;font-weight:700;margin:0;padding:0}.oembedall-stoqembed .oembedall-reputation-score{color:#444;
+font-size:120%;font-weight:700;margin-right:2px}.oembedall-stoqembed .oembedall-user-info{height:35px;width:185px}
+.oembedall-stoqembed .oembedall-user-info .oembedall-user-gravatar32{float:left;height:32px;width:32px}
+.oembedall-stoqembed .oembedall-user-info .oembedall-user-details{float:left;margin-left:5px;overflow:hidden;white-space:nowrap;width:145px}
+.oembedall-stoqembed .oembedall-question-hyperlink{font-weight:700}.oembedall-stoqembed .oembedall-stats{background:none repeat scroll 0 0 #eee;margin
+:0 0 0 7px;padding:4px 7px 6px;width:58px}.oembedall-stoqembed .oembedall-statscontainer{float:left;margin-right:8px;width:86px}
+.oembedall-stoqembed .oembedall-votes{color:#555;padding:0 0 7px;text-align:center}.oembedall-stoqembed .oembedall-vote-count-post{display:block;
+font-size:240%;color:#808185;display:block;font-weight:700}.oembedall-stoqembed .oembedall-views{color:#999;padding-top:4px;text-align:center}
+.oembedall-stoqembed .oembedall-status{margin-top:-3px;padding:4px 0;text-align:center;background:none repeat scroll 0 0 #75845c;color:#fff}
+.oembedall-stoqembed .oembedall-status strong{color:#fff;display:block;font-size:140%}.oembedall-stoqembed .oembedall-summary{float:left;width:635px}
+.oembedall-stoqembed .oembedall-excerpt{line-height:1.2;margin:0;padding:0 0 5px}.oembedall-stoqembed .oembedall-tags{float:left;line-height:18px}
+.oembedall-stoqembed .oembedall-tags a:hover{text-decoration:none}.oembedall-stoqembed .oembedall-post-tag{background-color:#e0eaf1;border-bottom:1px 
+solid #3e6d8e;border-right:1px solid #7f9fb6;color:#3e6d8e;font-size:90%;line-height:2.4;margin:2px 2px 2px 0;padding:3px 4px;text-decoration:none;
+white-space:nowrap}.oembedall-stoqembed .oembedall-post-tag:hover{background-color:#3e6d8e;border-bottom:1px solid #37607d;border-right:1px solid 
+#37607d;color:#e0eaf1}.oembedall-stoqembed .oembedall-fr{float:right}.oembedall-stoqembed .oembedall-statsarrow{background-image:
+url(http://cdn.sstatic.net/stackoverflow/img/sprites.png?v=3);background-repeat:no-repeat;overflow:hidden;background-position:0 -435px;float:right;
+height:13px;margin-top:12px;width:7px}.oembedall-facebook1{border:#1a3c6c solid 1px;padding:0;font:13.34px/1.4 verdana;width:500px}
+.oembedall-facebook2{background-color:#627add}.oembedall-facebook2 a{color:#e8e8e8;text-decoration:none}.oembedall-facebookBody{background-color:#fff;
+vertical-align:top;padding:5px}.oembedall-facebookBody .contents{display:inline-block;width:100%}.oembedall-facebookBody div img{float:left;
+margin-right:5px}div.oembedall-lanyard{-webkit-box-shadow:none;-webkit-transition-delay:0s;-webkit-transition-duration:.4000000059604645s;
+-webkit-transition-property:width;-webkit-transition-timing-function:cubic-bezier(.42,0,.58,1);background-attachment:scroll;background-clip:border-box
+;background-color:transparent;background-image:none;background-origin:padding-box;border-bottom-width:0;border-left-width:0;border-right-width:0;
+border-top-width:0;box-shadow:none;color:#112644;display:block;float:left;font-family:'Trebuchet MS',Trebuchet,sans-serif;font-size:16px;height:253px;
+line-height:19px;margin-bottom:0;margin-left:0;margin-right:0;margin-top:0;max-width:none;min-height:0;outline-color:#112644;outline-style:none;
+outline-width:0;overflow-x:visible;overflow-y:visible;padding-bottom:0;padding-left:0;padding-right:0;padding-top:0;position:relative;text-align:left;
+vertical-align:baseline;width:804px}div.oembedall-lanyard .tagline{font-size:1.5em}div.oembedall-lanyard .wrapper{overflow:hidden;clear:both}
+div.oembedall-lanyard .split{float:left;display:inline}div.oembedall-lanyard .prominent-place .flag:active,
+div.oembedall-lanyard .prominent-place .flag:focus,div.oembedall-lanyard .prominent-place .flag:hover,
+div.oembedall-lanyard .prominent-place .flag:link,div.oembedall-lanyard .prominent-place .flag:visited{float:left;display:block;width:48px;height:48px
+;position:relative;top:-5px;margin-right:10px}div.oembedall-lanyard .place-context{font-size:.889em}div.oembedall-lanyard .prominent-place .sub-place{
+display:block}div.oembedall-lanyard .prominent-place{font-size:1.125em;line-height:1.1em;font-weight:400}div.oembedall-lanyard .main-date{color:
+#8cb4e0;font-weight:700;line-height:1.1}div.oembedall-lanyard .first{margin-left:0;width:48.57%;margin:0 0 0 2.857%}

--- a/builders/html/assets/css/base.css
+++ b/builders/html/assets/css/base.css
@@ -5867,9 +5867,11 @@ pre {
   line-height: 20px;
   margin: 12px 0;
   padding: 6px 8px;
-  word-break: break-all;
+  overflow-x: auto;
+  /* word-break: break-all;*/
   word-wrap: break-word;
-  white-space: pre-wrap;
+  white-space: pre;
+  
 }
 pre code {
   background-color: transparent;
@@ -11346,6 +11348,10 @@ input[type="checkbox"]:checked + .switch-toggle:after, input[type="radio"]:check
 .twitter-typeahead .tt-menu .tt-cursor {
   background-color: #bbdefb;
 }
+
+.twitter-typeahead .tt-menu.tt-open {
+    cursor: pointer
+  }
 
 .content {
   padding-bottom: 24px;

--- a/builders/html/assets/css/base.min.css
+++ b/builders/html/assets/css/base.min.css
@@ -435,9 +435,9 @@ background-image:-webkit-radial-gradient(rgba(255,193,7,.1) 0,#ffc107 100%);back
 monospace}code{background-color:#f5f5f5;border:1px solid #e0e0e0;border-radius:4px;color:#b71c1c;font-size:75%;line-height:1;padding:2px 4px}kbd{
 background-color:#212121;border-radius:4px;color:#fff;font-size:75%;padding:2px 4px}kbd kbd{font-size:100%;font-weight:700;padding:0}pre{
 background-color:#f5f5f5;border:1px solid #e0e0e0;border-radius:2px;color:#212121;display:block;font-size:12px;line-height:20px;margin:12px 0;padding:
-6px 8px;word-break:break-all;word-wrap:break-word;white-space:pre-wrap}pre code{background-color:transparent;border-radius:0;color:inherit;font-size:
-inherit;padding:0}.col-lg-1,.col-lg-10,.col-lg-11,.col-lg-12,.col-lg-2,.col-lg-3,.col-lg-4,.col-lg-5,.col-lg-6,.col-lg-7,.col-lg-8,.col-lg-9,.col-md-1
-,.col-md-10,.col-md-11,.col-md-12,.col-md-2,.col-md-3,.col-md-4,.col-md-5,.col-md-6,.col-md-7,.col-md-8,.col-md-9,.col-sm-1,.col-sm-10,.col-sm-11,
+6px 8px;overflow-x:auto;word-wrap:break-word;white-space:pre}pre code{background-color:transparent;border-radius:0;color:inherit;font-size:inherit;
+padding:0}.col-lg-1,.col-lg-10,.col-lg-11,.col-lg-12,.col-lg-2,.col-lg-3,.col-lg-4,.col-lg-5,.col-lg-6,.col-lg-7,.col-lg-8,.col-lg-9,.col-md-1,
+.col-md-10,.col-md-11,.col-md-12,.col-md-2,.col-md-3,.col-md-4,.col-md-5,.col-md-6,.col-md-7,.col-md-8,.col-md-9,.col-sm-1,.col-sm-10,.col-sm-11,
 .col-sm-12,.col-sm-2,.col-sm-3,.col-sm-4,.col-sm-5,.col-sm-6,.col-sm-7,.col-sm-8,.col-sm-9,.col-xs-1,.col-xs-10,.col-xs-11,.col-xs-12,.col-xs-2,
 .col-xs-3,.col-xs-4,.col-xs-5,.col-xs-6,.col-xs-7,.col-xs-8,.col-xs-9,.col-xx-1,.col-xx-10,.col-xx-11,.col-xx-12,.col-xx-2,.col-xx-3,.col-xx-4,
 .col-xx-5,.col-xx-6,.col-xx-7,.col-xx-8,.col-xx-9{min-height:1px;position:relative;padding-left:16px;padding-right:16px}.col-xx-1,.col-xx-10,
@@ -1081,38 +1081,39 @@ line-height:0}.toast-inner:after{clear:both}.toast-show .toast-inner{-webkit-tra
 translate3d(0,0,0)}@media only screen and (min-width:768px){.toast-inner{border-radius:2px;float:left}}.no-csstransforms3d .toast-inner{opacity:0}
 .no-csstransforms3d .toast-show .toast-inner{opacity:1}.toast-text{overflow:hidden}[data-dismiss=toast]{cursor:pointer;float:right;font-weight:700;
 margin-left:16px;text-transform:uppercase}.twitter-typeahead{display:block!important}.twitter-typeahead .tt-menu{margin-top:24px;width:100%}
-.twitter-typeahead .tt-menu .tt-suggestion{padding:3px}.twitter-typeahead .tt-menu .tt-cursor{background-color:#bbdefb}.content{padding-bottom:24px}
-.searching .content{display:none}.content-fix-scroll{margin-right:-16px;margin-left:-16px;overflow:hidden;padding-right:16px;padding-left:16px}
-.content-fix.fixed .content-fix-scroll{position:fixed;top:48px;bottom:0;-webkit-backface-visibility:hidden;backface-visibility:hidden}
-.content-fix.fixed .content-fix-wrap{overflow-x:hidden;overflow-y:auto;padding-right:32px;padding-left:32px;position:absolute;top:0;right:-16px;bottom
-:0;left:-16px;-webkit-overflow-scrolling:touch;-ms-overflow-style:none}.content-heading{background-color:#01798a;color:#fff;overflow:hidden;
-padding-top:36px;position:relative;z-index:1;-webkit-transition:background-color .3s cubic-bezier(.4,0,.2,1),color .3s cubic-bezier(.4,0,.2,1);
-transition:background-color .3s cubic-bezier(.4,0,.2,1),color .3s cubic-bezier(.4,0,.2,1)}.page-alt .content-heading{background-color:#01798a}
-.page-blue .content-heading{background-color:#2196f3}.page-green .content-heading{background-color:#8bc34a}.page-purple .content-heading{
-background-color:#9c27b0}.page-red .content-heading{background-color:#f44336}.page-yellow .content-heading{background-color:#ffc107}
-.content-heading .heading{font-weight:300}h2,h3,h4,h5,h6{color:#01798a}.body h2:first-of-type{margin-top:0}.row-fix{position:relative}.argument,
-.attribute{font-weight:600;color:#01798a}fieldset#-lucee-debug{padding-left:300px}a.missing-link{text-decoration:underline red}.tile-toolbar{
-text-align:right}.arguments TH,.attributes TH{font-weight:400}.footer{background-color:#fafafa;border-top:1px solid #e0e0e0;color:#9e9e9e;text-align:
-center;position:absolute;bottom:0;right:0;left:0}.footer a{color:#9e9e9e}.footer a:focus,.footer a:hover{color:#212121}.header{background-color:
-#01798a;color:#fff;position:fixed;top:0;right:0;left:0;z-index:30;-webkit-backface-visibility:hidden;backface-visibility:hidden;-webkit-transition:
-background-color .3s cubic-bezier(.4,0,.2,1),box-shadow .15s linear;transition:background-color .3s cubic-bezier(.4,0,.2,1),box-shadow .15s linear}
-.header:after,.header:before{content:"";display:table;line-height:0}.header:after{clear:both}.header.fixed,.header.open,.menu-open .header{
-background-color:#00363e;-webkit-box-shadow:0 1px 10px rgba(0,0,0,.5);box-shadow:0 1px 10px rgba(0,0,0,.5)}.page-alt .header{background-color:#01798a}
-.page-alt .header.fixed,.page-alt .header.open{background-color:#00363e}.menu-open.page-alt .header{background-color:#00363e}.page-blue .header{
-background-color:#2196f3}.page-blue .header.fixed,.page-blue .header.open{background-color:#1976d2}.menu-open.page-blue .header{background-color:
-#1976d2}.page-green .header{background-color:#8bc34a}.page-green .header.fixed,.page-green .header.open{background-color:#689f38}
-.menu-open.page-green .header{background-color:#689f38}.page-purple .header{background-color:#9c27b0}.page-purple .header.fixed,
-.page-purple .header.open{background-color:#7b1fa2}.menu-open.page-purple .header{background-color:#7b1fa2}.page-red .header{background-color:#f44336}
-.page-red .header.fixed,.page-red .header.open{background-color:#d32f2f}.menu-open.page-red .header{background-color:#d32f2f}.page-yellow .header{
-background-color:#ffc107}.page-yellow .header.fixed,.page-yellow .header.open{background-color:#ffa000}.menu-open.page-yellow .header{background-color
-:#ffa000}.header a{color:#fff}.header .breadcrumb{color:#fff;margin-top:0;margin-bottom:0;max-height:48px;overflow:hidden;padding-right:16px;
-padding-left:16px}.header .breadcrumb .a,.header .breadcrumb a{text-decoration:none}.header .breadcrumb>.active{color:#fff;font-weight:300}
-.header .breadcrumb>.active>.a,.header .breadcrumb>.active>a{color:#fff}@media only screen and (max-width:767px){.header .breadcrumb>li{display:none}
-.header .breadcrumb>.active{display:block}.header .breadcrumb>.active:before{display:none}}.header .dropdown-menu{border-radius:2px}
-.header .dropdown-menu a{color:#212121}.header .dropdown-toggle{z-index:1}.header .dropdown-toggle:after{background-color:#01798a;border-radius:50%;
-content:"";display:block;height:36px;position:absolute;top:6px;right:6px;bottom:6px;left:6px;z-index:-1;-webkit-transform:scale(0);-ms-transform:
-scale(0);transform:scale(0);-webkit-transition:all .3s cubic-bezier(.4,0,.2,1);transition:all .3s cubic-bezier(.4,0,.2,1);-webkit-transition-property:
-background-color,-webkit-transform;transition-property:background-color,transform}.page-alt .header .dropdown-toggle:after{background-color:#01798a}
+.twitter-typeahead .tt-menu .tt-suggestion{padding:3px}.twitter-typeahead .tt-menu .tt-cursor{background-color:#bbdefb}
+.twitter-typeahead .tt-menu.tt-open{cursor:pointer}.content{padding-bottom:24px}.searching .content{display:none}.content-fix-scroll{margin-right:
+-16px;margin-left:-16px;overflow:hidden;padding-right:16px;padding-left:16px}.content-fix.fixed .content-fix-scroll{position:fixed;top:48px;bottom:0;
+-webkit-backface-visibility:hidden;backface-visibility:hidden}.content-fix.fixed .content-fix-wrap{overflow-x:hidden;overflow-y:auto;padding-right:
+32px;padding-left:32px;position:absolute;top:0;right:-16px;bottom:0;left:-16px;-webkit-overflow-scrolling:touch;-ms-overflow-style:none}
+.content-heading{background-color:#01798a;color:#fff;overflow:hidden;padding-top:36px;position:relative;z-index:1;-webkit-transition:background-color 
+.3s cubic-bezier(.4,0,.2,1),color .3s cubic-bezier(.4,0,.2,1);transition:background-color .3s cubic-bezier(.4,0,.2,1),color .3s 
+cubic-bezier(.4,0,.2,1)}.page-alt .content-heading{background-color:#01798a}.page-blue .content-heading{background-color:#2196f3}
+.page-green .content-heading{background-color:#8bc34a}.page-purple .content-heading{background-color:#9c27b0}.page-red .content-heading{
+background-color:#f44336}.page-yellow .content-heading{background-color:#ffc107}.content-heading .heading{font-weight:300}h2,h3,h4,h5,h6{color:#01798a
+}.body h2:first-of-type{margin-top:0}.row-fix{position:relative}.argument,.attribute{font-weight:600;color:#01798a}fieldset#-lucee-debug{padding-left:
+300px}a.missing-link{text-decoration:underline red}.tile-toolbar{text-align:right}.arguments TH,.attributes TH{font-weight:400}.footer{
+background-color:#fafafa;border-top:1px solid #e0e0e0;color:#9e9e9e;text-align:center;position:absolute;bottom:0;right:0;left:0}.footer a{color:
+#9e9e9e}.footer a:focus,.footer a:hover{color:#212121}.header{background-color:#01798a;color:#fff;position:fixed;top:0;right:0;left:0;z-index:30;
+-webkit-backface-visibility:hidden;backface-visibility:hidden;-webkit-transition:background-color .3s cubic-bezier(.4,0,.2,1),box-shadow .15s linear;
+transition:background-color .3s cubic-bezier(.4,0,.2,1),box-shadow .15s linear}.header:after,.header:before{content:"";display:table;line-height:0}
+.header:after{clear:both}.header.fixed,.header.open,.menu-open .header{background-color:#00363e;-webkit-box-shadow:0 1px 10px rgba(0,0,0,.5);
+box-shadow:0 1px 10px rgba(0,0,0,.5)}.page-alt .header{background-color:#01798a}.page-alt .header.fixed,.page-alt .header.open{background-color:
+#00363e}.menu-open.page-alt .header{background-color:#00363e}.page-blue .header{background-color:#2196f3}.page-blue .header.fixed,
+.page-blue .header.open{background-color:#1976d2}.menu-open.page-blue .header{background-color:#1976d2}.page-green .header{background-color:#8bc34a}
+.page-green .header.fixed,.page-green .header.open{background-color:#689f38}.menu-open.page-green .header{background-color:#689f38}
+.page-purple .header{background-color:#9c27b0}.page-purple .header.fixed,.page-purple .header.open{background-color:#7b1fa2}
+.menu-open.page-purple .header{background-color:#7b1fa2}.page-red .header{background-color:#f44336}.page-red .header.fixed,.page-red .header.open{
+background-color:#d32f2f}.menu-open.page-red .header{background-color:#d32f2f}.page-yellow .header{background-color:#ffc107}.page-yellow .header.fixed
+,.page-yellow .header.open{background-color:#ffa000}.menu-open.page-yellow .header{background-color:#ffa000}.header a{color:#fff}.header .breadcrumb{
+color:#fff;margin-top:0;margin-bottom:0;max-height:48px;overflow:hidden;padding-right:16px;padding-left:16px}.header .breadcrumb .a,
+.header .breadcrumb a{text-decoration:none}.header .breadcrumb>.active{color:#fff;font-weight:300}.header .breadcrumb>.active>.a,
+.header .breadcrumb>.active>a{color:#fff}@media only screen and (max-width:767px){.header .breadcrumb>li{display:none}.header .breadcrumb>.active{
+display:block}.header .breadcrumb>.active:before{display:none}}.header .dropdown-menu{border-radius:2px}.header .dropdown-menu a{color:#212121}
+.header .dropdown-toggle{z-index:1}.header .dropdown-toggle:after{background-color:#01798a;border-radius:50%;content:"";display:block;height:36px;
+position:absolute;top:6px;right:6px;bottom:6px;left:6px;z-index:-1;-webkit-transform:scale(0);-ms-transform:scale(0);transform:scale(0);
+-webkit-transition:all .3s cubic-bezier(.4,0,.2,1);transition:all .3s cubic-bezier(.4,0,.2,1);-webkit-transition-property:background-color,
+-webkit-transform;transition-property:background-color,transform}.page-alt .header .dropdown-toggle:after{background-color:#01798a}
 .page-blue .header .dropdown-toggle:after{background-color:#2196f3}.page-green .header .dropdown-toggle:after{background-color:#8bc34a}
 .page-purple .header .dropdown-toggle:after{background-color:#9c27b0}.page-red .header .dropdown-toggle:after{background-color:#f44336}
 .page-yellow .header .dropdown-toggle:after{background-color:#ffc107}.no-csstransforms .header .dropdown-toggle:after{display:none}

--- a/builders/html/assets/js/dist/base.35.min.js
+++ b/builders/html/assets/js/dist/base.35.min.js
@@ -1,0 +1,1958 @@
+function AnchorJS(e){"use strict";this.options=e||{},this._applyRemainingDefaultOptions=function(e){this.options.icon=this.options.hasOwnProperty(
+"icon")?e.icon:"&#xe9cb",this.options.visible=this.options.hasOwnProperty("visible")?e.visible:"hover",
+this.options.placement=this.options.hasOwnProperty("placement")?e.placement:"right",this.options.class=this.options.hasOwnProperty("class")?e.class:""
+},this._applyRemainingDefaultOptions(e),this.add=function(e){var t,n,i,o,r,a,s,l,c,u,d,h,p;if(this._applyRemainingDefaultOptions(this.options),e){if(
+"string"!=typeof e)throw new Error("The selector provided to AnchorJS was invalid.")}else e="h1, h2, h3, h4, h5, h6";if(0===(
+t=document.querySelectorAll(e)).length)return!1;for(this._addBaselineStyles(),n=document.querySelectorAll("[id]"),i=[].map.call(n,function(e){
+return e.id}),r=0;r<t.length;r++){if(t[r].hasAttribute("id"))o=t[r].getAttribute("id");else{for(c=a=t[r].textContent.replace(/[^\w\s-]/gi,"").replace(
+/\s+/g,"-").replace(/-{2,}/g,"-").substring(0,64).replace(/^-+|-+$/gm,"").toLowerCase(),l=0;void 0!==s&&(c=a+"-"+l),l+=1,-1!==(s=i.indexOf(c)););
+s=void 0,i.push(c),t[r].setAttribute("id",c),o=c}u=o.replace(/-/g," "),
+d='<a class="anchorjs-link '+this.options.class+'" href="#'+o+'" aria-label="Anchor link for: '+u+'" data-anchorjs-icon="'+this.options.icon+'"></a>',
+(h=document.createElement("div")).innerHTML=d,p=h.childNodes,"always"===this.options.visible&&(p[0].style.opacity="1"),
+"&#xe9cb"===this.options.icon&&(p[0].style.fontFamily="anchorjs-icons",p[0].style.fontStyle="normal",p[0].style.fontVariant="normal",
+p[0].style.fontWeight="normal"),"left"===this.options.placement?(p[0].style.position="absolute",p[0].style.marginLeft="-1em",
+p[0].style.paddingRight="0.5em",t[r].insertBefore(p[0],t[r].firstChild)):(p[0].style.paddingLeft="0.375em",t[r].appendChild(p[0]))}return this},
+this.remove=function(e){for(var t,n=document.querySelectorAll(e),i=0;i<n.length;i++)(t=n[i].querySelector(".anchorjs-link"))&&n[i].removeChild(t)
+;return this},this._addBaselineStyles=function(){if(null===document.head.querySelector("style.anchorjs")){var e,t=document.createElement("style")
+;t.className="anchorjs",t.appendChild(document.createTextNode("")),void 0===(e=document.head.querySelector('[rel="stylesheet"], style')
+)?document.head.appendChild(t):document.head.insertBefore(t,e),t.sheet.insertRule(
+" .anchorjs-link {   opacity: 0;   text-decoration: none;   -webkit-font-smoothing: antialiased;   -moz-osx-font-smoothing: grayscale; }",
+t.sheet.cssRules.length),t.sheet.insertRule(" *:hover > .anchorjs-link, .anchorjs-link:focus  {   opacity: 1; }",t.sheet.cssRules.length),
+t.sheet.insertRule(" [data-anchorjs-icon]::after {   content: attr(data-anchorjs-icon); }",t.sheet.cssRules.length),t.sheet.insertRule(
+' @font-face {   font-family: "anchorjs-icons";   font-style: normal;   font-weight: normal;   src: url(data:application/x-font-ttf;charset=utf-8;base64,AAEAAAALAIAAAwAwT1MvMg8SBTUAAAC8AAAAYGNtYXAWi9QdAAABHAAAAFRnYXNwAAAAEAAAAXAAAAAIZ2x5Zgq29TcAAAF4AAABNGhlYWQEZM3pAAACrAAAADZoaGVhBhUDxgAAAuQAAAAkaG10eASAADEAAAMIAAAAFGxvY2EAKACuAAADHAAAAAxtYXhwAAgAVwAAAygAAAAgbmFtZQ5yJ3cAAANIAAAB2nBvc3QAAwAAAAAFJAAAACAAAwJAAZAABQAAApkCzAAAAI8CmQLMAAAB6wAzAQkAAAAAAAAAAAAAAAAAAAABEAAAAAAAAAAAAAAAAAAAAABAAADpywPA/8AAQAPAAEAAAAABAAAAAAAAAAAAAAAgAAAAAAADAAAAAwAAABwAAQADAAAAHAADAAEAAAAcAAQAOAAAAAoACAACAAIAAQAg6cv//f//AAAAAAAg6cv//f//AAH/4xY5AAMAAQAAAAAAAAAAAAAAAQAB//8ADwABAAAAAAAAAAAAAgAANzkBAAAAAAEAAAAAAAAAAAACAAA3OQEAAAAAAQAAAAAAAAAAAAIAADc5AQAAAAACADEARAJTAsAAKwBUAAABIiYnJjQ/AT4BMzIWFxYUDwEGIicmND8BNjQnLgEjIgYPAQYUFxYUBw4BIwciJicmND8BNjIXFhQPAQYUFx4BMzI2PwE2NCcmNDc2MhcWFA8BDgEjARQGDAUtLXoWOR8fORYtLTgKGwoKCjgaGg0gEhIgDXoaGgkJBQwHdR85Fi0tOAobCgoKOBoaDSASEiANehoaCQkKGwotLXoWOR8BMwUFLYEuehYXFxYugC44CQkKGwo4GkoaDQ0NDXoaShoKGwoFBe8XFi6ALjgJCQobCjgaShoNDQ0NehpKGgobCgoKLYEuehYXAAEAAAABAACiToc1Xw889QALBAAAAAAA0XnFFgAAAADRecUWAAAAAAJTAsAAAAAIAAIAAAAAAAAAAQAAA8D/wAAABAAAAAAAAlMAAQAAAAAAAAAAAAAAAAAAAAUAAAAAAAAAAAAAAAACAAAAAoAAMQAAAAAACgAUAB4AmgABAAAABQBVAAIAAAAAAAIAAAAAAAAAAAAAAAAAAAAAAAAADgCuAAEAAAAAAAEADgAAAAEAAAAAAAIABwCfAAEAAAAAAAMADgBLAAEAAAAAAAQADgC0AAEAAAAAAAUACwAqAAEAAAAAAAYADgB1AAEAAAAAAAoAGgDeAAMAAQQJAAEAHAAOAAMAAQQJAAIADgCmAAMAAQQJAAMAHABZAAMAAQQJAAQAHADCAAMAAQQJAAUAFgA1AAMAAQQJAAYAHACDAAMAAQQJAAoANAD4YW5jaG9yanMtaWNvbnMAYQBuAGMAaABvAHIAagBzAC0AaQBjAG8AbgBzVmVyc2lvbiAxLjAAVgBlAHIAcwBpAG8AbgAgADEALgAwYW5jaG9yanMtaWNvbnMAYQBuAGMAaABvAHIAagBzAC0AaQBjAG8AbgBzYW5jaG9yanMtaWNvbnMAYQBuAGMAaABvAHIAagBzAC0AaQBjAG8AbgBzUmVndWxhcgBSAGUAZwB1AGwAYQByYW5jaG9yanMtaWNvbnMAYQBuAGMAaABvAHIAagBzAC0AaQBjAG8AbgBzRm9udCBnZW5lcmF0ZWQgYnkgSWNvTW9vbi4ARgBvAG4AdAAgAGcAZQBuAGUAcgBhAHQAZQBkACAAYgB5ACAASQBjAG8ATQBvAG8AbgAuAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==) format("truetype"); }'
+,t.sheet.cssRules.length)}}}if(function(e,t){"use strict";"object"==typeof module&&"object"==typeof module.exports?module.exports=e.document?t(e,!0
+):function(e){if(!e.document)throw new Error("jQuery requires a window with a document");return t(e)}:t(e)}("undefined"!=typeof window?window:this,
+function(k,e){"use strict";var t=[],T=k.document,i=Object.getPrototypeOf,s=t.slice,m=t.concat,l=t.push,o=t.indexOf,n={},r=n.toString,
+g=n.hasOwnProperty,a=g.toString,c=a.call(Object),v={},y=function(e){return"function"==typeof e&&"number"!=typeof e.nodeType},b=function(e){
+return null!=e&&e===e.window},u={type:!0,src:!0,noModule:!0};function w(e,t,n){var i,o=(t=t||T).createElement("script");if(o.text=e,n)for(i in u
+)n[i]&&(o[i]=n[i]);t.head.appendChild(o).parentNode.removeChild(o)}function A(e){
+return null==e?e+"":"object"==typeof e||"function"==typeof e?n[r.call(e)]||"object":typeof e}var d="3.3.1",E=function(e,t){return new E.fn.init(e,t)},
+h=/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g;function p(e){var t=!!e&&"length"in e&&e.length,n=A(e);return!y(e)&&!b(e)&&(
+"array"===n||0===t||"number"==typeof t&&0<t&&t-1 in e)}E.fn=E.prototype={jquery:d,constructor:E,length:0,toArray:function(){return s.call(this)},
+get:function(e){return null==e?s.call(this):e<0?this[e+this.length]:this[e]},pushStack:function(e){var t=E.merge(this.constructor(),e)
+;return t.prevObject=this,t},each:function(e){return E.each(this,e)},map:function(n){return this.pushStack(E.map(this,function(e,t){return n.call(e,t,
+e)}))},slice:function(){return this.pushStack(s.apply(this,arguments))},first:function(){return this.eq(0)},last:function(){return this.eq(-1)},
+eq:function(e){var t=this.length,n=+e+(e<0?t:0);return this.pushStack(0<=n&&n<t?[this[n]]:[])},end:function(){
+return this.prevObject||this.constructor()},push:l,sort:t.sort,splice:t.splice},E.extend=E.fn.extend=function(){var e,t,n,i,o,r,a=arguments[0]||{},s=1
+,l=arguments.length,c=!1;for("boolean"==typeof a&&(c=a,a=arguments[s]||{},s++),"object"==typeof a||y(a)||(a={}),s===l&&(a=this,s--);s<l;s++)if(null!=(
+e=arguments[s]))for(t in e)n=a[t],a!==(i=e[t])&&(c&&i&&(E.isPlainObject(i)||(o=Array.isArray(i)))?(r=o?(o=!1,n&&Array.isArray(n)?n:[]
+):n&&E.isPlainObject(n)?n:{},a[t]=E.extend(c,r,i)):void 0!==i&&(a[t]=i));return a},E.extend({expando:"jQuery"+(d+Math.random()).replace(/\D/g,""),
+isReady:!0,error:function(e){throw new Error(e)},noop:function(){},isPlainObject:function(e){var t,n;return!(!e||"[object Object]"!==r.call(e))&&(!(
+t=i(e))||"function"==typeof(n=g.call(t,"constructor")&&t.constructor)&&a.call(n)===c)},isEmptyObject:function(e){var t;for(t in e)return!1;return!0},
+globalEval:function(e){w(e)},each:function(e,t){var n,i=0;if(p(e))for(n=e.length;i<n&&!1!==t.call(e[i],i,e[i]);i++);else for(i in e)if(!1===t.call(
+e[i],i,e[i]))break;return e},trim:function(e){return null==e?"":(e+"").replace(h,"")},makeArray:function(e,t){var n=t||[];return null!=e&&(p(Object(e)
+)?E.merge(n,"string"==typeof e?[e]:e):l.call(n,e)),n},inArray:function(e,t,n){return null==t?-1:o.call(t,e,n)},merge:function(e,t){for(var n=+t.length
+,i=0,o=e.length;i<n;i++)e[o++]=t[i];return e.length=o,e},grep:function(e,t,n){for(var i=[],o=0,r=e.length,a=!n;o<r;o++)!t(e[o],o)!==a&&i.push(e[o])
+;return i},map:function(e,t,n){var i,o,r=0,a=[];if(p(e))for(i=e.length;r<i;r++)null!=(o=t(e[r],r,n))&&a.push(o);else for(r in e)null!=(o=t(e[r],r,n)
+)&&a.push(o);return m.apply([],a)},guid:1,support:v}),"function"==typeof Symbol&&(E.fn[Symbol.iterator]=t[Symbol.iterator]),E.each(
+"Boolean Number String Function Array Date RegExp Object Error Symbol".split(" "),function(e,t){n["[object "+t+"]"]=t.toLowerCase()});var f=function(n
+){var e,p,w,r,o,f,d,m,A,l,c,x,k,a,T,g,s,u,v,E="sizzle"+1*new Date,y=n.document,C=0,i=0,h=ae(),b=ae(),$=ae(),S=function(e,t){return e===t&&(c=!0),0},
+_={}.hasOwnProperty,t=[],D=t.pop,j=t.push,O=t.push,P=t.slice,N=function(e,t){for(var n=0,i=e.length;n<i;n++)if(e[n]===t)return n;return-1},
+R="checked|selected|async|autofocus|autoplay|controls|defer|disabled|hidden|ismap|loop|multiple|open|readonly|required|scoped",I="[\\x20\\t\\r\\n\\f]"
+,q="(?:\\\\.|[\\w-]|[^\0-\\xa0])+",
+L="\\["+I+"*("+q+")(?:"+I+"*([*^$|!~]?=)"+I+"*(?:'((?:\\\\.|[^\\\\'])*)'|\"((?:\\\\.|[^\\\\\"])*)\"|("+q+"))|)"+I+"*\\]",
+B=":("+q+")(?:\\((('((?:\\\\.|[^\\\\'])*)'|\"((?:\\\\.|[^\\\\\"])*)\")|((?:\\\\.|[^\\\\()[\\]]|"+L+")*)|.*)\\)|)",H=new RegExp(I+"+","g"),
+M=new RegExp("^"+I+"+|((?:^|[^\\\\])(?:\\\\.)*)"+I+"+$","g"),F=new RegExp("^"+I+"*,"+I+"*"),z=new RegExp("^"+I+"*([>+~]|"+I+")"+I+"*"),W=new RegExp(
+"="+I+"*([^\\]'\"]*?)"+I+"*\\]","g"),Q=new RegExp(B),Y=new RegExp("^"+q+"$"),U={ID:new RegExp("^#("+q+")"),CLASS:new RegExp("^\\.("+q+")"),
+TAG:new RegExp("^("+q+"|[*])"),ATTR:new RegExp("^"+L),PSEUDO:new RegExp("^"+B),CHILD:new RegExp(
+"^:(only|first|last|nth|nth-last)-(child|of-type)(?:\\("+I+"*(even|odd|(([+-]|)(\\d*)n|)"+I+"*(?:([+-]|)"+I+"*(\\d+)|))"+I+"*\\)|)","i"),
+bool:new RegExp("^(?:"+R+")$","i"),needsContext:new RegExp(
+"^"+I+"*[>+~]|:(even|odd|eq|gt|lt|nth|first|last)(?:\\("+I+"*((?:-\\d)?\\d*)"+I+"*\\)|)(?=[^-]|$)","i")},V=/^(?:input|select|textarea|button)$/i,
+X=/^h\d$/i,G=/^[^{]+\{\s*\[native \w/,K=/^(?:#([\w-]+)|(\w+)|\.([\w-]+))$/,J=/[+~]/,Z=new RegExp("\\\\([\\da-f]{1,6}"+I+"?|("+I+")|.)","ig"),
+ee=function(e,t,n){var i="0x"+t-65536;return i!=i||n?t:i<0?String.fromCharCode(i+65536):String.fromCharCode(i>>10|55296,1023&i|56320)},
+te=/([\0-\x1f\x7f]|^-?\d)|^-$|[^\0-\x1f\x7f-\uFFFF\w-]/g,ne=function(e,t){return t?"\0"===e?"�":e.slice(0,-1)+"\\"+e.charCodeAt(e.length-1).toString(
+16)+" ":"\\"+e},ie=function(){x()},oe=ye(function(e){return!0===e.disabled&&("form"in e||"label"in e)},{dir:"parentNode",next:"legend"});try{O.apply(
+t=P.call(y.childNodes),y.childNodes),t[y.childNodes.length].nodeType}catch(e){O={apply:t.length?function(e,t){j.apply(e,P.call(t))}:function(e,t){for(
+var n=e.length,i=0;e[n++]=t[i++];);e.length=n-1}}}function re(e,t,n,i){var o,r,a,s,l,c,u,d=t&&t.ownerDocument,h=t?t.nodeType:9;if(n=n||[],
+"string"!=typeof e||!e||1!==h&&9!==h&&11!==h)return n;if(!i&&((t?t.ownerDocument||t:y)!==k&&x(t),t=t||k,T)){if(11!==h&&(l=K.exec(e)))if(o=l[1]){if(
+9===h){if(!(a=t.getElementById(o)))return n;if(a.id===o)return n.push(a),n}else if(d&&(a=d.getElementById(o))&&v(t,a)&&a.id===o)return n.push(a),n
+}else{if(l[2])return O.apply(n,t.getElementsByTagName(e)),n;if((o=l[3])&&p.getElementsByClassName&&t.getElementsByClassName)return O.apply(n,
+t.getElementsByClassName(o)),n}if(p.qsa&&!$[e+" "]&&(!g||!g.test(e))){if(1!==h)d=t,u=e;else if("object"!==t.nodeName.toLowerCase()){for((
+s=t.getAttribute("id"))?s=s.replace(te,ne):t.setAttribute("id",s=E),r=(c=f(e)).length;r--;)c[r]="#"+s+" "+ve(c[r]);u=c.join(","),d=J.test(e)&&me(
+t.parentNode)||t}if(u)try{return O.apply(n,d.querySelectorAll(u)),n}catch(e){}finally{s===E&&t.removeAttribute("id")}}}return m(e.replace(M,"$1"),t,n,
+i)}function ae(){var i=[];return function e(t,n){return i.push(t+" ")>w.cacheLength&&delete e[i.shift()],e[t+" "]=n}}function se(e){return e[E]=!0,e}
+function le(e){var t=k.createElement("fieldset");try{return!!e(t)}catch(e){return!1}finally{t.parentNode&&t.parentNode.removeChild(t),t=null}}
+function ce(e,t){for(var n=e.split("|"),i=n.length;i--;)w.attrHandle[n[i]]=t}function ue(e,t){var n=t&&e,
+i=n&&1===e.nodeType&&1===t.nodeType&&e.sourceIndex-t.sourceIndex;if(i)return i;if(n)for(;n=n.nextSibling;)if(n===t)return-1;return e?1:-1}function de(
+t){return function(e){return"input"===e.nodeName.toLowerCase()&&e.type===t}}function he(n){return function(e){var t=e.nodeName.toLowerCase();return(
+"input"===t||"button"===t)&&e.type===n}}function pe(t){return function(e){
+return"form"in e?e.parentNode&&!1===e.disabled?"label"in e?"label"in e.parentNode?e.parentNode.disabled===t:e.disabled===t:e.isDisabled===t||e.isDisabled!==!t&&oe(
+e)===t:e.disabled===t:"label"in e&&e.disabled===t}}function fe(a){return se(function(r){return r=+r,se(function(e,t){for(var n,i=a([],e.length,r),
+o=i.length;o--;)e[n=i[o]]&&(e[n]=!(t[n]=e[n]))})})}function me(e){return e&&void 0!==e.getElementsByTagName&&e}for(e in p=re.support={},
+o=re.isXML=function(e){var t=e&&(e.ownerDocument||e).documentElement;return!!t&&"HTML"!==t.nodeName},x=re.setDocument=function(e){var t,n,
+i=e?e.ownerDocument||e:y;return i!==k&&9===i.nodeType&&i.documentElement&&(a=(k=i).documentElement,T=!o(k),y!==k&&(n=k.defaultView)&&n.top!==n&&(
+n.addEventListener?n.addEventListener("unload",ie,!1):n.attachEvent&&n.attachEvent("onunload",ie)),p.attributes=le(function(e){return e.className="i",
+!e.getAttribute("className")}),p.getElementsByTagName=le(function(e){return e.appendChild(k.createComment("")),!e.getElementsByTagName("*").length}),
+p.getElementsByClassName=G.test(k.getElementsByClassName),p.getById=le(function(e){return a.appendChild(e).id=E,
+!k.getElementsByName||!k.getElementsByName(E).length}),p.getById?(w.filter.ID=function(e){var t=e.replace(Z,ee);return function(e){
+return e.getAttribute("id")===t}},w.find.ID=function(e,t){if(void 0!==t.getElementById&&T){var n=t.getElementById(e);return n?[n]:[]}}):(
+w.filter.ID=function(e){var n=e.replace(Z,ee);return function(e){var t=void 0!==e.getAttributeNode&&e.getAttributeNode("id");return t&&t.value===n}},
+w.find.ID=function(e,t){if(void 0!==t.getElementById&&T){var n,i,o,r=t.getElementById(e);if(r){if((n=r.getAttributeNode("id"))&&n.value===e)return[r]
+;for(o=t.getElementsByName(e),i=0;r=o[i++];)if((n=r.getAttributeNode("id"))&&n.value===e)return[r]}return[]}}),
+w.find.TAG=p.getElementsByTagName?function(e,t){return void 0!==t.getElementsByTagName?t.getElementsByTagName(e):p.qsa?t.querySelectorAll(e):void 0
+}:function(e,t){var n,i=[],o=0,r=t.getElementsByTagName(e);if("*"!==e)return r;for(;n=r[o++];)1===n.nodeType&&i.push(n);return i},
+w.find.CLASS=p.getElementsByClassName&&function(e,t){if(void 0!==t.getElementsByClassName&&T)return t.getElementsByClassName(e)},s=[],g=[],(
+p.qsa=G.test(k.querySelectorAll))&&(le(function(e){a.appendChild(e
+).innerHTML="<a id='"+E+"'></a><select id='"+E+"-\r\\' msallowcapture=''><option selected=''></option></select>",e.querySelectorAll(
+"[msallowcapture^='']").length&&g.push("[*^$]="+I+"*(?:''|\"\")"),e.querySelectorAll("[selected]").length||g.push("\\["+I+"*(?:value|"+R+")"),
+e.querySelectorAll("[id~="+E+"-]").length||g.push("~="),e.querySelectorAll(":checked").length||g.push(":checked"),e.querySelectorAll("a#"+E+"+*"
+).length||g.push(".#.+[+~]")}),le(function(e){e.innerHTML="<a href='' disabled='disabled'></a><select disabled='disabled'><option/></select>"
+;var t=k.createElement("input");t.setAttribute("type","hidden"),e.appendChild(t).setAttribute("name","D"),e.querySelectorAll("[name=d]"
+).length&&g.push("name"+I+"*[*^$|!~]?="),2!==e.querySelectorAll(":enabled").length&&g.push(":enabled",":disabled"),a.appendChild(e).disabled=!0,
+2!==e.querySelectorAll(":disabled").length&&g.push(":enabled",":disabled"),e.querySelectorAll("*,:x"),g.push(",.*:")})),(p.matchesSelector=G.test(
+u=a.matches||a.webkitMatchesSelector||a.mozMatchesSelector||a.oMatchesSelector||a.msMatchesSelector))&&le(function(e){p.disconnectedMatch=u.call(e,"*"
+),u.call(e,"[s!='']:x"),s.push("!=",B)}),g=g.length&&new RegExp(g.join("|")),s=s.length&&new RegExp(s.join("|")),t=G.test(a.compareDocumentPosition),
+v=t||G.test(a.contains)?function(e,t){var n=9===e.nodeType?e.documentElement:e,i=t&&t.parentNode;return e===i||!(!i||1!==i.nodeType||!(
+n.contains?n.contains(i):e.compareDocumentPosition&&16&e.compareDocumentPosition(i)))}:function(e,t){if(t)for(;t=t.parentNode;)if(t===e)return!0
+;return!1},S=t?function(e,t){if(e===t)return c=!0,0;var n=!e.compareDocumentPosition-!t.compareDocumentPosition;return n||(1&(n=(e.ownerDocument||e
+)===(t.ownerDocument||t)?e.compareDocumentPosition(t):1)||!p.sortDetached&&t.compareDocumentPosition(e)===n?e===k||e.ownerDocument===y&&v(y,e
+)?-1:t===k||t.ownerDocument===y&&v(y,t)?1:l?N(l,e)-N(l,t):0:4&n?-1:1)}:function(e,t){if(e===t)return c=!0,0;var n,i=0,o=e.parentNode,r=t.parentNode,
+a=[e],s=[t];if(!o||!r)return e===k?-1:t===k?1:o?-1:r?1:l?N(l,e)-N(l,t):0;if(o===r)return ue(e,t);for(n=e;n=n.parentNode;)a.unshift(n);for(
+n=t;n=n.parentNode;)s.unshift(n);for(;a[i]===s[i];)i++;return i?ue(a[i],s[i]):a[i]===y?-1:s[i]===y?1:0}),k},re.matches=function(e,t){return re(e,null,
+null,t)},re.matchesSelector=function(e,t){if((e.ownerDocument||e)!==k&&x(e),t=t.replace(W,"='$1']"),p.matchesSelector&&T&&!$[t+" "]&&(!s||!s.test(t)
+)&&(!g||!g.test(t)))try{var n=u.call(e,t);if(n||p.disconnectedMatch||e.document&&11!==e.document.nodeType)return n}catch(e){}return 0<re(t,k,null,[e]
+).length},re.contains=function(e,t){return(e.ownerDocument||e)!==k&&x(e),v(e,t)},re.attr=function(e,t){(e.ownerDocument||e)!==k&&x(e)
+;var n=w.attrHandle[t.toLowerCase()],i=n&&_.call(w.attrHandle,t.toLowerCase())?n(e,t,!T):void 0;return void 0!==i?i:p.attributes||!T?e.getAttribute(t
+):(i=e.getAttributeNode(t))&&i.specified?i.value:null},re.escape=function(e){return(e+"").replace(te,ne)},re.error=function(e){throw new Error(
+"Syntax error, unrecognized expression: "+e)},re.uniqueSort=function(e){var t,n=[],i=0,o=0;if(c=!p.detectDuplicates,l=!p.sortStable&&e.slice(0),
+e.sort(S),c){for(;t=e[o++];)t===e[o]&&(i=n.push(o));for(;i--;)e.splice(n[i],1)}return l=null,e},r=re.getText=function(e){var t,n="",i=0,o=e.nodeType
+;if(o){if(1===o||9===o||11===o){if("string"==typeof e.textContent)return e.textContent;for(e=e.firstChild;e;e=e.nextSibling)n+=r(e)}else if(
+3===o||4===o)return e.nodeValue}else for(;t=e[i++];)n+=r(t);return n},(w=re.selectors={cacheLength:50,createPseudo:se,match:U,attrHandle:{},find:{},
+relative:{">":{dir:"parentNode",first:!0}," ":{dir:"parentNode"},"+":{dir:"previousSibling",first:!0},"~":{dir:"previousSibling"}},preFilter:{
+ATTR:function(e){return e[1]=e[1].replace(Z,ee),e[3]=(e[3]||e[4]||e[5]||"").replace(Z,ee),"~="===e[2]&&(e[3]=" "+e[3]+" "),e.slice(0,4)},
+CHILD:function(e){return e[1]=e[1].toLowerCase(),"nth"===e[1].slice(0,3)?(e[3]||re.error(e[0]),e[4]=+(e[4]?e[5]+(e[6]||1):2*(
+"even"===e[3]||"odd"===e[3])),e[5]=+(e[7]+e[8]||"odd"===e[3])):e[3]&&re.error(e[0]),e},PSEUDO:function(e){var t,n=!e[6]&&e[2];return U.CHILD.test(e[0]
+)?null:(e[3]?e[2]=e[4]||e[5]||"":n&&Q.test(n)&&(t=f(n,!0))&&(t=n.indexOf(")",n.length-t)-n.length)&&(e[0]=e[0].slice(0,t),e[2]=n.slice(0,t)),e.slice(0
+,3))}},filter:{TAG:function(e){var t=e.replace(Z,ee).toLowerCase();return"*"===e?function(){return!0}:function(e){
+return e.nodeName&&e.nodeName.toLowerCase()===t}},CLASS:function(e){var t=h[e+" "];return t||(t=new RegExp("(^|"+I+")"+e+"("+I+"|$)"))&&h(e,function(e
+){return t.test("string"==typeof e.className&&e.className||void 0!==e.getAttribute&&e.getAttribute("class")||"")})},ATTR:function(n,i,o){
+return function(e){var t=re.attr(e,n);return null==t?"!="===i:!i||(t+="","="===i?t===o:"!="===i?t!==o:"^="===i?o&&0===t.indexOf(o
+):"*="===i?o&&-1<t.indexOf(o):"$="===i?o&&t.slice(-o.length)===o:"~="===i?-1<(" "+t.replace(H," ")+" ").indexOf(o):"|="===i&&(t===o||t.slice(0,
+o.length+1)===o+"-"))}},CHILD:function(f,e,t,m,g){var v="nth"!==f.slice(0,3),y="last"!==f.slice(-4),b="of-type"===e;return 1===m&&0===g?function(e){
+return!!e.parentNode}:function(e,t,n){var i,o,r,a,s,l,c=v!==y?"nextSibling":"previousSibling",u=e.parentNode,d=b&&e.nodeName.toLowerCase(),h=!n&&!b,
+p=!1;if(u){if(v){for(;c;){for(a=e;a=a[c];)if(b?a.nodeName.toLowerCase()===d:1===a.nodeType)return!1;l=c="only"===f&&!l&&"nextSibling"}return!0}if(l=[
+y?u.firstChild:u.lastChild],y&&h){for(p=(s=(i=(o=(r=(a=u)[E]||(a[E]={}))[a.uniqueID]||(r[a.uniqueID]={}))[f]||[])[0]===C&&i[1])&&i[2],
+a=s&&u.childNodes[s];a=++s&&a&&a[c]||(p=s=0)||l.pop();)if(1===a.nodeType&&++p&&a===e){o[f]=[C,s,p];break}}else if(h&&(p=s=(i=(o=(r=(a=e)[E]||(a[E]={})
+)[a.uniqueID]||(r[a.uniqueID]={}))[f]||[])[0]===C&&i[1]),!1===p)for(;(a=++s&&a&&a[c]||(p=s=0)||l.pop())&&((b?a.nodeName.toLowerCase(
+)!==d:1!==a.nodeType)||!++p||(h&&((o=(r=a[E]||(a[E]={}))[a.uniqueID]||(r[a.uniqueID]={}))[f]=[C,p]),a!==e)););return(p-=g)===m||p%m==0&&0<=p/m}}},
+PSEUDO:function(e,r){var t,a=w.pseudos[e]||w.setFilters[e.toLowerCase()]||re.error("unsupported pseudo: "+e);return a[E]?a(r):1<a.length?(t=[e,e,"",r]
+,w.setFilters.hasOwnProperty(e.toLowerCase())?se(function(e,t){for(var n,i=a(e,r),o=i.length;o--;)e[n=N(e,i[o])]=!(t[n]=i[o])}):function(e){return a(e
+,0,t)}):a}},pseudos:{not:se(function(e){var i=[],o=[],s=d(e.replace(M,"$1"));return s[E]?se(function(e,t,n,i){for(var o,r=s(e,null,i,[]),
+a=e.length;a--;)(o=r[a])&&(e[a]=!(t[a]=o))}):function(e,t,n){return i[0]=e,s(i,null,n,o),i[0]=null,!o.pop()}}),has:se(function(t){return function(e){
+return 0<re(t,e).length}}),contains:se(function(t){return t=t.replace(Z,ee),function(e){return-1<(e.textContent||e.innerText||r(e)).indexOf(t)}}),
+lang:se(function(n){return Y.test(n||"")||re.error("unsupported lang: "+n),n=n.replace(Z,ee).toLowerCase(),function(e){var t;do{if(
+t=T?e.lang:e.getAttribute("xml:lang")||e.getAttribute("lang"))return(t=t.toLowerCase())===n||0===t.indexOf(n+"-")}while((e=e.parentNode
+)&&1===e.nodeType);return!1}}),target:function(e){var t=n.location&&n.location.hash;return t&&t.slice(1)===e.id},root:function(e){return e===a},
+focus:function(e){return e===k.activeElement&&(!k.hasFocus||k.hasFocus())&&!!(e.type||e.href||~e.tabIndex)},enabled:pe(!1),disabled:pe(!0),
+checked:function(e){var t=e.nodeName.toLowerCase();return"input"===t&&!!e.checked||"option"===t&&!!e.selected},selected:function(e){
+return e.parentNode&&e.parentNode.selectedIndex,!0===e.selected},empty:function(e){for(e=e.firstChild;e;e=e.nextSibling)if(e.nodeType<6)return!1
+;return!0},parent:function(e){return!w.pseudos.empty(e)},header:function(e){return X.test(e.nodeName)},input:function(e){return V.test(e.nodeName)},
+button:function(e){var t=e.nodeName.toLowerCase();return"input"===t&&"button"===e.type||"button"===t},text:function(e){var t
+;return"input"===e.nodeName.toLowerCase()&&"text"===e.type&&(null==(t=e.getAttribute("type"))||"text"===t.toLowerCase())},first:fe(function(){return[0
+]}),last:fe(function(e,t){return[t-1]}),eq:fe(function(e,t,n){return[n<0?n+t:n]}),even:fe(function(e,t){for(var n=0;n<t;n+=2)e.push(n);return e}),
+odd:fe(function(e,t){for(var n=1;n<t;n+=2)e.push(n);return e}),lt:fe(function(e,t,n){for(var i=n<0?n+t:n;0<=--i;)e.push(i);return e}),gt:fe(function(e
+,t,n){for(var i=n<0?n+t:n;++i<t;)e.push(i);return e})}}).pseudos.nth=w.pseudos.eq,{radio:!0,checkbox:!0,file:!0,password:!0,image:!0})w.pseudos[e]=de(
+e);for(e in{submit:!0,reset:!0})w.pseudos[e]=he(e);function ge(){}function ve(e){for(var t=0,n=e.length,i="";t<n;t++)i+=e[t].value;return i}
+function ye(s,e,t){var l=e.dir,c=e.next,u=c||l,d=t&&"parentNode"===u,h=i++;return e.first?function(e,t,n){for(;e=e[l];)if(1===e.nodeType||d)return s(e
+,t,n);return!1}:function(e,t,n){var i,o,r,a=[C,h];if(n){for(;e=e[l];)if((1===e.nodeType||d)&&s(e,t,n))return!0}else for(;e=e[l];)if(1===e.nodeType||d
+)if(o=(r=e[E]||(e[E]={}))[e.uniqueID]||(r[e.uniqueID]={}),c&&c===e.nodeName.toLowerCase())e=e[l]||e;else{if((i=o[u])&&i[0]===C&&i[1]===h
+)return a[2]=i[2];if((o[u]=a)[2]=s(e,t,n))return!0}return!1}}function be(o){return 1<o.length?function(e,t,n){for(var i=o.length;i--;)if(!o[i](e,t,n)
+)return!1;return!0}:o[0]}function we(e,t,n,i,o){for(var r,a=[],s=0,l=e.length,c=null!=t;s<l;s++)(r=e[s])&&(n&&!n(r,i,o)||(a.push(r),c&&t.push(s)))
+;return a}function Ae(p,f,m,g,v,e){return g&&!g[E]&&(g=Ae(g)),v&&!v[E]&&(v=Ae(v,e)),se(function(e,t,n,i){var o,r,a,s=[],l=[],c=t.length,u=e||function(
+e,t,n){for(var i=0,o=t.length;i<o;i++)re(e,t[i],n);return n}(f||"*",n.nodeType?[n]:n,[]),d=!p||!e&&f?u:we(u,s,p,n,i),h=m?v||(e?p:c||g)?[]:t:d;if(m&&m(
+d,h,n,i),g)for(o=we(h,l),g(o,[],n,i),r=o.length;r--;)(a=o[r])&&(h[l[r]]=!(d[l[r]]=a));if(e){if(v||p){if(v){for(o=[],r=h.length;r--;)(a=h[r])&&o.push(
+d[r]=a);v(null,h=[],o,i)}for(r=h.length;r--;)(a=h[r])&&-1<(o=v?N(e,a):s[r])&&(e[o]=!(t[o]=a))}}else h=we(h===t?h.splice(c,h.length):h),v?v(null,t,h,i
+):O.apply(t,h)})}function xe(e){for(var o,t,n,i=e.length,r=w.relative[e[0].type],a=r||w.relative[" "],s=r?1:0,l=ye(function(e){return e===o},a,!0),
+c=ye(function(e){return-1<N(o,e)},a,!0),u=[function(e,t,n){var i=!r&&(n||t!==A)||((o=t).nodeType?l(e,t,n):c(e,t,n));return o=null,i}];s<i;s++)if(
+t=w.relative[e[s].type])u=[ye(be(u),t)];else{if((t=w.filter[e[s].type].apply(null,e[s].matches))[E]){for(n=++s;n<i&&!w.relative[e[n].type];n++);
+return Ae(1<s&&be(u),1<s&&ve(e.slice(0,s-1).concat({value:" "===e[s-2].type?"*":""})).replace(M,"$1"),t,s<n&&xe(e.slice(s,n)),n<i&&xe(e=e.slice(n)),
+n<i&&ve(e))}u.push(t)}return be(u)}return ge.prototype=w.filters=w.pseudos,w.setFilters=new ge,f=re.tokenize=function(e,t){var n,i,o,r,a,s,l,
+c=b[e+" "];if(c)return t?0:c.slice(0);for(a=e,s=[],l=w.preFilter;a;){for(r in n&&!(i=F.exec(a))||(i&&(a=a.slice(i[0].length)||a),s.push(o=[])),n=!1,(
+i=z.exec(a))&&(n=i.shift(),o.push({value:n,type:i[0].replace(M," ")}),a=a.slice(n.length)),w.filter)!(i=U[r].exec(a))||l[r]&&!(i=l[r](i))||(n=i.shift(
+),o.push({value:n,type:r,matches:i}),a=a.slice(n.length));if(!n)break}return t?a.length:a?re.error(e):b(e,s).slice(0)},d=re.compile=function(e,t){
+var n,g,v,y,b,i,o=[],r=[],a=$[e+" "];if(!a){for(t||(t=f(e)),n=t.length;n--;)(a=xe(t[n]))[E]?o.push(a):r.push(a);(a=$(e,(g=r,y=0<(v=o).length,
+b=0<g.length,i=function(e,t,n,i,o){var r,a,s,l=0,c="0",u=e&&[],d=[],h=A,p=e||b&&w.find.TAG("*",o),f=C+=null==h?1:Math.random()||.1,m=p.length;for(o&&(
+A=t===k||t||o);c!==m&&null!=(r=p[c]);c++){if(b&&r){for(a=0,t||r.ownerDocument===k||(x(r),n=!T);s=g[a++];)if(s(r,t||k,n)){i.push(r);break}o&&(C=f)}y&&(
+(r=!s&&r)&&l--,e&&u.push(r))}if(l+=c,y&&c!==l){for(a=0;s=v[a++];)s(u,d,t,n);if(e){if(0<l)for(;c--;)u[c]||d[c]||(d[c]=D.call(i));d=we(d)}O.apply(i,d),
+o&&!e&&0<d.length&&1<l+v.length&&re.uniqueSort(i)}return o&&(C=f,A=h),u},y?se(i):i))).selector=e}return a},m=re.select=function(e,t,n,i){var o,r,a,s,l
+,c="function"==typeof e&&e,u=!i&&f(e=c.selector||e);if(n=n||[],1===u.length){if(2<(r=u[0]=u[0].slice(0)).length&&"ID"===(a=r[0]
+).type&&9===t.nodeType&&T&&w.relative[r[1].type]){if(!(t=(w.find.ID(a.matches[0].replace(Z,ee),t)||[])[0]))return n;c&&(t=t.parentNode),e=e.slice(
+r.shift().value.length)}for(o=U.needsContext.test(e)?0:r.length;o--&&(a=r[o],!w.relative[s=a.type]);)if((l=w.find[s])&&(i=l(a.matches[0].replace(Z,ee)
+,J.test(r[0].type)&&me(t.parentNode)||t))){if(r.splice(o,1),!(e=i.length&&ve(r)))return O.apply(n,i),n;break}}return(c||d(e,u))(i,t,!T,n,!t||J.test(e
+)&&me(t.parentNode)||t),n},p.sortStable=E.split("").sort(S).join("")===E,p.detectDuplicates=!!c,x(),p.sortDetached=le(function(e){
+return 1&e.compareDocumentPosition(k.createElement("fieldset"))}),le(function(e){return e.innerHTML="<a href='#'></a>",
+"#"===e.firstChild.getAttribute("href")})||ce("type|href|height|width",function(e,t,n){if(!n)return e.getAttribute(t,"type"===t.toLowerCase()?1:2)}),
+p.attributes&&le(function(e){return e.innerHTML="<input/>",e.firstChild.setAttribute("value",""),""===e.firstChild.getAttribute("value")})||ce("value"
+,function(e,t,n){if(!n&&"input"===e.nodeName.toLowerCase())return e.defaultValue}),le(function(e){return null==e.getAttribute("disabled")})||ce(R,
+function(e,t,n){var i;if(!n)return!0===e[t]?t.toLowerCase():(i=e.getAttributeNode(t))&&i.specified?i.value:null}),re}(k);E.find=f,E.expr=f.selectors,
+E.expr[":"]=E.expr.pseudos,E.uniqueSort=E.unique=f.uniqueSort,E.text=f.getText,E.isXMLDoc=f.isXML,E.contains=f.contains,E.escapeSelector=f.escape
+;var x=function(e,t,n){for(var i=[],o=void 0!==n;(e=e[t])&&9!==e.nodeType;)if(1===e.nodeType){if(o&&E(e).is(n))break;i.push(e)}return i},C=function(e,
+t){for(var n=[];e;e=e.nextSibling)1===e.nodeType&&e!==t&&n.push(e);return n},$=E.expr.match.needsContext;function S(e,t){
+return e.nodeName&&e.nodeName.toLowerCase()===t.toLowerCase()}var _=/^<([a-z][^\/\0>:\x20\t\r\n\f]*)[\x20\t\r\n\f]*\/?>(?:<\/\1>|)$/i;function D(e,n,i
+){return y(n)?E.grep(e,function(e,t){return!!n.call(e,t,e)!==i}):n.nodeType?E.grep(e,function(e){return e===n!==i}):"string"!=typeof n?E.grep(e,
+function(e){return-1<o.call(n,e)!==i}):E.filter(n,e,i)}E.filter=function(e,t,n){var i=t[0];return n&&(e=":not("+e+")"),
+1===t.length&&1===i.nodeType?E.find.matchesSelector(i,e)?[i]:[]:E.find.matches(e,E.grep(t,function(e){return 1===e.nodeType}))},E.fn.extend({
+find:function(e){var t,n,i=this.length,o=this;if("string"!=typeof e)return this.pushStack(E(e).filter(function(){for(t=0;t<i;t++)if(E.contains(o[t],
+this))return!0}));for(n=this.pushStack([]),t=0;t<i;t++)E.find(e,o[t],n);return 1<i?E.uniqueSort(n):n},filter:function(e){return this.pushStack(D(this,
+e||[],!1))},not:function(e){return this.pushStack(D(this,e||[],!0))},is:function(e){return!!D(this,"string"==typeof e&&$.test(e)?E(e):e||[],!1).length
+}});var j,O=/^(?:\s*(<[\w\W]+>)[^>]*|#([\w-]+))$/;(E.fn.init=function(e,t,n){var i,o;if(!e)return this;if(n=n||j,"string"!=typeof e
+)return e.nodeType?(this[0]=e,this.length=1,this):y(e)?void 0!==n.ready?n.ready(e):e(E):E.makeArray(e,this);if(!(
+i="<"===e[0]&&">"===e[e.length-1]&&3<=e.length?[null,e,null]:O.exec(e))||!i[1]&&t)return!t||t.jquery?(t||n).find(e):this.constructor(t).find(e);if(
+i[1]){if(t=t instanceof E?t[0]:t,E.merge(this,E.parseHTML(i[1],t&&t.nodeType?t.ownerDocument||t:T,!0)),_.test(i[1])&&E.isPlainObject(t))for(i in t)y(
+this[i])?this[i](t[i]):this.attr(i,t[i]);return this}return(o=T.getElementById(i[2]))&&(this[0]=o,this.length=1),this}).prototype=E.fn,j=E(T)
+;var P=/^(?:parents|prev(?:Until|All))/,N={children:!0,contents:!0,next:!0,prev:!0};function R(e,t){for(;(e=e[t])&&1!==e.nodeType;);return e}
+E.fn.extend({has:function(e){var t=E(e,this),n=t.length;return this.filter(function(){for(var e=0;e<n;e++)if(E.contains(this,t[e]))return!0})},
+closest:function(e,t){var n,i=0,o=this.length,r=[],a="string"!=typeof e&&E(e);if(!$.test(e))for(;i<o;i++)for(n=this[i];n&&n!==t;n=n.parentNode)if(
+n.nodeType<11&&(a?-1<a.index(n):1===n.nodeType&&E.find.matchesSelector(n,e))){r.push(n);break}return this.pushStack(1<r.length?E.uniqueSort(r):r)},
+index:function(e){return e?"string"==typeof e?o.call(E(e),this[0]):o.call(this,e.jquery?e[0]:e):this[0]&&this[0].parentNode?this.first().prevAll(
+).length:-1},add:function(e,t){return this.pushStack(E.uniqueSort(E.merge(this.get(),E(e,t))))},addBack:function(e){return this.add(
+null==e?this.prevObject:this.prevObject.filter(e))}}),E.each({parent:function(e){var t=e.parentNode;return t&&11!==t.nodeType?t:null},
+parents:function(e){return x(e,"parentNode")},parentsUntil:function(e,t,n){return x(e,"parentNode",n)},next:function(e){return R(e,"nextSibling")},
+prev:function(e){return R(e,"previousSibling")},nextAll:function(e){return x(e,"nextSibling")},prevAll:function(e){return x(e,"previousSibling")},
+nextUntil:function(e,t,n){return x(e,"nextSibling",n)},prevUntil:function(e,t,n){return x(e,"previousSibling",n)},siblings:function(e){return C((
+e.parentNode||{}).firstChild,e)},children:function(e){return C(e.firstChild)},contents:function(e){return S(e,"iframe")?e.contentDocument:(S(e,
+"template")&&(e=e.content||e),E.merge([],e.childNodes))}},function(i,o){E.fn[i]=function(e,t){var n=E.map(this,o,e);return"Until"!==i.slice(-5)&&(t=e)
+,t&&"string"==typeof t&&(n=E.filter(t,n)),1<this.length&&(N[i]||E.uniqueSort(n),P.test(i)&&n.reverse()),this.pushStack(n)}});var I=/[^\x20\t\r\n\f]+/g
+;function q(e){return e}function L(e){throw e}function B(e,t,n,i){var o;try{e&&y(o=e.promise)?o.call(e).done(t).fail(n):e&&y(o=e.then)?o.call(e,t,n
+):t.apply(void 0,[e].slice(i))}catch(e){n.apply(void 0,[e])}}E.Callbacks=function(i){var e,n;i="string"==typeof i?(e=i,n={},E.each(e.match(I)||[],
+function(e,t){n[t]=!0}),n):E.extend({},i);var o,t,r,a,s=[],l=[],c=-1,u=function(){for(a=a||i.once,r=o=!0;l.length;c=-1)for(t=l.shift();++c<s.length;
+)!1===s[c].apply(t[0],t[1])&&i.stopOnFalse&&(c=s.length,t=!1);i.memory||(t=!1),o=!1,a&&(s=t?[]:"")},d={add:function(){return s&&(t&&!o&&(c=s.length-1,
+l.push(t)),function n(e){E.each(e,function(e,t){y(t)?i.unique&&d.has(t)||s.push(t):t&&t.length&&"string"!==A(t)&&n(t)})}(arguments),t&&!o&&u()),this},
+remove:function(){return E.each(arguments,function(e,t){for(var n;-1<(n=E.inArray(t,s,n));)s.splice(n,1),n<=c&&c--}),this},has:function(e){
+return e?-1<E.inArray(e,s):0<s.length},empty:function(){return s&&(s=[]),this},disable:function(){return a=l=[],s=t="",this},disabled:function(){
+return!s},lock:function(){return a=l=[],t||o||(s=t=""),this},locked:function(){return!!a},fireWith:function(e,t){return a||(t=[e,(t=t||[]
+).slice?t.slice():t],l.push(t),o||u()),this},fire:function(){return d.fireWith(this,arguments),this},fired:function(){return!!r}};return d},E.extend({
+Deferred:function(e){var r=[["notify","progress",E.Callbacks("memory"),E.Callbacks("memory"),2],["resolve","done",E.Callbacks("once memory"),
+E.Callbacks("once memory"),0,"resolved"],["reject","fail",E.Callbacks("once memory"),E.Callbacks("once memory"),1,"rejected"]],o="pending",a={
+state:function(){return o},always:function(){return s.done(arguments).fail(arguments),this},catch:function(e){return a.then(null,e)},pipe:function(){
+var o=arguments;return E.Deferred(function(i){E.each(r,function(e,t){var n=y(o[t[4]])&&o[t[4]];s[t[1]](function(){var e=n&&n.apply(this,arguments)
+;e&&y(e.promise)?e.promise().progress(i.notify).done(i.resolve).fail(i.reject):i[t[0]+"With"](this,n?[e]:arguments)})}),o=null}).promise()},
+then:function(t,n,i){var l=0;function c(o,r,a,s){return function(){var n=this,i=arguments,e=function(){var e,t;if(!(o<l)){if((e=a.apply(n,i)
+)===r.promise())throw new TypeError("Thenable self-resolution");t=e&&("object"==typeof e||"function"==typeof e)&&e.then,y(t)?s?t.call(e,c(l,r,q,s),c(l
+,r,L,s)):(l++,t.call(e,c(l,r,q,s),c(l,r,L,s),c(l,r,q,r.notifyWith))):(a!==q&&(n=void 0,i=[e]),(s||r.resolveWith)(n,i))}},t=s?e:function(){try{e()
+}catch(e){E.Deferred.exceptionHook&&E.Deferred.exceptionHook(e,t.stackTrace),l<=o+1&&(a!==L&&(n=void 0,i=[e]),r.rejectWith(n,i))}};o?t():(
+E.Deferred.getStackHook&&(t.stackTrace=E.Deferred.getStackHook()),k.setTimeout(t))}}return E.Deferred(function(e){r[0][3].add(c(0,e,y(i)?i:q,
+e.notifyWith)),r[1][3].add(c(0,e,y(t)?t:q)),r[2][3].add(c(0,e,y(n)?n:L))}).promise()},promise:function(e){return null!=e?E.extend(e,a):a}},s={}
+;return E.each(r,function(e,t){var n=t[2],i=t[5];a[t[1]]=n.add,i&&n.add(function(){o=i},r[3-e][2].disable,r[3-e][3].disable,r[0][2].lock,r[0][3].lock)
+,n.add(t[3].fire),s[t[0]]=function(){return s[t[0]+"With"](this===s?void 0:this,arguments),this},s[t[0]+"With"]=n.fireWith}),a.promise(s),e&&e.call(s,
+s),s},when:function(e){var n=arguments.length,t=n,i=Array(t),o=s.call(arguments),r=E.Deferred(),a=function(t){return function(e){i[t]=this,
+o[t]=1<arguments.length?s.call(arguments):e,--n||r.resolveWith(i,o)}};if(n<=1&&(B(e,r.done(a(t)).resolve,r.reject,!n),"pending"===r.state()||y(
+o[t]&&o[t].then)))return r.then();for(;t--;)B(o[t],a(t),r.reject);return r.promise()}});var H=/^(Eval|Internal|Range|Reference|Syntax|Type|URI)Error$/
+;E.Deferred.exceptionHook=function(e,t){k.console&&k.console.warn&&e&&H.test(e.name)&&k.console.warn("jQuery.Deferred exception: "+e.message,e.stack,t
+)},E.readyException=function(e){k.setTimeout(function(){throw e})};var M=E.Deferred();function F(){T.removeEventListener("DOMContentLoaded",F),
+k.removeEventListener("load",F),E.ready()}E.fn.ready=function(e){return M.then(e).catch(function(e){E.readyException(e)}),this},E.extend({isReady:!1,
+readyWait:1,ready:function(e){(!0===e?--E.readyWait:E.isReady)||(E.isReady=!0)!==e&&0<--E.readyWait||M.resolveWith(T,[E])}}),E.ready.then=M.then,
+"complete"===T.readyState||"loading"!==T.readyState&&!T.documentElement.doScroll?k.setTimeout(E.ready):(T.addEventListener("DOMContentLoaded",F),
+k.addEventListener("load",F));var z=function(e,t,n,i,o,r,a){var s=0,l=e.length,c=null==n;if("object"===A(n))for(s in o=!0,n)z(e,t,s,n[s],!0,r,a
+);else if(void 0!==i&&(o=!0,y(i)||(a=!0),c&&(t=a?(t.call(e,i),null):(c=t,function(e,t,n){return c.call(E(e),n)})),t))for(;s<l;s++)t(e[s],n,a?i:i.call(
+e[s],s,t(e[s],n)));return o?e:c?t.call(e):l?t(e[0],n):r},W=/^-ms-/,Q=/-([a-z])/g;function Y(e,t){return t.toUpperCase()}function U(e){
+return e.replace(W,"ms-").replace(Q,Y)}var V=function(e){return 1===e.nodeType||9===e.nodeType||!+e.nodeType};function X(){
+this.expando=E.expando+X.uid++}X.uid=1,X.prototype={cache:function(e){var t=e[this.expando];return t||(t={},V(e)&&(
+e.nodeType?e[this.expando]=t:Object.defineProperty(e,this.expando,{value:t,configurable:!0}))),t},set:function(e,t,n){var i,o=this.cache(e);if(
+"string"==typeof t)o[U(t)]=n;else for(i in t)o[U(i)]=t[i];return o},get:function(e,t){return void 0===t?this.cache(e
+):e[this.expando]&&e[this.expando][U(t)]},access:function(e,t,n){return void 0===t||t&&"string"==typeof t&&void 0===n?this.get(e,t):(this.set(e,t,n),
+void 0!==n?n:t)},remove:function(e,t){var n,i=e[this.expando];if(void 0!==i){if(void 0!==t){n=(t=Array.isArray(t)?t.map(U):(t=U(t))in i?[t]:t.match(I
+)||[]).length;for(;n--;)delete i[t[n]]}(void 0===t||E.isEmptyObject(i))&&(e.nodeType?e[this.expando]=void 0:delete e[this.expando])}},
+hasData:function(e){var t=e[this.expando];return void 0!==t&&!E.isEmptyObject(t)}};var G=new X,K=new X,J=/^(?:\{[\w\W]*\}|\[[\w\W]*\])$/,Z=/[A-Z]/g
+;function ee(e,t,n){var i,o;if(void 0===n&&1===e.nodeType)if(i="data-"+t.replace(Z,"-$&").toLowerCase(),"string"==typeof(n=e.getAttribute(i))){try{
+n="true"===(o=n)||"false"!==o&&("null"===o?null:o===+o+""?+o:J.test(o)?JSON.parse(o):o)}catch(e){}K.set(e,t,n)}else n=void 0;return n}E.extend({
+hasData:function(e){return K.hasData(e)||G.hasData(e)},data:function(e,t,n){return K.access(e,t,n)},removeData:function(e,t){K.remove(e,t)},
+_data:function(e,t,n){return G.access(e,t,n)},_removeData:function(e,t){G.remove(e,t)}}),E.fn.extend({data:function(n,e){var t,i,o,r=this[0],
+a=r&&r.attributes;if(void 0!==n)return"object"==typeof n?this.each(function(){K.set(this,n)}):z(this,function(e){var t;if(r&&void 0===e
+)return void 0!==(t=K.get(r,n))?t:void 0!==(t=ee(r,n))?t:void 0;this.each(function(){K.set(this,n,e)})},null,e,1<arguments.length,null,!0);if(
+this.length&&(o=K.get(r),1===r.nodeType&&!G.get(r,"hasDataAttrs"))){for(t=a.length;t--;)a[t]&&0===(i=a[t].name).indexOf("data-")&&(i=U(i.slice(5)),ee(
+r,i,o[i]));G.set(r,"hasDataAttrs",!0)}return o},removeData:function(e){return this.each(function(){K.remove(this,e)})}}),E.extend({queue:function(e,t,
+n){var i;if(e)return t=(t||"fx")+"queue",i=G.get(e,t),n&&(!i||Array.isArray(n)?i=G.access(e,t,E.makeArray(n)):i.push(n)),i||[]},dequeue:function(e,t){
+t=t||"fx";var n=E.queue(e,t),i=n.length,o=n.shift(),r=E._queueHooks(e,t);"inprogress"===o&&(o=n.shift(),i--),o&&("fx"===t&&n.unshift("inprogress"),
+delete r.stop,o.call(e,function(){E.dequeue(e,t)},r)),!i&&r&&r.empty.fire()},_queueHooks:function(e,t){var n=t+"queueHooks";return G.get(e,n
+)||G.access(e,n,{empty:E.Callbacks("once memory").add(function(){G.remove(e,[t+"queue",n])})})}}),E.fn.extend({queue:function(t,n){var e=2
+;return"string"!=typeof t&&(n=t,t="fx",e--),arguments.length<e?E.queue(this[0],t):void 0===n?this:this.each(function(){var e=E.queue(this,t,n)
+;E._queueHooks(this,t),"fx"===t&&"inprogress"!==e[0]&&E.dequeue(this,t)})},dequeue:function(e){return this.each(function(){E.dequeue(this,e)})},
+clearQueue:function(e){return this.queue(e||"fx",[])},promise:function(e,t){var n,i=1,o=E.Deferred(),r=this,a=this.length,s=function(){
+--i||o.resolveWith(r,[r])};for("string"!=typeof e&&(t=e,e=void 0),e=e||"fx";a--;)(n=G.get(r[a],e+"queueHooks"))&&n.empty&&(i++,n.empty.add(s))
+;return s(),o.promise(t)}});var te=/[+-]?(?:\d*\.|)\d+(?:[eE][+-]?\d+|)/.source,ne=new RegExp("^(?:([+-])=|)("+te+")([a-z%]*)$","i"),ie=["Top","Right"
+,"Bottom","Left"],oe=function(e,t){return"none"===(e=t||e).style.display||""===e.style.display&&E.contains(e.ownerDocument,e)&&"none"===E.css(e,
+"display")},re=function(e,t,n,i){var o,r,a={};for(r in t)a[r]=e.style[r],e.style[r]=t[r];for(r in o=n.apply(e,i||[]),t)e.style[r]=a[r];return o}
+;function ae(e,t,n,i){var o,r,a=20,s=i?function(){return i.cur()}:function(){return E.css(e,t,"")},l=s(),c=n&&n[3]||(E.cssNumber[t]?"":"px"),u=(
+E.cssNumber[t]||"px"!==c&&+l)&&ne.exec(E.css(e,t));if(u&&u[3]!==c){for(l/=2,c=c||u[3],u=+l||1;a--;)E.style(e,t,u+c),(1-r)*(1-(r=s()/l||.5))<=0&&(a=0),
+u/=r;u*=2,E.style(e,t,u+c),n=n||[]}return n&&(u=+u||+l||0,o=n[1]?u+(n[1]+1)*n[2]:+n[2],i&&(i.unit=c,i.start=u,i.end=o)),o}var se={};function le(e,t){
+for(var n,i,o,r,a,s,l,c=[],u=0,d=e.length;u<d;u++)(i=e[u]).style&&(n=i.style.display,t?("none"===n&&(c[u]=G.get(i,"display")||null,c[u]||(
+i.style.display="")),""===i.style.display&&oe(i)&&(c[u]=(l=a=r=void 0,a=(o=i).ownerDocument,s=o.nodeName,(l=se[s])||(r=a.body.appendChild(
+a.createElement(s)),l=E.css(r,"display"),r.parentNode.removeChild(r),"none"===l&&(l="block"),se[s]=l)))):"none"!==n&&(c[u]="none",G.set(i,"display",n)
+));for(u=0;u<d;u++)null!=c[u]&&(e[u].style.display=c[u]);return e}E.fn.extend({show:function(){return le(this,!0)},hide:function(){return le(this)},
+toggle:function(e){return"boolean"==typeof e?e?this.show():this.hide():this.each(function(){oe(this)?E(this).show():E(this).hide()})}})
+;var ce=/^(?:checkbox|radio)$/i,ue=/<([a-z][^\/\0>\x20\t\r\n\f]+)/i,de=/^$|^module$|\/(?:java|ecma)script/i,he={option:[1,
+"<select multiple='multiple'>","</select>"],thead:[1,"<table>","</table>"],col:[2,"<table><colgroup>","</colgroup></table>"],tr:[2,"<table><tbody>",
+"</tbody></table>"],td:[3,"<table><tbody><tr>","</tr></tbody></table>"],_default:[0,"",""]};function pe(e,t){var n
+;return n=void 0!==e.getElementsByTagName?e.getElementsByTagName(t||"*"):void 0!==e.querySelectorAll?e.querySelectorAll(t||"*"):[],void 0===t||t&&S(e,
+t)?E.merge([e],n):n}function fe(e,t){for(var n=0,i=e.length;n<i;n++)G.set(e[n],"globalEval",!t||G.get(t[n],"globalEval"))}he.optgroup=he.option,
+he.tbody=he.tfoot=he.colgroup=he.caption=he.thead,he.th=he.td;var me,ge,ve=/<|&#?\w+;/;function ye(e,t,n,i,o){for(var r,a,s,l,c,u,
+d=t.createDocumentFragment(),h=[],p=0,f=e.length;p<f;p++)if((r=e[p])||0===r)if("object"===A(r))E.merge(h,r.nodeType?[r]:r);else if(ve.test(r)){for(
+a=a||d.appendChild(t.createElement("div")),s=(ue.exec(r)||["",""])[1].toLowerCase(),l=he[s]||he._default,a.innerHTML=l[1]+E.htmlPrefilter(r)+l[2],
+u=l[0];u--;)a=a.lastChild;E.merge(h,a.childNodes),(a=d.firstChild).textContent=""}else h.push(t.createTextNode(r));for(d.textContent="",p=0;r=h[p++];
+)if(i&&-1<E.inArray(r,i))o&&o.push(r);else if(c=E.contains(r.ownerDocument,r),a=pe(d.appendChild(r),"script"),c&&fe(a),n)for(u=0;r=a[u++];)de.test(
+r.type||"")&&n.push(r);return d}me=T.createDocumentFragment().appendChild(T.createElement("div")),(ge=T.createElement("input")).setAttribute("type",
+"radio"),ge.setAttribute("checked","checked"),ge.setAttribute("name","t"),me.appendChild(ge),v.checkClone=me.cloneNode(!0).cloneNode(!0
+).lastChild.checked,me.innerHTML="<textarea>x</textarea>",v.noCloneChecked=!!me.cloneNode(!0).lastChild.defaultValue;var be=T.documentElement,
+we=/^key/,Ae=/^(?:mouse|pointer|contextmenu|drag|drop)|click/,xe=/^([^.]*)(?:\.(.+)|)/;function ke(){return!0}function Te(){return!1}function Ee(){
+try{return T.activeElement}catch(e){}}function Ce(e,t,n,i,o,r){var a,s;if("object"==typeof t){for(s in"string"!=typeof n&&(i=i||n,n=void 0),t)Ce(e,s,n
+,i,t[s],r);return e}if(null==i&&null==o?(o=n,i=n=void 0):null==o&&("string"==typeof n?(o=i,i=void 0):(o=i,i=n,n=void 0)),!1===o)o=Te;else if(!o
+)return e;return 1===r&&(a=o,(o=function(e){return E().off(e),a.apply(this,arguments)}).guid=a.guid||(a.guid=E.guid++)),e.each(function(){E.event.add(
+this,t,o,i,n)})}E.event={global:{},add:function(t,e,n,i,o){var r,a,s,l,c,u,d,h,p,f,m,g=G.get(t);if(g)for(n.handler&&(n=(r=n).handler,o=r.selector),
+o&&E.find.matchesSelector(be,o),n.guid||(n.guid=E.guid++),(l=g.events)||(l=g.events={}),(a=g.handle)||(a=g.handle=function(e){
+return void 0!==E&&E.event.triggered!==e.type?E.event.dispatch.apply(t,arguments):void 0}),c=(e=(e||"").match(I)||[""]).length;c--;)p=m=(s=xe.exec(
+e[c])||[])[1],f=(s[2]||"").split(".").sort(),p&&(d=E.event.special[p]||{},p=(o?d.delegateType:d.bindType)||p,d=E.event.special[p]||{},u=E.extend({
+type:p,origType:m,data:i,handler:n,guid:n.guid,selector:o,needsContext:o&&E.expr.match.needsContext.test(o),namespace:f.join(".")},r),(h=l[p])||((
+h=l[p]=[]).delegateCount=0,d.setup&&!1!==d.setup.call(t,i,f,a)||t.addEventListener&&t.addEventListener(p,a)),d.add&&(d.add.call(t,u),u.handler.guid||(
+u.handler.guid=n.guid)),o?h.splice(h.delegateCount++,0,u):h.push(u),E.event.global[p]=!0)},remove:function(e,t,n,i,o){var r,a,s,l,c,u,d,h,p,f,m,
+g=G.hasData(e)&&G.get(e);if(g&&(l=g.events)){for(c=(t=(t||"").match(I)||[""]).length;c--;)if(p=m=(s=xe.exec(t[c])||[])[1],f=(s[2]||"").split("."
+).sort(),p){for(d=E.event.special[p]||{},h=l[p=(i?d.delegateType:d.bindType)||p]||[],s=s[2]&&new RegExp("(^|\\.)"+f.join("\\.(?:.*\\.|)")+"(\\.|$)"),
+a=r=h.length;r--;)u=h[r],!o&&m!==u.origType||n&&n.guid!==u.guid||s&&!s.test(u.namespace)||i&&i!==u.selector&&("**"!==i||!u.selector)||(h.splice(r,1),
+u.selector&&h.delegateCount--,d.remove&&d.remove.call(e,u));a&&!h.length&&(d.teardown&&!1!==d.teardown.call(e,f,g.handle)||E.removeEvent(e,p,g.handle)
+,delete l[p])}else for(p in l)E.event.remove(e,p+t[c],n,i,!0);E.isEmptyObject(l)&&G.remove(e,"handle events")}},dispatch:function(e){var t,n,i,o,r,a,
+s=E.event.fix(e),l=new Array(arguments.length),c=(G.get(this,"events")||{})[s.type]||[],u=E.event.special[s.type]||{};for(l[0]=s,
+t=1;t<arguments.length;t++)l[t]=arguments[t];if(s.delegateTarget=this,!u.preDispatch||!1!==u.preDispatch.call(this,s)){for(a=E.event.handlers.call(
+this,s,c),t=0;(o=a[t++])&&!s.isPropagationStopped();)for(s.currentTarget=o.elem,n=0;(r=o.handlers[n++])&&!s.isImmediatePropagationStopped();
+)s.rnamespace&&!s.rnamespace.test(r.namespace)||(s.handleObj=r,s.data=r.data,void 0!==(i=((E.event.special[r.origType]||{}).handle||r.handler).apply(
+o.elem,l))&&!1===(s.result=i)&&(s.preventDefault(),s.stopPropagation()));return u.postDispatch&&u.postDispatch.call(this,s),s.result}},
+handlers:function(e,t){var n,i,o,r,a,s=[],l=t.delegateCount,c=e.target;if(l&&c.nodeType&&!("click"===e.type&&1<=e.button))for(
+;c!==this;c=c.parentNode||this)if(1===c.nodeType&&("click"!==e.type||!0!==c.disabled)){for(r=[],a={},n=0;n<l;n++)void 0===a[o=(i=t[n]
+).selector+" "]&&(a[o]=i.needsContext?-1<E(o,this).index(c):E.find(o,this,null,[c]).length),a[o]&&r.push(i);r.length&&s.push({elem:c,handlers:r})}
+return c=this,l<t.length&&s.push({elem:c,handlers:t.slice(l)}),s},addProp:function(t,e){Object.defineProperty(E.Event.prototype,t,{enumerable:!0,
+configurable:!0,get:y(e)?function(){if(this.originalEvent)return e(this.originalEvent)}:function(){if(this.originalEvent)return this.originalEvent[t]
+},set:function(e){Object.defineProperty(this,t,{enumerable:!0,configurable:!0,writable:!0,value:e})}})},fix:function(e){
+return e[E.expando]?e:new E.Event(e)},special:{load:{noBubble:!0},focus:{trigger:function(){if(this!==Ee()&&this.focus)return this.focus(),!1},
+delegateType:"focusin"},blur:{trigger:function(){if(this===Ee()&&this.blur)return this.blur(),!1},delegateType:"focusout"},click:{trigger:function(){
+if("checkbox"===this.type&&this.click&&S(this,"input"))return this.click(),!1},_default:function(e){return S(e.target,"a")}},beforeunload:{
+postDispatch:function(e){void 0!==e.result&&e.originalEvent&&(e.originalEvent.returnValue=e.result)}}}},E.removeEvent=function(e,t,n){
+e.removeEventListener&&e.removeEventListener(t,n)},E.Event=function(e,t){if(!(this instanceof E.Event))return new E.Event(e,t);e&&e.type?(
+this.originalEvent=e,this.type=e.type,this.isDefaultPrevented=e.defaultPrevented||void 0===e.defaultPrevented&&!1===e.returnValue?ke:Te,
+this.target=e.target&&3===e.target.nodeType?e.target.parentNode:e.target,this.currentTarget=e.currentTarget,this.relatedTarget=e.relatedTarget
+):this.type=e,t&&E.extend(this,t),this.timeStamp=e&&e.timeStamp||Date.now(),this[E.expando]=!0},E.Event.prototype={constructor:E.Event,
+isDefaultPrevented:Te,isPropagationStopped:Te,isImmediatePropagationStopped:Te,isSimulated:!1,preventDefault:function(){var e=this.originalEvent
+;this.isDefaultPrevented=ke,e&&!this.isSimulated&&e.preventDefault()},stopPropagation:function(){var e=this.originalEvent;this.isPropagationStopped=ke
+,e&&!this.isSimulated&&e.stopPropagation()},stopImmediatePropagation:function(){var e=this.originalEvent;this.isImmediatePropagationStopped=ke,
+e&&!this.isSimulated&&e.stopImmediatePropagation(),this.stopPropagation()}},E.each({altKey:!0,bubbles:!0,cancelable:!0,changedTouches:!0,ctrlKey:!0,
+detail:!0,eventPhase:!0,metaKey:!0,pageX:!0,pageY:!0,shiftKey:!0,view:!0,char:!0,charCode:!0,key:!0,keyCode:!0,button:!0,buttons:!0,clientX:!0,
+clientY:!0,offsetX:!0,offsetY:!0,pointerId:!0,pointerType:!0,screenX:!0,screenY:!0,targetTouches:!0,toElement:!0,touches:!0,which:function(e){
+var t=e.button;return null==e.which&&we.test(e.type)?null!=e.charCode?e.charCode:e.keyCode:!e.which&&void 0!==t&&Ae.test(e.type
+)?1&t?1:2&t?3:4&t?2:0:e.which}},E.event.addProp),E.each({mouseenter:"mouseover",mouseleave:"mouseout",pointerenter:"pointerover",
+pointerleave:"pointerout"},function(e,o){E.event.special[e]={delegateType:o,bindType:o,handle:function(e){var t,n=e.relatedTarget,i=e.handleObj
+;return n&&(n===this||E.contains(this,n))||(e.type=i.origType,t=i.handler.apply(this,arguments),e.type=o),t}}}),E.fn.extend({on:function(e,t,n,i){
+return Ce(this,e,t,n,i)},one:function(e,t,n,i){return Ce(this,e,t,n,i,1)},off:function(e,t,n){var i,o;if(e&&e.preventDefault&&e.handleObj
+)return i=e.handleObj,E(e.delegateTarget).off(i.namespace?i.origType+"."+i.namespace:i.origType,i.selector,i.handler),this;if("object"!=typeof e
+)return!1!==t&&"function"!=typeof t||(n=t,t=void 0),!1===n&&(n=Te),this.each(function(){E.event.remove(this,e,n,t)});for(o in e)this.off(o,t,e[o])
+;return this}});var $e=/<(?!area|br|col|embed|hr|img|input|link|meta|param)(([a-z][^\/\0>\x20\t\r\n\f]*)[^>]*)\/>/gi,Se=/<script|<style|<link/i,
+_e=/checked\s*(?:[^=]|=\s*.checked.)/i,De=/^\s*<!(?:\[CDATA\[|--)|(?:\]\]|--)>\s*$/g;function je(e,t){return S(e,"table")&&S(
+11!==t.nodeType?t:t.firstChild,"tr")&&E(e).children("tbody")[0]||e}function Oe(e){return e.type=(null!==e.getAttribute("type"))+"/"+e.type,e}
+function Pe(e){return"true/"===(e.type||"").slice(0,5)?e.type=e.type.slice(5):e.removeAttribute("type"),e}function Ne(e,t){var n,i,o,r,a,s,l,c;if(
+1===t.nodeType){if(G.hasData(e)&&(r=G.access(e),a=G.set(t,r),c=r.events))for(o in delete a.handle,a.events={},c)for(n=0,i=c[o].length;n<i;n++
+)E.event.add(t,o,c[o][n]);K.hasData(e)&&(s=K.access(e),l=E.extend({},s),K.set(t,l))}}function Re(n,i,o,r){i=m.apply([],i);var e,t,a,s,l,c,u=0,
+d=n.length,h=d-1,p=i[0],f=y(p);if(f||1<d&&"string"==typeof p&&!v.checkClone&&_e.test(p))return n.each(function(e){var t=n.eq(e);f&&(i[0]=p.call(this,e
+,t.html())),Re(t,i,o,r)});if(d&&(t=(e=ye(i,n[0].ownerDocument,!1,n,r)).firstChild,1===e.childNodes.length&&(e=t),t||r)){for(s=(a=E.map(pe(e,"script"),
+Oe)).length;u<d;u++)l=e,u!==h&&(l=E.clone(l,!0,!0),s&&E.merge(a,pe(l,"script"))),o.call(n[u],l,u);if(s)for(c=a[a.length-1].ownerDocument,E.map(a,Pe),
+u=0;u<s;u++)l=a[u],de.test(l.type||"")&&!G.access(l,"globalEval")&&E.contains(c,l)&&(l.src&&"module"!==(l.type||"").toLowerCase(
+)?E._evalUrl&&E._evalUrl(l.src):w(l.textContent.replace(De,""),c,l))}return n}function Ie(e,t,n){for(var i,o=t?E.filter(t,e):e,r=0;null!=(i=o[r]);r++
+)n||1!==i.nodeType||E.cleanData(pe(i)),i.parentNode&&(n&&E.contains(i.ownerDocument,i)&&fe(pe(i,"script")),i.parentNode.removeChild(i));return e}
+E.extend({htmlPrefilter:function(e){return e.replace($e,"<$1></$2>")},clone:function(e,t,n){var i,o,r,a,s,l,c,u=e.cloneNode(!0),d=E.contains(
+e.ownerDocument,e);if(!(v.noCloneChecked||1!==e.nodeType&&11!==e.nodeType||E.isXMLDoc(e)))for(a=pe(u),i=0,o=(r=pe(e)).length;i<o;i++)s=r[i],l=a[i],
+void 0,"input"===(c=l.nodeName.toLowerCase())&&ce.test(s.type)?l.checked=s.checked:"input"!==c&&"textarea"!==c||(l.defaultValue=s.defaultValue);if(t
+)if(n)for(r=r||pe(e),a=a||pe(u),i=0,o=r.length;i<o;i++)Ne(r[i],a[i]);else Ne(e,u);return 0<(a=pe(u,"script")).length&&fe(a,!d&&pe(e,"script")),u},
+cleanData:function(e){for(var t,n,i,o=E.event.special,r=0;void 0!==(n=e[r]);r++)if(V(n)){if(t=n[G.expando]){if(t.events)for(i in t.events
+)o[i]?E.event.remove(n,i):E.removeEvent(n,i,t.handle);n[G.expando]=void 0}n[K.expando]&&(n[K.expando]=void 0)}}}),E.fn.extend({detach:function(e){
+return Ie(this,e,!0)},remove:function(e){return Ie(this,e)},text:function(e){return z(this,function(e){return void 0===e?E.text(this):this.empty(
+).each(function(){1!==this.nodeType&&11!==this.nodeType&&9!==this.nodeType||(this.textContent=e)})},null,e,arguments.length)},append:function(){
+return Re(this,arguments,function(e){1!==this.nodeType&&11!==this.nodeType&&9!==this.nodeType||je(this,e).appendChild(e)})},prepend:function(){
+return Re(this,arguments,function(e){if(1===this.nodeType||11===this.nodeType||9===this.nodeType){var t=je(this,e);t.insertBefore(e,t.firstChild)}})},
+before:function(){return Re(this,arguments,function(e){this.parentNode&&this.parentNode.insertBefore(e,this)})},after:function(){return Re(this,
+arguments,function(e){this.parentNode&&this.parentNode.insertBefore(e,this.nextSibling)})},empty:function(){for(var e,t=0;null!=(e=this[t]);t++
+)1===e.nodeType&&(E.cleanData(pe(e,!1)),e.textContent="");return this},clone:function(e,t){return e=null!=e&&e,t=null==t?e:t,this.map(function(){
+return E.clone(this,e,t)})},html:function(e){return z(this,function(e){var t=this[0]||{},n=0,i=this.length;if(void 0===e&&1===t.nodeType
+)return t.innerHTML;if("string"==typeof e&&!Se.test(e)&&!he[(ue.exec(e)||["",""])[1].toLowerCase()]){e=E.htmlPrefilter(e);try{for(;n<i;n++)1===(
+t=this[n]||{}).nodeType&&(E.cleanData(pe(t,!1)),t.innerHTML=e);t=0}catch(e){}}t&&this.empty().append(e)},null,e,arguments.length)},
+replaceWith:function(){var n=[];return Re(this,arguments,function(e){var t=this.parentNode;E.inArray(this,n)<0&&(E.cleanData(pe(this)),
+t&&t.replaceChild(e,this))},n)}}),E.each({appendTo:"append",prependTo:"prepend",insertBefore:"before",insertAfter:"after",replaceAll:"replaceWith"},
+function(e,a){E.fn[e]=function(e){for(var t,n=[],i=E(e),o=i.length-1,r=0;r<=o;r++)t=r===o?this:this.clone(!0),E(i[r])[a](t),l.apply(n,t.get())
+;return this.pushStack(n)}});var qe=new RegExp("^("+te+")(?!px)[a-z%]+$","i"),Le=function(e){var t=e.ownerDocument.defaultView;return t&&t.opener||(
+t=k),t.getComputedStyle(e)},Be=new RegExp(ie.join("|"),"i");function He(e,t,n){var i,o,r,a,s=e.style;return(n=n||Le(e))&&(""!==(a=n.getPropertyValue(t
+)||n[t])||E.contains(e.ownerDocument,e)||(a=E.style(e,t)),!v.pixelBoxStyles()&&qe.test(a)&&Be.test(t)&&(i=s.width,o=s.minWidth,r=s.maxWidth,
+s.minWidth=s.maxWidth=s.width=a,a=n.width,s.width=i,s.minWidth=o,s.maxWidth=r)),void 0!==a?a+"":a}function Me(e,t){return{get:function(){if(!e()
+)return(this.get=t).apply(this,arguments);delete this.get}}}!function(){function e(){if(l){
+s.style.cssText="position:absolute;left:-11111px;width:60px;margin-top:1px;padding:0;border:0",
+l.style.cssText="position:relative;display:block;box-sizing:border-box;overflow:scroll;margin:auto;border:1px;padding:1px;width:60%;top:1%",
+be.appendChild(s).appendChild(l);var e=k.getComputedStyle(l);n="1%"!==e.top,a=12===t(e.marginLeft),l.style.right="60%",r=36===t(e.right),i=36===t(
+e.width),l.style.position="absolute",o=36===l.offsetWidth||"absolute",be.removeChild(s),l=null}}function t(e){return Math.round(parseFloat(e))}var n,i
+,o,r,a,s=T.createElement("div"),l=T.createElement("div");l.style&&(l.style.backgroundClip="content-box",l.cloneNode(!0).style.backgroundClip="",
+v.clearCloneStyle="content-box"===l.style.backgroundClip,E.extend(v,{boxSizingReliable:function(){return e(),i},pixelBoxStyles:function(){return e(),r
+},pixelPosition:function(){return e(),n},reliableMarginLeft:function(){return e(),a},scrollboxSize:function(){return e(),o}}))}()
+;var Fe=/^(none|table(?!-c[ea]).+)/,ze=/^--/,We={position:"absolute",visibility:"hidden",display:"block"},Qe={letterSpacing:"0",fontWeight:"400"},Ye=[
+"Webkit","Moz","ms"],Ue=T.createElement("div").style;function Ve(e){var t=E.cssProps[e];return t||(t=E.cssProps[e]=function(e){if(e in Ue)return e
+;for(var t=e[0].toUpperCase()+e.slice(1),n=Ye.length;n--;)if((e=Ye[n]+t)in Ue)return e}(e)||e),t}function Xe(e,t,n){var i=ne.exec(t)
+;return i?Math.max(0,i[2]-(n||0))+(i[3]||"px"):t}function Ge(e,t,n,i,o,r){var a="width"===t?1:0,s=0,l=0;if(n===(i?"border":"content"))return 0;for(
+;a<4;a+=2)"margin"===n&&(l+=E.css(e,n+ie[a],!0,o)),i?("content"===n&&(l-=E.css(e,"padding"+ie[a],!0,o)),"margin"!==n&&(l-=E.css(e,
+"border"+ie[a]+"Width",!0,o))):(l+=E.css(e,"padding"+ie[a],!0,o),"padding"!==n?l+=E.css(e,"border"+ie[a]+"Width",!0,o):s+=E.css(e,
+"border"+ie[a]+"Width",!0,o));return!i&&0<=r&&(l+=Math.max(0,Math.ceil(e["offset"+t[0].toUpperCase()+t.slice(1)]-r-l-s-.5))),l}function Ke(e,t,n){
+var i=Le(e),o=He(e,t,i),r="border-box"===E.css(e,"boxSizing",!1,i),a=r;if(qe.test(o)){if(!n)return o;o="auto"}return a=a&&(v.boxSizingReliable(
+)||o===e.style[t]),("auto"===o||!parseFloat(o)&&"inline"===E.css(e,"display",!1,i))&&(o=e["offset"+t[0].toUpperCase()+t.slice(1)],a=!0),(o=parseFloat(
+o)||0)+Ge(e,t,n||(r?"border":"content"),a,i,o)+"px"}function Je(e,t,n,i,o){return new Je.prototype.init(e,t,n,i,o)}E.extend({cssHooks:{opacity:{
+get:function(e,t){if(t){var n=He(e,"opacity");return""===n?"1":n}}}},cssNumber:{animationIterationCount:!0,columnCount:!0,fillOpacity:!0,flexGrow:!0,
+flexShrink:!0,fontWeight:!0,lineHeight:!0,opacity:!0,order:!0,orphans:!0,widows:!0,zIndex:!0,zoom:!0},cssProps:{},style:function(e,t,n,i){if(
+e&&3!==e.nodeType&&8!==e.nodeType&&e.style){var o,r,a,s=U(t),l=ze.test(t),c=e.style;if(l||(t=Ve(s)),a=E.cssHooks[t]||E.cssHooks[s],void 0===n
+)return a&&"get"in a&&void 0!==(o=a.get(e,!1,i))?o:c[t];"string"===(r=typeof n)&&(o=ne.exec(n))&&o[1]&&(n=ae(e,t,o),r="number"),null!=n&&n==n&&(
+"number"===r&&(n+=o&&o[3]||(E.cssNumber[s]?"":"px")),v.clearCloneStyle||""!==n||0!==t.indexOf("background")||(c[t]="inherit"),a&&"set"in a&&void 0===(
+n=a.set(e,n,i))||(l?c.setProperty(t,n):c[t]=n))}},css:function(e,t,n,i){var o,r,a,s=U(t);return ze.test(t)||(t=Ve(s)),(a=E.cssHooks[t]||E.cssHooks[s]
+)&&"get"in a&&(o=a.get(e,!0,n)),void 0===o&&(o=He(e,t,i)),"normal"===o&&t in Qe&&(o=Qe[t]),""===n||n?(r=parseFloat(o),!0===n||isFinite(r)?r||0:o):o}})
+,E.each(["height","width"],function(e,s){E.cssHooks[s]={get:function(e,t,n){if(t)return!Fe.test(E.css(e,"display"))||e.getClientRects(
+).length&&e.getBoundingClientRect().width?Ke(e,s,n):re(e,We,function(){return Ke(e,s,n)})},set:function(e,t,n){var i,o=Le(e),r="border-box"===E.css(e,
+"boxSizing",!1,o),a=n&&Ge(e,s,n,r,o);return r&&v.scrollboxSize()===o.position&&(a-=Math.ceil(e["offset"+s[0].toUpperCase()+s.slice(1)]-parseFloat(o[s]
+)-Ge(e,s,"border",!1,o)-.5)),a&&(i=ne.exec(t))&&"px"!==(i[3]||"px")&&(e.style[s]=t,t=E.css(e,s)),Xe(0,t,a)}}}),E.cssHooks.marginLeft=Me(
+v.reliableMarginLeft,function(e,t){if(t)return(parseFloat(He(e,"marginLeft"))||e.getBoundingClientRect().left-re(e,{marginLeft:0},function(){
+return e.getBoundingClientRect().left}))+"px"}),E.each({margin:"",padding:"",border:"Width"},function(o,r){E.cssHooks[o+r]={expand:function(e){for(
+var t=0,n={},i="string"==typeof e?e.split(" "):[e];t<4;t++)n[o+ie[t]+r]=i[t]||i[t-2]||i[0];return n}},"margin"!==o&&(E.cssHooks[o+r].set=Xe)}),
+E.fn.extend({css:function(e,t){return z(this,function(e,t,n){var i,o,r={},a=0;if(Array.isArray(t)){for(i=Le(e),o=t.length;a<o;a++)r[t[a]]=E.css(e,t[a]
+,!1,i);return r}return void 0!==n?E.style(e,t,n):E.css(e,t)},e,t,1<arguments.length)}}),((E.Tween=Je).prototype={constructor:Je,init:function(e,t,n,i,
+o,r){this.elem=e,this.prop=n,this.easing=o||E.easing._default,this.options=t,this.start=this.now=this.cur(),this.end=i,this.unit=r||(
+E.cssNumber[n]?"":"px")},cur:function(){var e=Je.propHooks[this.prop];return e&&e.get?e.get(this):Je.propHooks._default.get(this)},run:function(e){
+var t,n=Je.propHooks[this.prop];return this.options.duration?this.pos=t=E.easing[this.easing](e,this.options.duration*e,0,1,this.options.duration
+):this.pos=t=e,this.now=(this.end-this.start)*t+this.start,this.options.step&&this.options.step.call(this.elem,this.now,this),n&&n.set?n.set(this
+):Je.propHooks._default.set(this),this}}).init.prototype=Je.prototype,(Je.propHooks={_default:{get:function(e){var t
+;return 1!==e.elem.nodeType||null!=e.elem[e.prop]&&null==e.elem.style[e.prop]?e.elem[e.prop]:(t=E.css(e.elem,e.prop,""))&&"auto"!==t?t:0},
+set:function(e){E.fx.step[e.prop]?E.fx.step[e.prop](e
+):1!==e.elem.nodeType||null==e.elem.style[E.cssProps[e.prop]]&&!E.cssHooks[e.prop]?e.elem[e.prop]=e.now:E.style(e.elem,e.prop,e.now+e.unit)}}}
+).scrollTop=Je.propHooks.scrollLeft={set:function(e){e.elem.nodeType&&e.elem.parentNode&&(e.elem[e.prop]=e.now)}},E.easing={linear:function(e){
+return e},swing:function(e){return.5-Math.cos(e*Math.PI)/2},_default:"swing"},E.fx=Je.prototype.init,E.fx.step={};var Ze,et,tt,nt,
+it=/^(?:toggle|show|hide)$/,ot=/queueHooks$/;function rt(){et&&(!1===T.hidden&&k.requestAnimationFrame?k.requestAnimationFrame(rt):k.setTimeout(rt,
+E.fx.interval),E.fx.tick())}function at(){return k.setTimeout(function(){Ze=void 0}),Ze=Date.now()}function st(e,t){var n,i=0,o={height:e};for(
+t=t?1:0;i<4;i+=2-t)o["margin"+(n=ie[i])]=o["padding"+n]=e;return t&&(o.opacity=o.width=e),o}function lt(e,t,n){for(var i,o=(ct.tweeners[t]||[]
+).concat(ct.tweeners["*"]),r=0,a=o.length;r<a;r++)if(i=o[r].call(n,t,e))return i}function ct(r,e,t){var n,a,i=0,o=ct.prefilters.length,s=E.Deferred(
+).always(function(){delete l.elem}),l=function(){if(a)return!1;for(var e=Ze||at(),t=Math.max(0,c.startTime+c.duration-e),n=1-(t/c.duration||0),i=0,
+o=c.tweens.length;i<o;i++)c.tweens[i].run(n);return s.notifyWith(r,[c,n,t]),n<1&&o?t:(o||s.notifyWith(r,[c,1,0]),s.resolveWith(r,[c]),!1)},
+c=s.promise({elem:r,props:E.extend({},e),opts:E.extend(!0,{specialEasing:{},easing:E.easing._default},t),originalProperties:e,originalOptions:t,
+startTime:Ze||at(),duration:t.duration,tweens:[],createTween:function(e,t){var n=E.Tween(r,c.opts,e,t,c.opts.specialEasing[e]||c.opts.easing)
+;return c.tweens.push(n),n},stop:function(e){var t=0,n=e?c.tweens.length:0;if(a)return this;for(a=!0;t<n;t++)c.tweens[t].run(1);return e?(
+s.notifyWith(r,[c,1,0]),s.resolveWith(r,[c,e])):s.rejectWith(r,[c,e]),this}}),u=c.props;for(!function(e,t){var n,i,o,r,a;for(n in e)if(o=t[i=U(n)],
+r=e[n],Array.isArray(r)&&(o=r[1],r=e[n]=r[0]),n!==i&&(e[i]=r,delete e[n]),(a=E.cssHooks[i])&&"expand"in a)for(n in r=a.expand(r),delete e[i],r
+)n in e||(e[n]=r[n],t[n]=o);else t[i]=o}(u,c.opts.specialEasing);i<o;i++)if(n=ct.prefilters[i].call(c,r,u,c.opts))return y(n.stop)&&(E._queueHooks(
+c.elem,c.opts.queue).stop=n.stop.bind(n)),n;return E.map(u,lt,c),y(c.opts.start)&&c.opts.start.call(r,c),c.progress(c.opts.progress).done(c.opts.done,
+c.opts.complete).fail(c.opts.fail).always(c.opts.always),E.fx.timer(E.extend(l,{elem:r,anim:c,queue:c.opts.queue})),c}E.Animation=E.extend(ct,{
+tweeners:{"*":[function(e,t){var n=this.createTween(e,t);return ae(n.elem,e,ne.exec(t),n),n}]},tweener:function(e,t){for(var n,i=0,o=(e=y(e)?(t=e,["*"
+]):e.match(I)).length;i<o;i++)n=e[i],ct.tweeners[n]=ct.tweeners[n]||[],ct.tweeners[n].unshift(t)},prefilters:[function(e,t,n){var i,o,r,a,s,l,c,u,
+d="width"in t||"height"in t,h=this,p={},f=e.style,m=e.nodeType&&oe(e),g=G.get(e,"fxshow");for(i in n.queue||(null==(a=E._queueHooks(e,"fx")
+).unqueued&&(a.unqueued=0,s=a.empty.fire,a.empty.fire=function(){a.unqueued||s()}),a.unqueued++,h.always(function(){h.always(function(){a.unqueued--,
+E.queue(e,"fx").length||a.empty.fire()})})),t)if(o=t[i],it.test(o)){if(delete t[i],r=r||"toggle"===o,o===(m?"hide":"show")){if(
+"show"!==o||!g||void 0===g[i])continue;m=!0}p[i]=g&&g[i]||E.style(e,i)}if((l=!E.isEmptyObject(t))||!E.isEmptyObject(p))for(i in d&&1===e.nodeType&&(
+n.overflow=[f.overflow,f.overflowX,f.overflowY],null==(c=g&&g.display)&&(c=G.get(e,"display")),"none"===(u=E.css(e,"display"))&&(c?u=c:(le([e],!0),
+c=e.style.display||c,u=E.css(e,"display"),le([e]))),("inline"===u||"inline-block"===u&&null!=c)&&"none"===E.css(e,"float")&&(l||(h.done(function(){
+f.display=c}),null==c&&(u=f.display,c="none"===u?"":u)),f.display="inline-block")),n.overflow&&(f.overflow="hidden",h.always(function(){
+f.overflow=n.overflow[0],f.overflowX=n.overflow[1],f.overflowY=n.overflow[2]})),l=!1,p)l||(g?"hidden"in g&&(m=g.hidden):g=G.access(e,"fxshow",{
+display:c}),r&&(g.hidden=!m),m&&le([e],!0),h.done(function(){for(i in m||le([e]),G.remove(e,"fxshow"),p)E.style(e,i,p[i])})),l=lt(m?g[i]:0,i,h),
+i in g||(g[i]=l.start,m&&(l.end=l.start,l.start=0))}],prefilter:function(e,t){t?ct.prefilters.unshift(e):ct.prefilters.push(e)}}),E.speed=function(e,t
+,n){var i=e&&"object"==typeof e?E.extend({},e):{complete:n||!n&&t||y(e)&&e,duration:e,easing:n&&t||t&&!y(t)&&t}
+;return E.fx.off?i.duration=0:"number"!=typeof i.duration&&(
+i.duration in E.fx.speeds?i.duration=E.fx.speeds[i.duration]:i.duration=E.fx.speeds._default),null!=i.queue&&!0!==i.queue||(i.queue="fx"),
+i.old=i.complete,i.complete=function(){y(i.old)&&i.old.call(this),i.queue&&E.dequeue(this,i.queue)},i},E.fn.extend({fadeTo:function(e,t,n,i){
+return this.filter(oe).css("opacity",0).show().end().animate({opacity:t},e,n,i)},animate:function(t,e,n,i){var o=E.isEmptyObject(t),r=E.speed(e,n,i),
+a=function(){var e=ct(this,E.extend({},t),r);(o||G.get(this,"finish"))&&e.stop(!0)};return a.finish=a,o||!1===r.queue?this.each(a):this.queue(r.queue,
+a)},stop:function(o,e,r){var a=function(e){var t=e.stop;delete e.stop,t(r)};return"string"!=typeof o&&(r=e,e=o,o=void 0),e&&!1!==o&&this.queue(o||"fx"
+,[]),this.each(function(){var e=!0,t=null!=o&&o+"queueHooks",n=E.timers,i=G.get(this);if(t)i[t]&&i[t].stop&&a(i[t]);else for(t in i
+)i[t]&&i[t].stop&&ot.test(t)&&a(i[t]);for(t=n.length;t--;)n[t].elem!==this||null!=o&&n[t].queue!==o||(n[t].anim.stop(r),e=!1,n.splice(t,1))
+;!e&&r||E.dequeue(this,o)})},finish:function(a){return!1!==a&&(a=a||"fx"),this.each(function(){var e,t=G.get(this),n=t[a+"queue"],i=t[a+"queueHooks"],
+o=E.timers,r=n?n.length:0;for(t.finish=!0,E.queue(this,a,[]),i&&i.stop&&i.stop.call(this,!0),e=o.length;e--;)o[e].elem===this&&o[e].queue===a&&(
+o[e].anim.stop(!0),o.splice(e,1));for(e=0;e<r;e++)n[e]&&n[e].finish&&n[e].finish.call(this);delete t.finish})}}),E.each(["toggle","show","hide"],
+function(e,i){var o=E.fn[i];E.fn[i]=function(e,t,n){return null==e||"boolean"==typeof e?o.apply(this,arguments):this.animate(st(i,!0),e,t,n)}}),
+E.each({slideDown:st("show"),slideUp:st("hide"),slideToggle:st("toggle"),fadeIn:{opacity:"show"},fadeOut:{opacity:"hide"},fadeToggle:{opacity:"toggle"
+}},function(e,i){E.fn[e]=function(e,t,n){return this.animate(i,e,t,n)}}),E.timers=[],E.fx.tick=function(){var e,t=0,n=E.timers;for(Ze=Date.now(
+);t<n.length;t++)(e=n[t])()||n[t]!==e||n.splice(t--,1);n.length||E.fx.stop(),Ze=void 0},E.fx.timer=function(e){E.timers.push(e),E.fx.start()},
+E.fx.interval=13,E.fx.start=function(){et||(et=!0,rt())},E.fx.stop=function(){et=null},E.fx.speeds={slow:600,fast:200,_default:400},
+E.fn.delay=function(i,e){return i=E.fx&&E.fx.speeds[i]||i,e=e||"fx",this.queue(e,function(e,t){var n=k.setTimeout(e,i);t.stop=function(){
+k.clearTimeout(n)}})},tt=T.createElement("input"),nt=T.createElement("select").appendChild(T.createElement("option")),tt.type="checkbox",
+v.checkOn=""!==tt.value,v.optSelected=nt.selected,(tt=T.createElement("input")).value="t",tt.type="radio",v.radioValue="t"===tt.value;var ut,
+dt=E.expr.attrHandle;E.fn.extend({attr:function(e,t){return z(this,E.attr,e,t,1<arguments.length)},removeAttr:function(e){return this.each(function(){
+E.removeAttr(this,e)})}}),E.extend({attr:function(e,t,n){var i,o,r=e.nodeType;if(3!==r&&8!==r&&2!==r)return void 0===e.getAttribute?E.prop(e,t,n):(
+1===r&&E.isXMLDoc(e)||(o=E.attrHooks[t.toLowerCase()]||(E.expr.match.bool.test(t)?ut:void 0)),void 0!==n?null===n?void E.removeAttr(e,t
+):o&&"set"in o&&void 0!==(i=o.set(e,n,t))?i:(e.setAttribute(t,n+""),n):o&&"get"in o&&null!==(i=o.get(e,t))?i:null==(i=E.find.attr(e,t))?void 0:i)},
+attrHooks:{type:{set:function(e,t){if(!v.radioValue&&"radio"===t&&S(e,"input")){var n=e.value;return e.setAttribute("type",t),n&&(e.value=n),t}}}},
+removeAttr:function(e,t){var n,i=0,o=t&&t.match(I);if(o&&1===e.nodeType)for(;n=o[i++];)e.removeAttribute(n)}}),ut={set:function(e,t,n){
+return!1===t?E.removeAttr(e,n):e.setAttribute(n,n),n}},E.each(E.expr.match.bool.source.match(/\w+/g),function(e,t){var a=dt[t]||E.find.attr
+;dt[t]=function(e,t,n){var i,o,r=t.toLowerCase();return n||(o=dt[r],dt[r]=i,i=null!=a(e,t,n)?r:null,dt[r]=o),i}})
+;var ht=/^(?:input|select|textarea|button)$/i,pt=/^(?:a|area)$/i;function ft(e){return(e.match(I)||[]).join(" ")}function mt(e){
+return e.getAttribute&&e.getAttribute("class")||""}function gt(e){return Array.isArray(e)?e:"string"==typeof e&&e.match(I)||[]}E.fn.extend({
+prop:function(e,t){return z(this,E.prop,e,t,1<arguments.length)},removeProp:function(e){return this.each(function(){delete this[E.propFix[e]||e]})}}),
+E.extend({prop:function(e,t,n){var i,o,r=e.nodeType;if(3!==r&&8!==r&&2!==r)return 1===r&&E.isXMLDoc(e)||(t=E.propFix[t]||t,o=E.propHooks[t]),
+void 0!==n?o&&"set"in o&&void 0!==(i=o.set(e,n,t))?i:e[t]=n:o&&"get"in o&&null!==(i=o.get(e,t))?i:e[t]},propHooks:{tabIndex:{get:function(e){
+var t=E.find.attr(e,"tabindex");return t?parseInt(t,10):ht.test(e.nodeName)||pt.test(e.nodeName)&&e.href?0:-1}}},propFix:{for:"htmlFor",
+class:"className"}}),v.optSelected||(E.propHooks.selected={get:function(e){var t=e.parentNode;return t&&t.parentNode&&t.parentNode.selectedIndex,null
+},set:function(e){var t=e.parentNode;t&&(t.selectedIndex,t.parentNode&&t.parentNode.selectedIndex)}}),E.each(["tabIndex","readOnly","maxLength",
+"cellSpacing","cellPadding","rowSpan","colSpan","useMap","frameBorder","contentEditable"],function(){E.propFix[this.toLowerCase()]=this}),E.fn.extend(
+{addClass:function(t){var e,n,i,o,r,a,s,l=0;if(y(t))return this.each(function(e){E(this).addClass(t.call(this,e,mt(this)))});if((e=gt(t)).length)for(
+;n=this[l++];)if(o=mt(n),i=1===n.nodeType&&" "+ft(o)+" "){for(a=0;r=e[a++];)i.indexOf(" "+r+" ")<0&&(i+=r+" ");o!==(s=ft(i))&&n.setAttribute("class",s
+)}return this},removeClass:function(t){var e,n,i,o,r,a,s,l=0;if(y(t))return this.each(function(e){E(this).removeClass(t.call(this,e,mt(this)))});if(
+!arguments.length)return this.attr("class","");if((e=gt(t)).length)for(;n=this[l++];)if(o=mt(n),i=1===n.nodeType&&" "+ft(o)+" "){for(a=0;r=e[a++];
+)for(;-1<i.indexOf(" "+r+" ");)i=i.replace(" "+r+" "," ");o!==(s=ft(i))&&n.setAttribute("class",s)}return this},toggleClass:function(o,t){
+var r=typeof o,a="string"===r||Array.isArray(o);return"boolean"==typeof t&&a?t?this.addClass(o):this.removeClass(o):y(o)?this.each(function(e){E(this
+).toggleClass(o.call(this,e,mt(this),t),t)}):this.each(function(){var e,t,n,i;if(a)for(t=0,n=E(this),i=gt(o);e=i[t++];)n.hasClass(e)?n.removeClass(e
+):n.addClass(e);else void 0!==o&&"boolean"!==r||((e=mt(this))&&G.set(this,"__className__",e),this.setAttribute&&this.setAttribute("class",
+e||!1===o?"":G.get(this,"__className__")||""))})},hasClass:function(e){var t,n,i=0;for(t=" "+e+" ";n=this[i++];)if(1===n.nodeType&&-1<(" "+ft(mt(n)
+)+" ").indexOf(t))return!0;return!1}});var vt=/\r/g;E.fn.extend({val:function(n){var i,e,o,t=this[0];return arguments.length?(o=y(n),this.each(
+function(e){var t;1===this.nodeType&&(null==(t=o?n.call(this,e,E(this).val()):n)?t="":"number"==typeof t?t+="":Array.isArray(t)&&(t=E.map(t,function(e
+){return null==e?"":e+""})),(i=E.valHooks[this.type]||E.valHooks[this.nodeName.toLowerCase()])&&"set"in i&&void 0!==i.set(this,t,"value")||(
+this.value=t))})):t?(i=E.valHooks[t.type]||E.valHooks[t.nodeName.toLowerCase()])&&"get"in i&&void 0!==(e=i.get(t,"value"))?e:"string"==typeof(
+e=t.value)?e.replace(vt,""):null==e?"":e:void 0}}),E.extend({valHooks:{option:{get:function(e){var t=E.find.attr(e,"value");return null!=t?t:ft(
+E.text(e))}},select:{get:function(e){var t,n,i,o=e.options,r=e.selectedIndex,a="select-one"===e.type,s=a?null:[],l=a?r+1:o.length;for(
+i=r<0?l:a?r:0;i<l;i++)if(((n=o[i]).selected||i===r)&&!n.disabled&&(!n.parentNode.disabled||!S(n.parentNode,"optgroup"))){if(t=E(n).val(),a)return t
+;s.push(t)}return s},set:function(e,t){for(var n,i,o=e.options,r=E.makeArray(t),a=o.length;a--;)((i=o[a]).selected=-1<E.inArray(E.valHooks.option.get(
+i),r))&&(n=!0);return n||(e.selectedIndex=-1),r}}}}),E.each(["radio","checkbox"],function(){E.valHooks[this]={set:function(e,t){if(Array.isArray(t)
+)return e.checked=-1<E.inArray(E(e).val(),t)}},v.checkOn||(E.valHooks[this].get=function(e){return null===e.getAttribute("value")?"on":e.value})}),
+v.focusin="onfocusin"in k;var yt=/^(?:focusinfocus|focusoutblur)$/,bt=function(e){e.stopPropagation()};E.extend(E.event,{trigger:function(e,t,n,i){
+var o,r,a,s,l,c,u,d,h=[n||T],p=g.call(e,"type")?e.type:e,f=g.call(e,"namespace")?e.namespace.split("."):[];if(r=d=a=n=n||T,
+3!==n.nodeType&&8!==n.nodeType&&!yt.test(p+E.event.triggered)&&(-1<p.indexOf(".")&&(p=(f=p.split(".")).shift(),f.sort()),l=p.indexOf(":")<0&&"on"+p,(
+e=e[E.expando]?e:new E.Event(p,"object"==typeof e&&e)).isTrigger=i?2:3,e.namespace=f.join("."),e.rnamespace=e.namespace?new RegExp("(^|\\.)"+f.join(
+"\\.(?:.*\\.|)")+"(\\.|$)"):null,e.result=void 0,e.target||(e.target=n),t=null==t?[e]:E.makeArray(t,[e]),u=E.event.special[p]||{},
+i||!u.trigger||!1!==u.trigger.apply(n,t))){if(!i&&!u.noBubble&&!b(n)){for(s=u.delegateType||p,yt.test(s+p)||(r=r.parentNode);r;r=r.parentNode)h.push(r
+),a=r;a===(n.ownerDocument||T)&&h.push(a.defaultView||a.parentWindow||k)}for(o=0;(r=h[o++])&&!e.isPropagationStopped();)d=r,e.type=1<o?s:u.bindType||p
+,(c=(G.get(r,"events")||{})[e.type]&&G.get(r,"handle"))&&c.apply(r,t),(c=l&&r[l])&&c.apply&&V(r)&&(e.result=c.apply(r,t),
+!1===e.result&&e.preventDefault());return e.type=p,i||e.isDefaultPrevented()||u._default&&!1!==u._default.apply(h.pop(),t)||!V(n)||l&&y(n[p])&&!b(n
+)&&((a=n[l])&&(n[l]=null),E.event.triggered=p,e.isPropagationStopped()&&d.addEventListener(p,bt),n[p](),e.isPropagationStopped(
+)&&d.removeEventListener(p,bt),E.event.triggered=void 0,a&&(n[l]=a)),e.result}},simulate:function(e,t,n){var i=E.extend(new E.Event,n,{type:e,
+isSimulated:!0});E.event.trigger(i,null,t)}}),E.fn.extend({trigger:function(e,t){return this.each(function(){E.event.trigger(e,t,this)})},
+triggerHandler:function(e,t){var n=this[0];if(n)return E.event.trigger(e,t,n,!0)}}),v.focusin||E.each({focus:"focusin",blur:"focusout"},function(n,i){
+var o=function(e){E.event.simulate(i,e.target,E.event.fix(e))};E.event.special[i]={setup:function(){var e=this.ownerDocument||this,t=G.access(e,i)
+;t||e.addEventListener(n,o,!0),G.access(e,i,(t||0)+1)},teardown:function(){var e=this.ownerDocument||this,t=G.access(e,i)-1;t?G.access(e,i,t):(
+e.removeEventListener(n,o,!0),G.remove(e,i))}}});var wt=k.location,At=Date.now(),xt=/\?/;E.parseXML=function(e){var t;if(!e||"string"!=typeof e
+)return null;try{t=(new k.DOMParser).parseFromString(e,"text/xml")}catch(e){t=void 0}return t&&!t.getElementsByTagName("parsererror").length||E.error(
+"Invalid XML: "+e),t};var kt=/\[\]$/,Tt=/\r?\n/g,Et=/^(?:submit|button|image|reset|file)$/i,Ct=/^(?:input|select|textarea|keygen)/i;function $t(n,e,i,
+o){var t;if(Array.isArray(e))E.each(e,function(e,t){i||kt.test(n)?o(n,t):$t(n+"["+("object"==typeof t&&null!=t?e:"")+"]",t,i,o)});else if(
+i||"object"!==A(e))o(n,e);else for(t in e)$t(n+"["+t+"]",e[t],i,o)}E.param=function(e,t){var n,i=[],o=function(e,t){var n=y(t)?t():t
+;i[i.length]=encodeURIComponent(e)+"="+encodeURIComponent(null==n?"":n)};if(Array.isArray(e)||e.jquery&&!E.isPlainObject(e))E.each(e,function(){o(
+this.name,this.value)});else for(n in e)$t(n,e[n],t,o);return i.join("&")},E.fn.extend({serialize:function(){return E.param(this.serializeArray())},
+serializeArray:function(){return this.map(function(){var e=E.prop(this,"elements");return e?E.makeArray(e):this}).filter(function(){var e=this.type
+;return this.name&&!E(this).is(":disabled")&&Ct.test(this.nodeName)&&!Et.test(e)&&(this.checked||!ce.test(e))}).map(function(e,t){var n=E(this).val()
+;return null==n?null:Array.isArray(n)?E.map(n,function(e){return{name:t.name,value:e.replace(Tt,"\r\n")}}):{name:t.name,value:n.replace(Tt,"\r\n")}}
+).get()}});var St=/%20/g,_t=/#.*$/,Dt=/([?&])_=[^&]*/,jt=/^(.*?):[ \t]*([^\r\n]*)$/gm,Ot=/^(?:GET|HEAD)$/,Pt=/^\/\//,Nt={},Rt={},It="*/".concat("*"),
+qt=T.createElement("a");function Lt(r){return function(e,t){"string"!=typeof e&&(t=e,e="*");var n,i=0,o=e.toLowerCase().match(I)||[];if(y(t))for(
+;n=o[i++];)"+"===n[0]?(n=n.slice(1)||"*",(r[n]=r[n]||[]).unshift(t)):(r[n]=r[n]||[]).push(t)}}function Bt(t,o,r,a){var s={},l=t===Rt;function c(e){
+var i;return s[e]=!0,E.each(t[e]||[],function(e,t){var n=t(o,r,a);return"string"!=typeof n||l||s[n]?l?!(i=n):void 0:(o.dataTypes.unshift(n),c(n),!1)})
+,i}return c(o.dataTypes[0])||!s["*"]&&c("*")}function Ht(e,t){var n,i,o=E.ajaxSettings.flatOptions||{};for(n in t)void 0!==t[n]&&((o[n]?e:i||(i={})
+)[n]=t[n]);return i&&E.extend(!0,e,i),e}qt.href=wt.href,E.extend({active:0,lastModified:{},etag:{},ajaxSettings:{url:wt.href,type:"GET",
+isLocal:/^(?:about|app|app-storage|.+-extension|file|res|widget):$/.test(wt.protocol),global:!0,processData:!0,async:!0,
+contentType:"application/x-www-form-urlencoded; charset=UTF-8",accepts:{"*":It,text:"text/plain",html:"text/html",xml:"application/xml, text/xml",
+json:"application/json, text/javascript"},contents:{xml:/\bxml\b/,html:/\bhtml/,json:/\bjson\b/},responseFields:{xml:"responseXML",
+text:"responseText",json:"responseJSON"},converters:{"* text":String,"text html":!0,"text json":JSON.parse,"text xml":E.parseXML},flatOptions:{url:!0,
+context:!0}},ajaxSetup:function(e,t){return t?Ht(Ht(e,E.ajaxSettings),t):Ht(E.ajaxSettings,e)},ajaxPrefilter:Lt(Nt),ajaxTransport:Lt(Rt),
+ajax:function(e,t){"object"==typeof e&&(t=e,e=void 0),t=t||{};var u,d,h,n,p,i,f,m,o,r,g=E.ajaxSetup({},t),v=g.context||g,y=g.context&&(
+v.nodeType||v.jquery)?E(v):E.event,b=E.Deferred(),w=E.Callbacks("once memory"),A=g.statusCode||{},a={},s={},l="canceled",x={readyState:0,
+getResponseHeader:function(e){var t;if(f){if(!n)for(n={};t=jt.exec(h);)n[t[1].toLowerCase()]=t[2];t=n[e.toLowerCase()]}return null==t?null:t},
+getAllResponseHeaders:function(){return f?h:null},setRequestHeader:function(e,t){return null==f&&(e=s[e.toLowerCase()]=s[e.toLowerCase()]||e,a[e]=t),
+this},overrideMimeType:function(e){return null==f&&(g.mimeType=e),this},statusCode:function(e){var t;if(e)if(f)x.always(e[x.status]);else for(t in e
+)A[t]=[A[t],e[t]];return this},abort:function(e){var t=e||l;return u&&u.abort(t),c(0,t),this}};if(b.promise(x),g.url=((e||g.url||wt.href)+"").replace(
+Pt,wt.protocol+"//"),g.type=t.method||t.type||g.method||g.type,g.dataTypes=(g.dataType||"*").toLowerCase().match(I)||[""],null==g.crossDomain){
+i=T.createElement("a");try{i.href=g.url,i.href=i.href,g.crossDomain=qt.protocol+"//"+qt.host!=i.protocol+"//"+i.host}catch(e){g.crossDomain=!0}}if(
+g.data&&g.processData&&"string"!=typeof g.data&&(g.data=E.param(g.data,g.traditional)),Bt(Nt,g,t,x),f)return x;for(o in(m=E.event&&g.global
+)&&0==E.active++&&E.event.trigger("ajaxStart"),g.type=g.type.toUpperCase(),g.hasContent=!Ot.test(g.type),d=g.url.replace(_t,""),
+g.hasContent?g.data&&g.processData&&0===(g.contentType||"").indexOf("application/x-www-form-urlencoded")&&(g.data=g.data.replace(St,"+")):(
+r=g.url.slice(d.length),g.data&&(g.processData||"string"==typeof g.data)&&(d+=(xt.test(d)?"&":"?")+g.data,delete g.data),!1===g.cache&&(d=d.replace(Dt
+,"$1"),r=(xt.test(d)?"&":"?")+"_="+At+++r),g.url=d+r),g.ifModified&&(E.lastModified[d]&&x.setRequestHeader("If-Modified-Since",E.lastModified[d]),
+E.etag[d]&&x.setRequestHeader("If-None-Match",E.etag[d])),(g.data&&g.hasContent&&!1!==g.contentType||t.contentType)&&x.setRequestHeader("Content-Type"
+,g.contentType),x.setRequestHeader("Accept",g.dataTypes[0]&&g.accepts[g.dataTypes[0]]?g.accepts[g.dataTypes[0]]+(
+"*"!==g.dataTypes[0]?", "+It+"; q=0.01":""):g.accepts["*"]),g.headers)x.setRequestHeader(o,g.headers[o]);if(g.beforeSend&&(!1===g.beforeSend.call(v,x,
+g)||f))return x.abort();if(l="abort",w.add(g.complete),x.done(g.success),x.fail(g.error),u=Bt(Rt,g,t,x)){if(x.readyState=1,m&&y.trigger("ajaxSend",[x,
+g]),f)return x;g.async&&0<g.timeout&&(p=k.setTimeout(function(){x.abort("timeout")},g.timeout));try{f=!1,u.send(a,c)}catch(e){if(f)throw e;c(-1,e)}
+}else c(-1,"No Transport");function c(e,t,n,i){var o,r,a,s,l,c=t;f||(f=!0,p&&k.clearTimeout(p),u=void 0,h=i||"",x.readyState=0<e?4:0,
+o=200<=e&&e<300||304===e,n&&(s=function(e,t,n){for(var i,o,r,a,s=e.contents,l=e.dataTypes;"*"===l[0];)l.shift(),void 0===i&&(
+i=e.mimeType||t.getResponseHeader("Content-Type"));if(i)for(o in s)if(s[o]&&s[o].test(i)){l.unshift(o);break}if(l[0]in n)r=l[0];else{for(o in n){if(
+!l[0]||e.converters[o+" "+l[0]]){r=o;break}a||(a=o)}r=r||a}if(r)return r!==l[0]&&l.unshift(r),n[r]}(g,x,n)),s=function(e,t,n,i){var o,r,a,s,l,c={},
+u=e.dataTypes.slice();if(u[1])for(a in e.converters)c[a.toLowerCase()]=e.converters[a];for(r=u.shift();r;)if(e.responseFields[r]&&(
+n[e.responseFields[r]]=t),!l&&i&&e.dataFilter&&(t=e.dataFilter(t,e.dataType)),l=r,r=u.shift())if("*"===r)r=l;else if("*"!==l&&l!==r){if(!(
+a=c[l+" "+r]||c["* "+r]))for(o in c)if((s=o.split(" "))[1]===r&&(a=c[l+" "+s[0]]||c["* "+s[0]])){!0===a?a=c[o]:!0!==c[o]&&(r=s[0],u.unshift(s[1]))
+;break}if(!0!==a)if(a&&e.throws)t=a(t);else try{t=a(t)}catch(e){return{state:"parsererror",error:a?e:"No conversion from "+l+" to "+r}}}return{
+state:"success",data:t}}(g,s,x,o),o?(g.ifModified&&((l=x.getResponseHeader("Last-Modified"))&&(E.lastModified[d]=l),(l=x.getResponseHeader("etag"))&&(
+E.etag[d]=l)),204===e||"HEAD"===g.type?c="nocontent":304===e?c="notmodified":(c=s.state,r=s.data,o=!(a=s.error))):(a=c,!e&&c||(c="error",e<0&&(e=0))),
+x.status=e,x.statusText=(t||c)+"",o?b.resolveWith(v,[r,c,x]):b.rejectWith(v,[x,c,a]),x.statusCode(A),A=void 0,m&&y.trigger(o?"ajaxSuccess":"ajaxError"
+,[x,g,o?r:a]),w.fireWith(v,[x,c]),m&&(y.trigger("ajaxComplete",[x,g]),--E.active||E.event.trigger("ajaxStop")))}return x},getJSON:function(e,t,n){
+return E.get(e,t,n,"json")},getScript:function(e,t){return E.get(e,void 0,t,"script")}}),E.each(["get","post"],function(e,o){E[o]=function(e,t,n,i){
+return y(t)&&(i=i||n,n=t,t=void 0),E.ajax(E.extend({url:e,type:o,dataType:i,data:t,success:n},E.isPlainObject(e)&&e))}}),E._evalUrl=function(e){
+return E.ajax({url:e,type:"GET",dataType:"script",cache:!0,async:!1,global:!1,throws:!0})},E.fn.extend({wrapAll:function(e){var t;return this[0]&&(y(e
+)&&(e=e.call(this[0])),t=E(e,this[0].ownerDocument).eq(0).clone(!0),this[0].parentNode&&t.insertBefore(this[0]),t.map(function(){for(
+var e=this;e.firstElementChild;)e=e.firstElementChild;return e}).append(this)),this},wrapInner:function(n){return y(n)?this.each(function(e){E(this
+).wrapInner(n.call(this,e))}):this.each(function(){var e=E(this),t=e.contents();t.length?t.wrapAll(n):e.append(n)})},wrap:function(t){var n=y(t)
+;return this.each(function(e){E(this).wrapAll(n?t.call(this,e):t)})},unwrap:function(e){return this.parent(e).not("body").each(function(){E(this
+).replaceWith(this.childNodes)}),this}}),E.expr.pseudos.hidden=function(e){return!E.expr.pseudos.visible(e)},E.expr.pseudos.visible=function(e){
+return!!(e.offsetWidth||e.offsetHeight||e.getClientRects().length)},E.ajaxSettings.xhr=function(){try{return new k.XMLHttpRequest}catch(e){}};var Mt={
+0:200,1223:204},Ft=E.ajaxSettings.xhr();v.cors=!!Ft&&"withCredentials"in Ft,v.ajax=Ft=!!Ft,E.ajaxTransport(function(o){var r,a;if(
+v.cors||Ft&&!o.crossDomain)return{send:function(e,t){var n,i=o.xhr();if(i.open(o.type,o.url,o.async,o.username,o.password),o.xhrFields)for(
+n in o.xhrFields)i[n]=o.xhrFields[n];for(n in o.mimeType&&i.overrideMimeType&&i.overrideMimeType(o.mimeType),o.crossDomain||e["X-Requested-With"]||(
+e["X-Requested-With"]="XMLHttpRequest"),e)i.setRequestHeader(n,e[n]);r=function(e){return function(){r&&(
+r=a=i.onload=i.onerror=i.onabort=i.ontimeout=i.onreadystatechange=null,"abort"===e?i.abort():"error"===e?"number"!=typeof i.status?t(0,"error"):t(
+i.status,i.statusText):t(Mt[i.status]||i.status,i.statusText,"text"!==(i.responseType||"text")||"string"!=typeof i.responseText?{binary:i.response}:{
+text:i.responseText},i.getAllResponseHeaders()))}},i.onload=r(),a=i.onerror=i.ontimeout=r("error"),
+void 0!==i.onabort?i.onabort=a:i.onreadystatechange=function(){4===i.readyState&&k.setTimeout(function(){r&&a()})},r=r("abort");try{i.send(
+o.hasContent&&o.data||null)}catch(e){if(r)throw e}},abort:function(){r&&r()}}}),E.ajaxPrefilter(function(e){e.crossDomain&&(e.contents.script=!1)}),
+E.ajaxSetup({accepts:{script:"text/javascript, application/javascript, application/ecmascript, application/x-ecmascript"},contents:{
+script:/\b(?:java|ecma)script\b/},converters:{"text script":function(e){return E.globalEval(e),e}}}),E.ajaxPrefilter("script",function(e){
+void 0===e.cache&&(e.cache=!1),e.crossDomain&&(e.type="GET")}),E.ajaxTransport("script",function(n){var i,o;if(n.crossDomain)return{send:function(e,t
+){i=E("<script>").prop({charset:n.scriptCharset,src:n.url}).on("load error",o=function(e){i.remove(),o=null,e&&t("error"===e.type?404:200,e.type)}),
+T.head.appendChild(i[0])},abort:function(){o&&o()}}});var zt,Wt=[],Qt=/(=)\?(?=&|$)|\?\?/;E.ajaxSetup({jsonp:"callback",jsonpCallback:function(){
+var e=Wt.pop()||E.expando+"_"+At++;return this[e]=!0,e}}),E.ajaxPrefilter("json jsonp",function(e,t,n){var i,o,r,a=!1!==e.jsonp&&(Qt.test(e.url
+)?"url":"string"==typeof e.data&&0===(e.contentType||"").indexOf("application/x-www-form-urlencoded")&&Qt.test(e.data)&&"data");if(
+a||"jsonp"===e.dataTypes[0])return i=e.jsonpCallback=y(e.jsonpCallback)?e.jsonpCallback():e.jsonpCallback,a?e[a]=e[a].replace(Qt,"$1"+i
+):!1!==e.jsonp&&(e.url+=(xt.test(e.url)?"&":"?")+e.jsonp+"="+i),e.converters["script json"]=function(){return r||E.error(i+" was not called"),r[0]},
+e.dataTypes[0]="json",o=k[i],k[i]=function(){r=arguments},n.always(function(){void 0===o?E(k).removeProp(i):k[i]=o,e[i]&&(
+e.jsonpCallback=t.jsonpCallback,Wt.push(i)),r&&y(o)&&o(r[0]),r=o=void 0}),"script"}),v.createHTMLDocument=((zt=T.implementation.createHTMLDocument(""
+).body).innerHTML="<form></form><form></form>",2===zt.childNodes.length),E.parseHTML=function(e,t,n){return"string"!=typeof e?[]:(
+"boolean"==typeof t&&(n=t,t=!1),t||(v.createHTMLDocument?((i=(t=T.implementation.createHTMLDocument("")).createElement("base")).href=T.location.href,
+t.head.appendChild(i)):t=T),r=!n&&[],(o=_.exec(e))?[t.createElement(o[1])]:(o=ye([e],t,r),r&&r.length&&E(r).remove(),E.merge([],o.childNodes)));var i,
+o,r},E.fn.load=function(e,t,n){var i,o,r,a=this,s=e.indexOf(" ");return-1<s&&(i=ft(e.slice(s)),e=e.slice(0,s)),y(t)?(n=t,t=void 0
+):t&&"object"==typeof t&&(o="POST"),0<a.length&&E.ajax({url:e,type:o||"GET",dataType:"html",data:t}).done(function(e){r=arguments,a.html(i?E("<div>"
+).append(E.parseHTML(e)).find(i):e)}).always(n&&function(e,t){a.each(function(){n.apply(this,r||[e.responseText,t,e])})}),this},E.each(["ajaxStart",
+"ajaxStop","ajaxComplete","ajaxError","ajaxSuccess","ajaxSend"],function(e,t){E.fn[t]=function(e){return this.on(t,e)}}),
+E.expr.pseudos.animated=function(t){return E.grep(E.timers,function(e){return t===e.elem}).length},E.offset={setOffset:function(e,t,n){var i,o,r,a,s,l
+,c=E.css(e,"position"),u=E(e),d={};"static"===c&&(e.style.position="relative"),s=u.offset(),r=E.css(e,"top"),l=E.css(e,"left"),o=(
+"absolute"===c||"fixed"===c)&&-1<(r+l).indexOf("auto")?(a=(i=u.position()).top,i.left):(a=parseFloat(r)||0,parseFloat(l)||0),y(t)&&(t=t.call(e,n,
+E.extend({},s))),null!=t.top&&(d.top=t.top-s.top+a),null!=t.left&&(d.left=t.left-s.left+o),"using"in t?t.using.call(e,d):u.css(d)}},E.fn.extend({
+offset:function(t){if(arguments.length)return void 0===t?this:this.each(function(e){E.offset.setOffset(this,t,e)});var e,n,i=this[0]
+;return i?i.getClientRects().length?(e=i.getBoundingClientRect(),n=i.ownerDocument.defaultView,{top:e.top+n.pageYOffset,left:e.left+n.pageXOffset}):{
+top:0,left:0}:void 0},position:function(){if(this[0]){var e,t,n,i=this[0],o={top:0,left:0};if("fixed"===E.css(i,"position"))t=i.getBoundingClientRect(
+);else{for(t=this.offset(),n=i.ownerDocument,e=i.offsetParent||n.documentElement;e&&(e===n.body||e===n.documentElement)&&"static"===E.css(e,"position"
+);)e=e.parentNode;e&&e!==i&&1===e.nodeType&&((o=E(e).offset()).top+=E.css(e,"borderTopWidth",!0),o.left+=E.css(e,"borderLeftWidth",!0))}return{
+top:t.top-o.top-E.css(i,"marginTop",!0),left:t.left-o.left-E.css(i,"marginLeft",!0)}}},offsetParent:function(){return this.map(function(){for(
+var e=this.offsetParent;e&&"static"===E.css(e,"position");)e=e.offsetParent;return e||be})}}),E.each({scrollLeft:"pageXOffset",scrollTop:"pageYOffset"
+},function(t,o){var r="pageYOffset"===o;E.fn[t]=function(e){return z(this,function(e,t,n){var i;if(b(e)?i=e:9===e.nodeType&&(i=e.defaultView),
+void 0===n)return i?i[o]:e[t];i?i.scrollTo(r?i.pageXOffset:n,r?n:i.pageYOffset):e[t]=n},t,e,arguments.length)}}),E.each(["top","left"],function(e,n){
+E.cssHooks[n]=Me(v.pixelPosition,function(e,t){if(t)return t=He(e,n),qe.test(t)?E(e).position()[n]+"px":t})}),E.each({Height:"height",Width:"width"},
+function(a,s){E.each({padding:"inner"+a,content:s,"":"outer"+a},function(i,r){E.fn[r]=function(e,t){var n=arguments.length&&(i||"boolean"!=typeof e),
+o=i||(!0===e||!0===t?"margin":"border");return z(this,function(e,t,n){var i;return b(e)?0===r.indexOf("outer"
+)?e["inner"+a]:e.document.documentElement["client"+a]:9===e.nodeType?(i=e.documentElement,Math.max(e.body["scroll"+a],i["scroll"+a],e.body["offset"+a]
+,i["offset"+a],i["client"+a])):void 0===n?E.css(e,t,o):E.style(e,t,n,o)},s,n?e:void 0,n)}})}),E.each(
+"blur focus focusin focusout resize scroll click dblclick mousedown mouseup mousemove mouseover mouseout mouseenter mouseleave change select submit keydown keypress keyup contextmenu".split(
+" "),function(e,n){E.fn[n]=function(e,t){return 0<arguments.length?this.on(n,null,e,t):this.trigger(n)}}),E.fn.extend({hover:function(e,t){
+return this.mouseenter(e).mouseleave(t||e)}}),E.fn.extend({bind:function(e,t,n){return this.on(e,null,t,n)},unbind:function(e,t){return this.off(e,
+null,t)},delegate:function(e,t,n,i){return this.on(t,e,n,i)},undelegate:function(e,t,n){return 1===arguments.length?this.off(e,"**"):this.off(t,
+e||"**",n)}}),E.proxy=function(e,t){var n,i,o;if("string"==typeof t&&(n=e[t],t=e,e=n),y(e))return i=s.call(arguments,2),(o=function(){return e.apply(
+t||this,i.concat(s.call(arguments)))}).guid=e.guid=e.guid||E.guid++,o},E.holdReady=function(e){e?E.readyWait++:E.ready(!0)},E.isArray=Array.isArray,
+E.parseJSON=JSON.parse,E.nodeName=S,E.isFunction=y,E.isWindow=b,E.camelCase=U,E.type=A,E.now=Date.now,E.isNumeric=function(e){var t=E.type(e);return(
+"number"===t||"string"===t)&&!isNaN(e-parseFloat(e))},"function"==typeof define&&define.amd&&define("jquery",[],function(){return E});var Yt=k.jQuery,
+Ut=k.$;return E.noConflict=function(e){return k.$===E&&(k.$=Ut),e&&k.jQuery===E&&(k.jQuery=Yt),E},e||(k.jQuery=k.$=E),E}),function(r,s,e,m){
+"use strict";var a,l=["","webkit","Moz","MS","ms","o"],t=s.createElement("div"),n="function",c=Math.round,g=Math.abs,v=Date.now;function u(e,t,n){
+return setTimeout(y(e,n),t)}function i(e,t,n){return!!Array.isArray(e)&&(d(e,n[t],n),!0)}function d(e,t,n){var i;if(e)if(e.forEach)e.forEach(t,n
+);else if(e.length!==m)for(i=0;i<e.length;)t.call(n,e[i],i,e),i++;else for(i in e)e.hasOwnProperty(i)&&t.call(n,e[i],i,e)}function o(i,e,t){
+var o="DEPRECATED METHOD: "+e+"\n"+t+" AT \n";return function(){var e=new Error("get-stack-trace"),t=e&&e.stack?e.stack.replace(/^[^\(]+?[\n$]/gm,""
+).replace(/^\s+at\s+/gm,"").replace(/^Object.<anonymous>\s*\(/gm,"{anonymous}()@"):"Unknown Stack Trace",n=r.console&&(r.console.warn||r.console.log)
+;return n&&n.call(r.console,o,t),i.apply(this,arguments)}}a="function"!=typeof Object.assign?function(e){if(e===m||null===e)throw new TypeError(
+"Cannot convert undefined or null to object");for(var t=Object(e),n=1;n<arguments.length;n++){var i=arguments[n];if(i!==m&&null!==i)for(var o in i
+)i.hasOwnProperty(o)&&(t[o]=i[o])}return t}:Object.assign;var h=o(function(e,t,n){for(var i=Object.keys(t),o=0;o<i.length;)(!n||n&&e[i[o]]===m)&&(
+e[i[o]]=t[i[o]]),o++;return e},"extend","Use `assign`."),p=o(function(e,t){return h(e,t,!0)},"merge","Use `assign`.");function f(e,t,n){var i,
+o=t.prototype;(i=e.prototype=Object.create(o)).constructor=e,i._super=o,n&&a(i,n)}function y(e,t){return function(){return e.apply(t,arguments)}}
+function b(e,t){return typeof e==n?e.apply(t&&t[0]||m,t):e}function w(e,t){return e===m?t:e}function A(t,e,n){d(E(e),function(e){t.addEventListener(e,
+n,!1)})}function x(t,e,n){d(E(e),function(e){t.removeEventListener(e,n,!1)})}function k(e,t){for(;e;){if(e==t)return!0;e=e.parentNode}return!1}
+function T(e,t){return-1<e.indexOf(t)}function E(e){return e.trim().split(/\s+/g)}function C(e,t,n){if(e.indexOf&&!n)return e.indexOf(t);for(
+var i=0;i<e.length;){if(n&&e[i][n]==t||!n&&e[i]===t)return i;i++}return-1}function $(e){return Array.prototype.slice.call(e,0)}function S(e,n,t){for(
+var i=[],o=[],r=0;r<e.length;){var a=n?e[r][n]:e[r];C(o,a)<0&&i.push(e[r]),o[r]=a,r++}return t&&(i=n?i.sort(function(e,t){return e[n]>t[n]}):i.sort())
+,i}function _(e,t){for(var n,i,o=t[0].toUpperCase()+t.slice(1),r=0;r<l.length;){if((i=(n=l[r])?n+o:t)in e)return i;r++}return m}var D=1;function j(e){
+var t=e.ownerDocument||e;return t.defaultView||t.parentWindow||r}var O="ontouchstart"in r,P=_(r,"PointerEvent")!==m,
+N=O&&/mobile|tablet|ip(ad|hone|od)|android/i.test(navigator.userAgent),R="touch",I="mouse",q=25,L=1,B=4,H=8,M=1,F=2,z=4,W=8,Q=16,Y=F|z,U=W|Q,V=Y|U,X=[
+"x","y"],G=["clientX","clientY"];function K(t,e){var n=this;this.manager=t,this.callback=e,this.element=t.element,this.target=t.options.inputTarget,
+this.domHandler=function(e){b(t.options.enable,[t])&&n.handler(e)},this.init()}function J(e,t,n){var i=n.pointers.length,o=n.changedPointers.length,
+r=t&L&&i-o==0,a=t&(B|H)&&i-o==0;n.isFirst=!!r,n.isFinal=!!a,r&&(e.session={}),n.eventType=t,function(e,t){var n=e.session,i=t.pointers,o=i.length
+;n.firstInput||(n.firstInput=Z(t));1<o&&!n.firstMultiple?n.firstMultiple=Z(t):1===o&&(n.firstMultiple=!1);var r=n.firstInput,a=n.firstMultiple,
+s=a?a.center:r.center,l=t.center=ee(i);t.timeStamp=v(),t.deltaTime=t.timeStamp-r.timeStamp,t.angle=oe(s,l),t.distance=ie(s,l),function(e,t){
+var n=t.center,i=e.offsetDelta||{},o=e.prevDelta||{},r=e.prevInput||{};t.eventType!==L&&r.eventType!==B||(o=e.prevDelta={x:r.deltaX||0,y:r.deltaY||0},
+i=e.offsetDelta={x:n.x,y:n.y});t.deltaX=o.x+(n.x-i.x),t.deltaY=o.y+(n.y-i.y)}(n,t),t.offsetDirection=ne(t.deltaX,t.deltaY);var c=te(t.deltaTime,
+t.deltaX,t.deltaY);t.overallVelocityX=c.x,t.overallVelocityY=c.y,t.overallVelocity=g(c.x)>g(c.y)?c.x:c.y,t.scale=a?(h=a.pointers,p=i,ie(p[0],p[1],G
+)/ie(h[0],h[1],G)):1,t.rotation=a?(u=a.pointers,d=i,oe(d[1],d[0],G)+oe(u[1],u[0],G)):0,
+t.maxPointers=n.prevInput?t.pointers.length>n.prevInput.maxPointers?t.pointers.length:n.prevInput.maxPointers:t.pointers.length,function(e,t){var n,i,
+o,r,a=e.lastInterval||t,s=t.timeStamp-a.timeStamp;if(t.eventType!=H&&(q<s||a.velocity===m)){var l=t.deltaX-a.deltaX,c=t.deltaY-a.deltaY,u=te(s,l,c)
+;i=u.x,o=u.y,n=g(u.x)>g(u.y)?u.x:u.y,r=ne(l,c),e.lastInterval=t}else n=a.velocity,i=a.velocityX,o=a.velocityY,r=a.direction;t.velocity=n,t.velocityX=i
+,t.velocityY=o,t.direction=r}(n,t);var u,d;var h,p;var f=e.element;k(t.srcEvent.target,f)&&(f=t.srcEvent.target);t.target=f}(e,n),e.emit(
+"hammer.input",n),e.recognize(n),e.session.prevInput=n}function Z(e){for(var t=[],n=0;n<e.pointers.length;)t[n]={clientX:c(e.pointers[n].clientX),
+clientY:c(e.pointers[n].clientY)},n++;return{timeStamp:v(),pointers:t,center:ee(t),deltaX:e.deltaX,deltaY:e.deltaY}}function ee(e){var t=e.length;if(
+1===t)return{x:c(e[0].clientX),y:c(e[0].clientY)};for(var n=0,i=0,o=0;o<t;)n+=e[o].clientX,i+=e[o].clientY,o++;return{x:c(n/t),y:c(i/t)}}function te(e
+,t,n){return{x:t/e||0,y:n/e||0}}function ne(e,t){return e===t?M:g(e)>=g(t)?e<0?F:z:t<0?W:Q}function ie(e,t,n){n||(n=X);var i=t[n[0]]-e[n[0]],
+o=t[n[1]]-e[n[1]];return Math.sqrt(i*i+o*o)}function oe(e,t,n){n||(n=X);var i=t[n[0]]-e[n[0]],o=t[n[1]]-e[n[1]];return 180*Math.atan2(o,i)/Math.PI}
+K.prototype={handler:function(){},init:function(){this.evEl&&A(this.element,this.evEl,this.domHandler),this.evTarget&&A(this.target,this.evTarget,
+this.domHandler),this.evWin&&A(j(this.element),this.evWin,this.domHandler)},destroy:function(){this.evEl&&x(this.element,this.evEl,this.domHandler),
+this.evTarget&&x(this.target,this.evTarget,this.domHandler),this.evWin&&x(j(this.element),this.evWin,this.domHandler)}};var re={mousedown:L,
+mousemove:2,mouseup:B},ae="mousedown",se="mousemove mouseup";function le(){this.evEl=ae,this.evWin=se,this.pressed=!1,K.apply(this,arguments)}f(le,K,{
+handler:function(e){var t=re[e.type];t&L&&0===e.button&&(this.pressed=!0),2&t&&1!==e.which&&(t=B),this.pressed&&(t&B&&(this.pressed=!1),this.callback(
+this.manager,t,{pointers:[e],changedPointers:[e],pointerType:I,srcEvent:e}))}});var ce={pointerdown:L,pointermove:2,pointerup:B,pointercancel:H,
+pointerout:H},ue={2:R,3:"pen",4:I,5:"kinect"},de="pointerdown",he="pointermove pointerup pointercancel";function pe(){this.evEl=de,this.evWin=he,
+K.apply(this,arguments),this.store=this.manager.session.pointerEvents=[]}r.MSPointerEvent&&!r.PointerEvent&&(de="MSPointerDown",
+he="MSPointerMove MSPointerUp MSPointerCancel"),f(pe,K,{handler:function(e){var t=this.store,n=!1,i=e.type.toLowerCase().replace("ms",""),o=ce[i],
+r=ue[e.pointerType]||e.pointerType,a=r==R,s=C(t,e.pointerId,"pointerId");o&L&&(0===e.button||a)?s<0&&(t.push(e),s=t.length-1):o&(B|H)&&(n=!0),s<0||(
+t[s]=e,this.callback(this.manager,o,{pointers:t,changedPointers:[e],pointerType:r,srcEvent:e}),n&&t.splice(s,1))}});var fe={touchstart:L,touchmove:2,
+touchend:B,touchcancel:H};function me(){this.evTarget="touchstart",this.evWin="touchstart touchmove touchend touchcancel",this.started=!1,K.apply(this
+,arguments)}f(me,K,{handler:function(e){var t=fe[e.type];if(t===L&&(this.started=!0),this.started){var n=function(e,t){var n=$(e.touches),i=$(
+e.changedTouches);t&(B|H)&&(n=S(n.concat(i),"identifier",!0));return[n,i]}.call(this,e,t);t&(B|H)&&n[0].length-n[1].length==0&&(this.started=!1),
+this.callback(this.manager,t,{pointers:n[0],changedPointers:n[1],pointerType:R,srcEvent:e})}}});var ge={touchstart:L,touchmove:2,touchend:B,
+touchcancel:H},ve="touchstart touchmove touchend touchcancel";function ye(){this.evTarget=ve,this.targetIds={},K.apply(this,arguments)}f(ye,K,{
+handler:function(e){var t=ge[e.type],n=function(e,t){var n=$(e.touches),i=this.targetIds;if(t&(2|L)&&1===n.length)return i[n[0].identifier]=!0,[n,n]
+;var o,r,a=$(e.changedTouches),s=[],l=this.target;if(r=n.filter(function(e){return k(e.target,l)}),t===L)for(o=0;o<r.length;)i[r[o].identifier]=!0,o++
+;o=0;for(;o<a.length;)i[a[o].identifier]&&s.push(a[o]),t&(B|H)&&delete i[a[o].identifier],o++;return s.length?[S(r.concat(s),"identifier",!0),s
+]:void 0}.call(this,e,t);n&&this.callback(this.manager,t,{pointers:n[0],changedPointers:n[1],pointerType:R,srcEvent:e})}});var be=2500;function we(){
+K.apply(this,arguments);var e=y(this.handler,this);this.touch=new ye(this.manager,e),this.mouse=new le(this.manager,e),this.primaryTouch=null,
+this.lastTouches=[]}function Ae(e){var t=e.changedPointers[0];if(t.identifier===this.primaryTouch){var n={x:t.clientX,y:t.clientY}
+;this.lastTouches.push(n);var i=this.lastTouches;setTimeout(function(){var e=i.indexOf(n);-1<e&&i.splice(e,1)},be)}}f(we,K,{handler:function(e,t,n){
+var i=n.pointerType==R,o=n.pointerType==I;if(!(o&&n.sourceCapabilities&&n.sourceCapabilities.firesTouchEvents)){if(i)(function(e,t){e&L?(
+this.primaryTouch=t.changedPointers[0].identifier,Ae.call(this,t)):e&(B|H)&&Ae.call(this,t)}).call(this,t,n);else if(o&&function(e){for(
+var t=e.srcEvent.clientX,n=e.srcEvent.clientY,i=0;i<this.lastTouches.length;i++){var o=this.lastTouches[i],r=Math.abs(t-o.x),a=Math.abs(n-o.y);if(
+r<=25&&a<=25)return!0}return!1}.call(this,n))return;this.callback(e,t,n)}},destroy:function(){this.touch.destroy(),this.mouse.destroy()}});var xe=_(
+t.style,"touchAction"),ke=xe!==m,Te="compute",Ee="manipulation",Ce="none",$e="pan-x",Se="pan-y",_e=function(){if(!ke)return!1;var t={},
+n=r.CSS&&r.CSS.supports;return["auto","manipulation","pan-y","pan-x","pan-x pan-y","none"].forEach(function(e){t[e]=!n||r.CSS.supports("touch-action",
+e)}),t}();function De(e,t){this.manager=e,this.set(t)}De.prototype={set:function(e){e==Te&&(e=this.compute()),ke&&this.manager.element.style&&_e[e]&&(
+this.manager.element.style[xe]=e),this.actions=e.toLowerCase().trim()},update:function(){this.set(this.manager.options.touchAction)},compute:function(
+){var t=[];return d(this.manager.recognizers,function(e){b(e.options.enable,[e])&&(t=t.concat(e.getTouchAction()))}),function(e){if(T(e,Ce))return Ce
+;var t=T(e,$e),n=T(e,Se);if(t&&n)return Ce;if(t||n)return t?$e:Se;if(T(e,Ee))return Ee;return"auto"}(t.join(" "))},preventDefaults:function(e){
+var t=e.srcEvent,n=e.offsetDirection;if(this.manager.session.prevented)t.preventDefault();else{var i=this.actions,o=T(i,Ce)&&!_e[Ce],r=T(i,Se
+)&&!_e[Se],a=T(i,$e)&&!_e[$e];if(o){var s=1===e.pointers.length,l=e.distance<2,c=e.deltaTime<250;if(s&&l&&c)return}if(!a||!r
+)return o||r&&n&Y||a&&n&U?this.preventSrc(t):void 0}},preventSrc:function(e){this.manager.session.prevented=!0,e.preventDefault()}};var je=1
+;function Oe(e){this.options=a({},this.defaults,e||{}),this.id=D++,this.manager=null,this.options.enable=w(this.options.enable,!0),this.state=je,
+this.simultaneous={},this.requireFail=[]}function Pe(e){return 16&e?"cancel":8&e?"end":4&e?"move":2&e?"start":""}function Ne(e){
+return e==Q?"down":e==W?"up":e==F?"left":e==z?"right":""}function Re(e,t){var n=t.manager;return n?n.get(e):e}function Ie(){Oe.apply(this,arguments)}
+function qe(){Ie.apply(this,arguments),this.pX=null,this.pY=null}function Le(){Ie.apply(this,arguments)}function Be(){Oe.apply(this,arguments),
+this._timer=null,this._input=null}function He(){Ie.apply(this,arguments)}function Me(){Ie.apply(this,arguments)}function Fe(){Oe.apply(this,arguments)
+,this.pTime=!1,this.pCenter=!1,this._timer=null,this._input=null,this.count=0}function ze(e,t){return(t=t||{}).recognizers=w(t.recognizers,
+ze.defaults.preset),new We(e,t)}Oe.prototype={defaults:{},set:function(e){return a(this.options,e),this.manager&&this.manager.touchAction.update(),
+this},recognizeWith:function(e){if(i(e,"recognizeWith",this))return this;var t=this.simultaneous;return t[(e=Re(e,this)).id]||(t[e.id]=e
+).recognizeWith(this),this},dropRecognizeWith:function(e){return i(e,"dropRecognizeWith",this)||(e=Re(e,this),delete this.simultaneous[e.id]),this},
+requireFailure:function(e){if(i(e,"requireFailure",this))return this;var t=this.requireFail;return-1===C(t,e=Re(e,this))&&(t.push(e),e.requireFailure(
+this)),this},dropRequireFailure:function(e){if(i(e,"dropRequireFailure",this))return this;e=Re(e,this);var t=C(this.requireFail,e)
+;return-1<t&&this.requireFail.splice(t,1),this},hasRequireFailures:function(){return 0<this.requireFail.length},canRecognizeWith:function(e){
+return!!this.simultaneous[e.id]},emit:function(t){var n=this,e=this.state;function i(e){n.manager.emit(e,t)}e<8&&i(n.options.event+Pe(e)),i(
+n.options.event),t.additionalEvent&&i(t.additionalEvent),8<=e&&i(n.options.event+Pe(e))},tryEmit:function(e){if(this.canEmit())return this.emit(e)
+;this.state=32},canEmit:function(){for(var e=0;e<this.requireFail.length;){if(!(this.requireFail[e].state&(32|je)))return!1;e++}return!0},
+recognize:function(e){var t=a({},e);if(!b(this.options.enable,[this,t]))return this.reset(),void(this.state=32);56&this.state&&(this.state=je),
+this.state=this.process(t),30&this.state&&this.tryEmit(t)},process:function(e){},getTouchAction:function(){},reset:function(){}},f(Ie,Oe,{defaults:{
+pointers:1},attrTest:function(e){var t=this.options.pointers;return 0===t||e.pointers.length===t},process:function(e){var t=this.state,n=e.eventType,
+i=6&t,o=this.attrTest(e);return i&&(n&H||!o)?16|t:i||o?n&B?8|t:2&t?4|t:2:32}}),f(qe,Ie,{defaults:{event:"pan",threshold:10,pointers:1,direction:V},
+getTouchAction:function(){var e=this.options.direction,t=[];return e&Y&&t.push(Se),e&U&&t.push($e),t},directionTest:function(e){var t=this.options,
+n=!0,i=e.distance,o=e.direction,r=e.deltaX,a=e.deltaY;return o&t.direction||(i=t.direction&Y?(o=0===r?M:r<0?F:z,n=r!=this.pX,Math.abs(e.deltaX)):(
+o=0===a?M:a<0?W:Q,n=a!=this.pY,Math.abs(e.deltaY))),e.direction=o,n&&i>t.threshold&&o&t.direction},attrTest:function(e){
+return Ie.prototype.attrTest.call(this,e)&&(2&this.state||!(2&this.state)&&this.directionTest(e))},emit:function(e){this.pX=e.deltaX,this.pY=e.deltaY
+;var t=Ne(e.direction);t&&(e.additionalEvent=this.options.event+t),this._super.emit.call(this,e)}}),f(Le,Ie,{defaults:{event:"pinch",threshold:0,
+pointers:2},getTouchAction:function(){return[Ce]},attrTest:function(e){return this._super.attrTest.call(this,e)&&(Math.abs(e.scale-1
+)>this.options.threshold||2&this.state)},emit:function(e){if(1!==e.scale){var t=e.scale<1?"in":"out";e.additionalEvent=this.options.event+t}
+this._super.emit.call(this,e)}}),f(Be,Oe,{defaults:{event:"press",pointers:1,time:251,threshold:9},getTouchAction:function(){return["auto"]},
+process:function(e){var t=this.options,n=e.pointers.length===t.pointers,i=e.distance<t.threshold,o=e.deltaTime>t.time;if(this._input=e,
+!i||!n||e.eventType&(B|H)&&!o)this.reset();else if(e.eventType&L)this.reset(),this._timer=u(function(){this.state=8,this.tryEmit()},t.time,this
+);else if(e.eventType&B)return 8;return 32},reset:function(){clearTimeout(this._timer)},emit:function(e){8===this.state&&(
+e&&e.eventType&B?this.manager.emit(this.options.event+"up",e):(this._input.timeStamp=v(),this.manager.emit(this.options.event,this._input)))}}),f(He,
+Ie,{defaults:{event:"rotate",threshold:0,pointers:2},getTouchAction:function(){return[Ce]},attrTest:function(e){return this._super.attrTest.call(this,
+e)&&(Math.abs(e.rotation)>this.options.threshold||2&this.state)}}),f(Me,Ie,{defaults:{event:"swipe",threshold:10,velocity:.3,direction:Y|U,pointers:1
+},getTouchAction:function(){return qe.prototype.getTouchAction.call(this)},attrTest:function(e){var t,n=this.options.direction;return n&(Y|U
+)?t=e.overallVelocity:n&Y?t=e.overallVelocityX:n&U&&(t=e.overallVelocityY),this._super.attrTest.call(this,e
+)&&n&e.offsetDirection&&e.distance>this.options.threshold&&e.maxPointers==this.options.pointers&&g(t)>this.options.velocity&&e.eventType&B},
+emit:function(e){var t=Ne(e.offsetDirection);t&&this.manager.emit(this.options.event+t,e),this.manager.emit(this.options.event,e)}}),f(Fe,Oe,{
+defaults:{event:"tap",pointers:1,taps:1,interval:300,time:250,threshold:9,posThreshold:10},getTouchAction:function(){return[Ee]},process:function(e){
+var t=this.options,n=e.pointers.length===t.pointers,i=e.distance<t.threshold,o=e.deltaTime<t.time;if(this.reset(),e.eventType&L&&0===this.count
+)return this.failTimeout();if(i&&o&&n){if(e.eventType!=B)return this.failTimeout();var r=!this.pTime||e.timeStamp-this.pTime<t.interval,
+a=!this.pCenter||ie(this.pCenter,e.center)<t.posThreshold;if(this.pTime=e.timeStamp,this.pCenter=e.center,a&&r?this.count+=1:this.count=1,
+this._input=e,0===this.count%t.taps)return this.hasRequireFailures()?(this._timer=u(function(){this.state=8,this.tryEmit()},t.interval,this),2):8}
+return 32},failTimeout:function(){return this._timer=u(function(){this.state=32},this.options.interval,this),32},reset:function(){clearTimeout(
+this._timer)},emit:function(){8==this.state&&(this._input.tapCount=this.count,this.manager.emit(this.options.event,this._input))}}),ze.VERSION="2.0.8"
+,ze.defaults={domEvents:!1,touchAction:Te,enable:!0,inputTarget:null,inputClass:null,preset:[[He,{enable:!1}],[Le,{enable:!1},["rotate"]],[Me,{
+direction:Y}],[qe,{direction:Y},["swipe"]],[Fe],[Fe,{event:"doubletap",taps:2},["tap"]],[Be]],cssProps:{userSelect:"none",touchSelect:"none",
+touchCallout:"none",contentZooming:"none",userDrag:"none",tapHighlightColor:"rgba(0,0,0,0)"}};function We(e,t){var n;this.options=a({},ze.defaults,
+t||{}),this.options.inputTarget=this.options.inputTarget||e,this.handlers={},this.session={},this.recognizers=[],this.oldCssProps={},this.element=e,
+this.input=new((n=this).options.inputClass||(P?pe:N?ye:O?we:le))(n,J),this.touchAction=new De(this,this.options.touchAction),Qe(this,!0),d(
+this.options.recognizers,function(e){var t=this.add(new e[0](e[1]));e[2]&&t.recognizeWith(e[2]),e[3]&&t.requireFailure(e[3])},this)}function Qe(n,i){
+var o,r=n.element;r.style&&(d(n.options.cssProps,function(e,t){o=_(r.style,t),i?(n.oldCssProps[o]=r.style[o],r.style[o]=e
+):r.style[o]=n.oldCssProps[o]||""}),i||(n.oldCssProps={}))}We.prototype={set:function(e){return a(this.options,e),
+e.touchAction&&this.touchAction.update(),e.inputTarget&&(this.input.destroy(),this.input.target=e.inputTarget,this.input.init()),this},stop:function(e
+){this.session.stopped=e?2:1},recognize:function(e){var t=this.session;if(!t.stopped){var n;this.touchAction.preventDefaults(e);var i=this.recognizers
+,o=t.curRecognizer;(!o||o&&8&o.state)&&(o=t.curRecognizer=null);for(var r=0;r<i.length;)n=i[r],2===t.stopped||o&&n!=o&&!n.canRecognizeWith(o)?n.reset(
+):n.recognize(e),!o&&14&n.state&&(o=t.curRecognizer=n),r++}},get:function(e){if(e instanceof Oe)return e;for(var t=this.recognizers,n=0;n<t.length;n++
+)if(t[n].options.event==e)return t[n];return null},add:function(e){if(i(e,"add",this))return this;var t=this.get(e.options.event)
+;return t&&this.remove(t),this.recognizers.push(e),(e.manager=this).touchAction.update(),e},remove:function(e){if(i(e,"remove",this))return this;if(
+e=this.get(e)){var t=this.recognizers,n=C(t,e);-1!==n&&(t.splice(n,1),this.touchAction.update())}return this},on:function(e,t){if(e!==m&&t!==m){
+var n=this.handlers;return d(E(e),function(e){n[e]=n[e]||[],n[e].push(t)}),this}},off:function(e,t){if(e!==m){var n=this.handlers;return d(E(e),
+function(e){t?n[e]&&n[e].splice(C(n[e],t),1):delete n[e]}),this}},emit:function(e,t){var n,i,o;this.options.domEvents&&(n=e,i=t,(o=s.createEvent(
+"Event")).initEvent(n,!0,!0),(o.gesture=i).target.dispatchEvent(o));var r=this.handlers[e]&&this.handlers[e].slice();if(r&&r.length){t.type=e,
+t.preventDefault=function(){t.srcEvent.preventDefault()};for(var a=0;a<r.length;)r[a](t),a++}},destroy:function(){this.element&&Qe(this,!1),
+this.handlers={},this.session={},this.input.destroy(),this.element=null}},a(ze,{INPUT_START:L,INPUT_MOVE:2,INPUT_END:B,INPUT_CANCEL:H,
+STATE_POSSIBLE:je,STATE_BEGAN:2,STATE_CHANGED:4,STATE_ENDED:8,STATE_RECOGNIZED:8,STATE_CANCELLED:16,STATE_FAILED:32,DIRECTION_NONE:M,DIRECTION_LEFT:F,
+DIRECTION_RIGHT:z,DIRECTION_UP:W,DIRECTION_DOWN:Q,DIRECTION_HORIZONTAL:Y,DIRECTION_VERTICAL:U,DIRECTION_ALL:V,Manager:We,Input:K,TouchAction:De,
+TouchInput:ye,MouseInput:le,PointerEventInput:pe,TouchMouseInput:we,SingleTouchInput:me,Recognizer:Oe,AttrRecognizer:Ie,Tap:Fe,Pan:qe,Swipe:Me,
+Pinch:Le,Rotate:He,Press:Be,on:A,off:x,each:d,merge:p,extend:h,assign:a,inherit:f,bindFn:y,prefixed:_}),(void 0!==r?r:"undefined"!=typeof self?self:{}
+).Hammer=ze,"function"==typeof define&&define.amd?define(function(){return ze}
+):"undefined"!=typeof module&&module.exports?module.exports=ze:r.Hammer=ze}(window,document),function(){var t,e=new AnchorJS,i=$("header.header")
+;e.add(".body h1"),e.add(".body h2"),e.add(".body h3"),e.add(".body h4"),e.add(".body h5"),e.add(".body h6"),e.add(".body .argument"),e.add(
+".body .attribute"),t=function(){var e,t,n=$(window.location.hash);n.length&&(e=i.height()+20,t=n.offset().top,$("html, body").scrollTop(t-e))},$(
+".anchorjs-link").click(function(e){e.preventDefault(),window.location.hash=$(this).get(0).hash,t()}),$(function(){t()})}(),"undefined"==typeof jQuery
+)throw new Error("Bootstrap's JavaScript requires jQuery");!function(e){"use strict";var t=jQuery.fn.jquery.split(" ")[0].split(".");if(
+t[0]<2&&t[1]<9||1==t[0]&&9==t[1]&&t[2]<1)throw new Error("Bootstrap's JavaScript requires jQuery version 1.9.1 or higher")}(),function(s){"use strict"
+;function r(i){i&&3===i.which||(s(".dropdown-backdrop").remove(),s(c).each(function(){var e=s(this),t=l(e),n={relatedTarget:this};t.hasClass("open"
+)&&(t.trigger(i=s.Event("hide.bs.dropdown",n)),i.isDefaultPrevented()||(e.attr("aria-expanded","false"),t.removeClass("open").trigger(
+"hidden.bs.dropdown",n)))}))}function l(e){var t=e.attr("data-target");t||(t=(t=e.attr("href"))&&/#[A-Za-z]/.test(t)&&t.replace(/.*(?=#[^\s]*$)/,""))
+;var n=t&&s(t);return n&&n.length?n:e.parent()}var c='[data-toggle="dropdown"]',i=function(e){s(e).on("click.bs.dropdown",this.toggle)}
+;i.VERSION="3.3.4",i.prototype.toggle=function(e){var t=s(this);if(!t.is(".disabled, :disabled")){var n=l(t),i=n.hasClass("open");if(r(),!i){
+"ontouchstart"in document.documentElement&&!n.closest(".navbar-nav").length&&s('<div class="dropdown-backdrop"/>').insertAfter(s(this)).on("click",r)
+;var o={relatedTarget:this};if(n.trigger(e=s.Event("show.bs.dropdown",o)),e.isDefaultPrevented())return;t.trigger("focus").attr("aria-expanded","true"
+),n.toggleClass("open").trigger("shown.bs.dropdown",o)}return!1}},i.prototype.keydown=function(e){if(/(38|40|27|32)/.test(e.which
+)&&!/input|textarea/i.test(e.target.tagName)){var t=s(this);if(e.preventDefault(),e.stopPropagation(),!t.is(".disabled, :disabled")){var n=l(t),
+i=n.hasClass("open");if(!i&&27!=e.which||i&&27==e.which)return 27==e.which&&n.find(c).trigger("focus"),t.trigger("click")
+;var o=" li:not(.disabled):visible a",r=n.find('[role="menu"]'+o+', [role="listbox"]'+o);if(r.length){var a=r.index(e.target);38==e.which&&0<a&&a--,
+40==e.which&&a<r.length-1&&a++,~a||(a=0),r.eq(a).trigger("focus")}}}};var e=s.fn.dropdown;s.fn.dropdown=function(n){return this.each(function(){
+var e=s(this),t=e.data("bs.dropdown");t||e.data("bs.dropdown",t=new i(this)),"string"==typeof n&&t[n].call(e)})},s.fn.dropdown.Constructor=i,
+s.fn.dropdown.noConflict=function(){return s.fn.dropdown=e,this},s(document).on("click.bs.dropdown.data-api",r).on("click.bs.dropdown.data-api",
+".dropdown form",function(e){e.stopPropagation()}).on("click.bs.dropdown.data-api",c,i.prototype.toggle).on("keydown.bs.dropdown.data-api",c,
+i.prototype.keydown).on("keydown.bs.dropdown.data-api",'[role="menu"]',i.prototype.keydown).on("keydown.bs.dropdown.data-api",'[role="listbox"]',
+i.prototype.keydown)}(jQuery),function(r){"use strict";function a(i,o){return this.each(function(){var e=r(this),t=e.data("bs.modal"),n=r.extend({},
+s.DEFAULTS,e.data(),"object"==typeof i&&i);t||e.data("bs.modal",t=new s(this,n)),"string"==typeof i?t[i](o):n.show&&t.show(o)})}var s=function(e,t){
+this.options=t,this.$body=r(document.body),this.$element=r(e),this.$dialog=this.$element.find(".modal-dialog"),this.$backdrop=null,this.isShown=null,
+this.originalBodyPad=null,this.scrollbarWidth=0,this.ignoreBackdropClick=!1,this.options.remote&&this.$element.find(".modal-content").load(
+this.options.remote,r.proxy(function(){this.$element.trigger("loaded.bs.modal")},this))};s.VERSION="3.3.4",s.TRANSITION_DURATION=300,
+s.BACKDROP_TRANSITION_DURATION=150,s.DEFAULTS={backdrop:!0,keyboard:!0,show:!0},s.prototype.toggle=function(e){return this.isShown?this.hide(
+):this.show(e)},s.prototype.show=function(n){var i=this,e=r.Event("show.bs.modal",{relatedTarget:n});this.$element.trigger(e),
+this.isShown||e.isDefaultPrevented()||(this.isShown=!0,this.checkScrollbar(),this.setScrollbar(),this.$body.addClass("modal-open"),this.escape(),
+this.resize(),this.$element.on("click.dismiss.bs.modal",'[data-dismiss="modal"]',r.proxy(this.hide,this)),this.$dialog.on("mousedown.dismiss.bs.modal"
+,function(){i.$element.one("mouseup.dismiss.bs.modal",function(e){r(e.target).is(i.$element)&&(i.ignoreBackdropClick=!0)})}),this.backdrop(function(){
+var e=r.support.transition&&i.$element.hasClass("fade");i.$element.parent().length||i.$element.appendTo(i.$body),i.$element.show().scrollTop(0),
+i.adjustDialog(),e&&i.$element[0].offsetWidth,i.$element.addClass("in").attr("aria-hidden",!1),i.enforceFocus();var t=r.Event("shown.bs.modal",{
+relatedTarget:n});e?i.$dialog.one("bsTransitionEnd",function(){i.$element.trigger("focus").trigger(t)}).emulateTransitionEnd(s.TRANSITION_DURATION
+):i.$element.trigger("focus").trigger(t)}))},s.prototype.hide=function(e){e&&e.preventDefault(),e=r.Event("hide.bs.modal"),this.$element.trigger(e),
+this.isShown&&!e.isDefaultPrevented()&&(this.isShown=!1,this.escape(),this.resize(),r(document).off("focusin.bs.modal"),this.$element.removeClass("in"
+).attr("aria-hidden",!0).off("click.dismiss.bs.modal").off("mouseup.dismiss.bs.modal"),this.$dialog.off("mousedown.dismiss.bs.modal"),
+r.support.transition&&this.$element.hasClass("fade")?this.$element.one("bsTransitionEnd",r.proxy(this.hideModal,this)).emulateTransitionEnd(
+s.TRANSITION_DURATION):this.hideModal())},s.prototype.enforceFocus=function(){r(document).off("focusin.bs.modal").on("focusin.bs.modal",r.proxy(
+function(e){this.$element[0]===e.target||this.$element.has(e.target).length||this.$element.trigger("focus")},this))},s.prototype.escape=function(){
+this.isShown&&this.options.keyboard?this.$element.on("keydown.dismiss.bs.modal",r.proxy(function(e){27==e.which&&this.hide()},this)
+):this.isShown||this.$element.off("keydown.dismiss.bs.modal")},s.prototype.resize=function(){this.isShown?r(window).on("resize.bs.modal",r.proxy(
+this.handleUpdate,this)):r(window).off("resize.bs.modal")},s.prototype.hideModal=function(){var e=this;this.$element.hide(),this.backdrop(function(){
+e.$body.removeClass("modal-open"),e.resetAdjustments(),e.resetScrollbar(),e.$element.trigger("hidden.bs.modal")})},
+s.prototype.removeBackdrop=function(){this.$backdrop&&this.$backdrop.remove(),this.$backdrop=null},s.prototype.backdrop=function(e){var t=this,
+n=this.$element.hasClass("fade")?"fade":"";if(this.isShown&&this.options.backdrop){var i=r.support.transition&&n;if(this.$backdrop=r(
+'<div class="modal-backdrop '+n+'" />').appendTo(this.$body),this.$element.on("click.dismiss.bs.modal",r.proxy(function(e){
+return this.ignoreBackdropClick?void(this.ignoreBackdropClick=!1):void(e.target===e.currentTarget&&(
+"static"==this.options.backdrop?this.$element[0].focus():this.hide()))},this)),i&&this.$backdrop[0].offsetWidth,this.$backdrop.addClass("in"),!e
+)return;i?this.$backdrop.one("bsTransitionEnd",e).emulateTransitionEnd(s.BACKDROP_TRANSITION_DURATION):e()}else if(!this.isShown&&this.$backdrop){
+this.$backdrop.removeClass("in");var o=function(){t.removeBackdrop(),e&&e()};r.support.transition&&this.$element.hasClass("fade")?this.$backdrop.one(
+"bsTransitionEnd",o).emulateTransitionEnd(s.BACKDROP_TRANSITION_DURATION):o()}else e&&e()},s.prototype.handleUpdate=function(){this.adjustDialog()},
+s.prototype.adjustDialog=function(){var e=this.$element[0].scrollHeight>document.documentElement.clientHeight;this.$element.css({
+paddingLeft:!this.bodyIsOverflowing&&e?this.scrollbarWidth:"",paddingRight:this.bodyIsOverflowing&&!e?this.scrollbarWidth:""})},
+s.prototype.resetAdjustments=function(){this.$element.css({paddingLeft:"",paddingRight:""})},s.prototype.checkScrollbar=function(){
+var e=window.innerWidth;if(!e){var t=document.documentElement.getBoundingClientRect();e=t.right-Math.abs(t.left)}
+this.bodyIsOverflowing=document.body.clientWidth<e,this.scrollbarWidth=this.measureScrollbar()},s.prototype.setScrollbar=function(){var e=parseInt(
+this.$body.css("padding-right")||0,10);this.originalBodyPad=document.body.style.paddingRight||"",this.bodyIsOverflowing&&this.$body.css(
+"padding-right",e+this.scrollbarWidth)},s.prototype.resetScrollbar=function(){this.$body.css("padding-right",this.originalBodyPad)},
+s.prototype.measureScrollbar=function(){var e=document.createElement("div");e.className="modal-scrollbar-measure",this.$body.append(e)
+;var t=e.offsetWidth-e.clientWidth;return this.$body[0].removeChild(e),t};var e=r.fn.modal;r.fn.modal=a,r.fn.modal.Constructor=s,
+r.fn.modal.noConflict=function(){return r.fn.modal=e,this},r(document).on("click.bs.modal.data-api",'[data-toggle="modal"]',function(e){var t=r(this),
+n=t.attr("href"),i=r(t.attr("data-target")||n&&n.replace(/.*(?=#[^\s]+$)/,"")),o=i.data("bs.modal")?"toggle":r.extend({remote:!/#/.test(n)&&n},i.data(
+),t.data());t.is("a")&&e.preventDefault(),i.one("show.bs.modal",function(e){e.isDefaultPrevented()||i.one("hidden.bs.modal",function(){t.is(":visible"
+)&&t.trigger("focus")})}),a.call(i,o,this)})}(jQuery),function(g){"use strict";var v=function(e,t){this.type=null,this.options=null,this.enabled=null,
+this.timeout=null,this.hoverState=null,this.$element=null,this.init("tooltip",e,t)};v.VERSION="3.3.4",v.TRANSITION_DURATION=150,v.DEFAULTS={
+animation:!0,placement:"top",selector:!1,
+template:'<div class="tooltip" role="tooltip"><div class="tooltip-arrow"></div><div class="tooltip-inner"></div></div>',trigger:"hover focus",
+title:"",delay:0,html:!1,container:!1,viewport:{selector:"body",padding:0}},v.prototype.init=function(e,t,n){if(this.enabled=!0,this.type=e,
+this.$element=g(t),this.options=this.getOptions(n),this.$viewport=this.options.viewport&&g(this.options.viewport.selector||this.options.viewport),
+this.$element[0]instanceof document.constructor&&!this.options.selector)throw new Error(
+"`selector` option must be specified when initializing "+this.type+" on the window.document object!");for(var i=this.options.trigger.split(" "),
+o=i.length;o--;){var r=i[o];if("click"==r)this.$element.on("click."+this.type,this.options.selector,g.proxy(this.toggle,this));else if("manual"!=r){
+var a="hover"==r?"mouseenter":"focusin",s="hover"==r?"mouseleave":"focusout";this.$element.on(a+"."+this.type,this.options.selector,g.proxy(this.enter
+,this)),this.$element.on(s+"."+this.type,this.options.selector,g.proxy(this.leave,this))}}this.options.selector?this._options=g.extend({},this.options
+,{trigger:"manual",selector:""}):this.fixTitle()},v.prototype.getDefaults=function(){return v.DEFAULTS},v.prototype.getOptions=function(e){return(
+e=g.extend({},this.getDefaults(),this.$element.data(),e)).delay&&"number"==typeof e.delay&&(e.delay={show:e.delay,hide:e.delay}),e},
+v.prototype.getDelegateOptions=function(){var n={},i=this.getDefaults();return this._options&&g.each(this._options,function(e,t){i[e]!=t&&(n[e]=t)}),n
+},v.prototype.enter=function(e){var t=e instanceof this.constructor?e:g(e.currentTarget).data("bs."+this.type);return t&&t.$tip&&t.$tip.is(":visible"
+)?void(t.hoverState="in"):(t||(t=new this.constructor(e.currentTarget,this.getDelegateOptions()),g(e.currentTarget).data("bs."+this.type,t)),
+clearTimeout(t.timeout),t.hoverState="in",t.options.delay&&t.options.delay.show?void(t.timeout=setTimeout(function(){"in"==t.hoverState&&t.show()},
+t.options.delay.show)):t.show())},v.prototype.leave=function(e){var t=e instanceof this.constructor?e:g(e.currentTarget).data("bs."+this.type)
+;return t||(t=new this.constructor(e.currentTarget,this.getDelegateOptions()),g(e.currentTarget).data("bs."+this.type,t)),clearTimeout(t.timeout),
+t.hoverState="out",t.options.delay&&t.options.delay.hide?void(t.timeout=setTimeout(function(){"out"==t.hoverState&&t.hide()},t.options.delay.hide)
+):t.hide()},v.prototype.show=function(){var e=g.Event("show.bs."+this.type);if(this.hasContent()&&this.enabled){this.$element.trigger(e)
+;var t=g.contains(this.$element[0].ownerDocument.documentElement,this.$element[0]);if(e.isDefaultPrevented()||!t)return;var n=this,i=this.tip(),
+o=this.getUID(this.type);this.setContent(),i.attr("id",o),this.$element.attr("aria-describedby",o),this.options.animation&&i.addClass("fade")
+;var r="function"==typeof this.options.placement?this.options.placement.call(this,i[0],this.$element[0]):this.options.placement,a=/\s?auto?\s?/i,
+s=a.test(r);s&&(r=r.replace(a,"")||"top"),i.detach().css({top:0,left:0,display:"block"}).addClass(r).data("bs."+this.type,this),
+this.options.container?i.appendTo(this.options.container):i.insertAfter(this.$element);var l=this.getPosition(),c=i[0].offsetWidth,u=i[0].offsetHeight
+;if(s){var d=r,h=this.options.container?g(this.options.container):this.$element.parent(),p=this.getPosition(h)
+;r="bottom"==r&&l.bottom+u>p.bottom?"top":"top"==r&&l.top-u<p.top?"bottom":"right"==r&&l.right+c>p.width?"left":"left"==r&&l.left-c<p.left?"right":r,
+i.removeClass(d).addClass(r)}var f=this.getCalculatedOffset(r,l,c,u);this.applyPlacement(f,r);var m=function(){var e=n.hoverState;n.$element.trigger(
+"shown.bs."+n.type),n.hoverState=null,"out"==e&&n.leave(n)};g.support.transition&&this.$tip.hasClass("fade")?i.one("bsTransitionEnd",m
+).emulateTransitionEnd(v.TRANSITION_DURATION):m()}},v.prototype.applyPlacement=function(e,t){var n=this.tip(),i=n[0].offsetWidth,o=n[0].offsetHeight,
+r=parseInt(n.css("margin-top"),10),a=parseInt(n.css("margin-left"),10);isNaN(r)&&(r=0),isNaN(a)&&(a=0),e.top=e.top+r,e.left=e.left+a,
+g.offset.setOffset(n[0],g.extend({using:function(e){n.css({top:Math.round(e.top),left:Math.round(e.left)})}},e),0),n.addClass("in")
+;var s=n[0].offsetWidth,l=n[0].offsetHeight;"top"==t&&l!=o&&(e.top=e.top+o-l);var c=this.getViewportAdjustedDelta(t,e,s,l)
+;c.left?e.left+=c.left:e.top+=c.top;var u=/top|bottom/.test(t),d=u?2*c.left-i+s:2*c.top-o+l,h=u?"offsetWidth":"offsetHeight";n.offset(e),
+this.replaceArrow(d,n[0][h],u)},v.prototype.replaceArrow=function(e,t,n){this.arrow().css(n?"left":"top",50*(1-e/t)+"%").css(n?"top":"left","")},
+v.prototype.setContent=function(){var e=this.tip(),t=this.getTitle();e.find(".tooltip-inner")[this.options.html?"html":"text"](t),e.removeClass(
+"fade in top bottom left right")},v.prototype.hide=function(e){function t(){"in"!=n.hoverState&&i.detach(),n.$element.removeAttr("aria-describedby"
+).trigger("hidden.bs."+n.type),e&&e()}var n=this,i=g(this.$tip),o=g.Event("hide.bs."+this.type);return this.$element.trigger(o),o.isDefaultPrevented(
+)?void 0:(i.removeClass("in"),g.support.transition&&i.hasClass("fade")?i.one("bsTransitionEnd",t).emulateTransitionEnd(v.TRANSITION_DURATION):t(),
+this.hoverState=null,this)},v.prototype.fixTitle=function(){var e=this.$element;(e.attr("title")||"string"!=typeof e.attr("data-original-title")
+)&&e.attr("data-original-title",e.attr("title")||"").attr("title","")},v.prototype.hasContent=function(){return this.getTitle()},
+v.prototype.getPosition=function(e){var t=(e=e||this.$element)[0],n="BODY"==t.tagName,i=t.getBoundingClientRect();null==i.width&&(i=g.extend({},i,{
+width:i.right-i.left,height:i.bottom-i.top}));var o=n?{top:0,left:0}:e.offset(),r={
+scroll:n?document.documentElement.scrollTop||document.body.scrollTop:e.scrollTop()},a=n?{width:g(window).width(),height:g(window).height()}:null
+;return g.extend({},i,r,a,o)},v.prototype.getCalculatedOffset=function(e,t,n,i){return"bottom"==e?{top:t.top+t.height,left:t.left+t.width/2-n/2
+}:"top"==e?{top:t.top-i,left:t.left+t.width/2-n/2}:"left"==e?{top:t.top+t.height/2-i/2,left:t.left-n}:{top:t.top+t.height/2-i/2,left:t.left+t.width}},
+v.prototype.getViewportAdjustedDelta=function(e,t,n,i){var o={top:0,left:0};if(!this.$viewport)return o
+;var r=this.options.viewport&&this.options.viewport.padding||0,a=this.getPosition(this.$viewport);if(/right|left/.test(e)){var s=t.top-r-a.scroll,
+l=t.top+r-a.scroll+i;s<a.top?o.top=a.top-s:l>a.top+a.height&&(o.top=a.top+a.height-l)}else{var c=t.left-r,u=t.left+r+n
+;c<a.left?o.left=a.left-c:u>a.width&&(o.left=a.left+a.width-u)}return o},v.prototype.getTitle=function(){var e=this.$element,t=this.options
+;return e.attr("data-original-title")||("function"==typeof t.title?t.title.call(e[0]):t.title)},v.prototype.getUID=function(e){for(;e+=~~(
+1e6*Math.random()),document.getElementById(e););return e},v.prototype.tip=function(){return this.$tip=this.$tip||g(this.options.template)},
+v.prototype.arrow=function(){return this.$arrow=this.$arrow||this.tip().find(".tooltip-arrow")},v.prototype.enable=function(){this.enabled=!0},
+v.prototype.disable=function(){this.enabled=!1},v.prototype.toggleEnabled=function(){this.enabled=!this.enabled},v.prototype.toggle=function(e){
+var t=this;e&&((t=g(e.currentTarget).data("bs."+this.type))||(t=new this.constructor(e.currentTarget,this.getDelegateOptions()),g(e.currentTarget
+).data("bs."+this.type,t))),t.tip().hasClass("in")?t.leave(t):t.enter(t)},v.prototype.destroy=function(){var e=this;clearTimeout(this.timeout),
+this.hide(function(){e.$element.off("."+e.type).removeData("bs."+e.type)})};var e=g.fn.tooltip;g.fn.tooltip=function(i){return this.each(function(){
+var e=g(this),t=e.data("bs.tooltip"),n="object"==typeof i&&i;(t||!/destroy|hide/.test(i))&&(t||e.data("bs.tooltip",t=new v(this,n)),
+"string"==typeof i&&t[i]())})},g.fn.tooltip.Constructor=v,g.fn.tooltip.noConflict=function(){return g.fn.tooltip=e,this}}(jQuery),function(s){
+"use strict";function t(n){return this.each(function(){var e=s(this),t=e.data("bs.tab");t||e.data("bs.tab",t=new a(this)),"string"==typeof n&&t[n]()})
+}var a=function(e){this.element=s(e)};a.VERSION="3.3.4",a.TRANSITION_DURATION=150,a.prototype.show=function(){var e=this.element,t=e.closest(
+"ul:not(.dropdown-menu)"),n=e.data("target");if(n||(n=(n=e.attr("href"))&&n.replace(/.*(?=#[^\s]*$)/,"")),!e.parent("li").hasClass("active")){
+var i=t.find(".active:last a"),o=s.Event("hide.bs.tab",{relatedTarget:e[0]}),r=s.Event("show.bs.tab",{relatedTarget:i[0]});if(i.trigger(o),e.trigger(r
+),!r.isDefaultPrevented()&&!o.isDefaultPrevented()){var a=s(n);this.activate(e.closest("li"),t),this.activate(a,a.parent(),function(){i.trigger({
+type:"hidden.bs.tab",relatedTarget:e[0]}),e.trigger({type:"shown.bs.tab",relatedTarget:i[0]})})}}},a.prototype.activate=function(e,t,n){function i(){
+o.removeClass("active").find("> .dropdown-menu > .active").removeClass("active").end().find('[data-toggle="tab"]').attr("aria-expanded",!1),
+e.addClass("active").find('[data-toggle="tab"]').attr("aria-expanded",!0),r?(e[0].offsetWidth,e.addClass("in")):e.removeClass("fade"),e.parent(
+".dropdown-menu").length&&e.closest("li.dropdown").addClass("active").end().find('[data-toggle="tab"]').attr("aria-expanded",!0),n&&n()}var o=t.find(
+"> .active"),r=n&&s.support.transition&&(o.length&&o.hasClass("fade")||!!t.find("> .fade").length);o.length&&r?o.one("bsTransitionEnd",i
+).emulateTransitionEnd(a.TRANSITION_DURATION):i(),o.removeClass("in")};var e=s.fn.tab;s.fn.tab=t,s.fn.tab.Constructor=a,s.fn.tab.noConflict=function(
+){return s.fn.tab=e,this};var n=function(e){e.preventDefault(),t.call(s(this),"show")};s(document).on("click.bs.tab.data-api",'[data-toggle="tab"]',n
+).on("click.bs.tab.data-api",'[data-toggle="pill"]',n)}(jQuery),function(a){"use strict";function o(e){var t,n=e.attr("data-target")||(t=e.attr("href"
+))&&t.replace(/.*(?=#[^\s]+$)/,"");return a(n)}function s(i){return this.each(function(){var e=a(this),t=e.data("bs.collapse"),n=a.extend({},
+l.DEFAULTS,e.data(),"object"==typeof i&&i);!t&&n.toggle&&/show|hide/.test(i)&&(n.toggle=!1),t||e.data("bs.collapse",t=new l(this,n)),
+"string"==typeof i&&t[i]()})}var l=function(e,t){this.$element=a(e),this.options=a.extend({},l.DEFAULTS,t),this.$trigger=a(
+'[data-toggle="collapse"][href="#'+e.id+'"],[data-toggle="collapse"][data-target="#'+e.id+'"]'),this.transitioning=null,
+this.options.parent?this.$parent=this.getParent():this.addAriaAndCollapsedClass(this.$element,this.$trigger),this.options.toggle&&this.toggle()}
+;l.VERSION="3.3.4",l.TRANSITION_DURATION=350,l.DEFAULTS={toggle:!0},l.prototype.dimension=function(){return this.$element.hasClass("width"
+)?"width":"height"},l.prototype.show=function(){if(!this.transitioning&&!this.$element.hasClass("in")){var e,t=this.$parent&&this.$parent.find(
+".tile-collapse").children(".in, .collapsing");if(!(t&&t.length&&((e=t.data("bs.collapse"))&&e.transitioning))){var n=a.Event("show.bs.collapse");if(
+this.$element.trigger(n),!n.isDefaultPrevented()){t&&t.length&&(s.call(t,"hide"),e||t.data("bs.collapse",null));var i=this.dimension()
+;this.$element.removeClass("collapse").addClass("collapsing")[i](0).attr("aria-expanded",!0),this.$trigger.removeClass("collapsed").attr(
+"aria-expanded",!0),this.transitioning=1;var o=function(){this.$element.removeClass("collapsing").addClass("collapse in")[i](""),this.transitioning=0,
+this.$element.trigger("shown.bs.collapse")};if(!a.support.transition)return o.call(this);var r=a.camelCase(["scroll",i].join("-"));this.$element.one(
+"bsTransitionEnd",a.proxy(o,this)).emulateTransitionEnd(l.TRANSITION_DURATION)[i](this.$element[0][r])}}}},l.prototype.hide=function(){if(
+!this.transitioning&&this.$element.hasClass("in")){var e=a.Event("hide.bs.collapse");if(this.$element.trigger(e),!e.isDefaultPrevented()){
+var t=this.dimension();this.$element[t](this.$element[t]())[0].offsetHeight,this.$element.addClass("collapsing").removeClass("collapse in").attr(
+"aria-expanded",!1),this.$trigger.addClass("collapsed").attr("aria-expanded",!1),this.transitioning=1;var n=function(){this.transitioning=0,
+this.$element.removeClass("collapsing").addClass("collapse").trigger("hidden.bs.collapse")};return a.support.transition?void this.$element[t](0).one(
+"bsTransitionEnd",a.proxy(n,this)).emulateTransitionEnd(l.TRANSITION_DURATION):n.call(this)}}},l.prototype.toggle=function(){
+this[this.$element.hasClass("in")?"hide":"show"]()},l.prototype.getParent=function(){return a(this.options.parent).find(
+'[data-toggle="collapse"][data-parent="'+this.options.parent+'"]').each(a.proxy(function(e,t){var n=a(t);this.addAriaAndCollapsedClass(o(n),n)},this)
+).end()},l.prototype.addAriaAndCollapsedClass=function(e,t){var n=e.hasClass("in");e.attr("aria-expanded",n),t.toggleClass("collapsed",!n).attr(
+"aria-expanded",n)};var e=a.fn.collapse;a.fn.collapse=s,a.fn.collapse.Constructor=l,a.fn.collapse.noConflict=function(){return a.fn.collapse=e,this},
+a(document).on("click.bs.collapse.data-api",'[data-toggle="collapse"]',function(e){var t=a(this);t.attr("data-target")||e.preventDefault();var n=o(t),
+i=n.data("bs.collapse")?"toggle":t.data();s.call(n,i)})}(jQuery),function(i){"use strict";i.fn.emulateTransitionEnd=function(e){var t=!1,n=this;i(this
+).one("bsTransitionEnd",function(){t=!0});return setTimeout(function(){t||i(n).trigger(i.support.transition.end)},e),this},i(function(){
+i.support.transition=function(){var e=document.createElement("bootstrap"),t={WebkitTransition:"webkitTransitionEnd",MozTransition:"transitionend",
+OTransition:"oTransitionEnd otransitionend",transition:"transitionend"};for(var n in t)if(void 0!==e.style[n])return{end:t[n]};return!1}(),
+i.support.transition&&(i.event.special.bsTransitionEnd={bindType:i.support.transition.end,delegateType:i.support.transition.end,handle:function(e){
+return i(e.target).is(this)?e.handleObj.handler.apply(this,arguments):void 0}})})}(jQuery);var contentPadding=0,footerOffset=0;$(".content").length&&(
+contentPadding=parseInt($(".content").css("padding-bottom").replace("px",""))),$(window).on("scroll",function(){$(".content-fix").each(function(){$(
+this).outerHeight()<$(this).closest(".row-fix").outerHeight()&&contentFix($(this))})});var contentFix=function(e){
+var t=window.innerHeight+window.pageYOffset;window.pageYOffset>=e.offset().top-headerHeight?(e.is('[class*="col-xx"]')||e.is('[class*="col-xs"]'
+)&&480<=$(window).width()||e.is('[class*="col-sm"]')&&768<=$(window).width()||e.is('[class*="col-md"]')&&992<=$(window).width()||e.is(
+'[class*="col-lg"]')&&1440<=$(window).width())&&(e.hasClass("fixed")||(e.addClass("fixed"),$(".content-fix-wrap",e).scrollTop(0)),
+0!=footerOffset&&footerOffset<=t&&$(".content-fix-inner",e).css("padding-bottom",t-footerOffset+contentPadding)):(e.removeClass("fixed"),$(
+".content-fix-inner",e).css("padding-bottom",""))},contentFixPushCal=function(){$(".content-fix-scroll").each(function(){$(this).css("width",$(this
+).closest(".content-fix").outerWidth()),$(".content-fix-inner",$(this)).css("width",$(this).closest(".content-fix").width())}),$(".footer").length&&(
+footerOffset=$(".footer").offset().top)};function floatingLabel(e){var t=e.closest(".form-group-label");e.val()?t.addClass("control-highlight"
+):t.removeClass("control-highlight")}$(".collapse-description").click(function(){var e=$(this),t=e.data(),n=$("#"+t.target);n.find(
+"tr > *:nth-child(2)").toggle(!t.expanded),n.find("tr > *:nth-child(3)").toggle(!t.expanded),e.data("expanded",!t.expanded),e.text(
+t.expanded?"Collapse All":"Expand All"),t.installed||(e.data("installed",!0),$("#"+t.target+" TBODY TR").click(function(){var e=$(this),t=e.find(
+"*:nth-child(2)").is(":visible");e.find("*:nth-child(2)").toggle(t),e.find("*:nth-child(3)").toggle(t)}))}),function(e){
+"function"==typeof define&&define.amd?define("picker",["jquery"],e):"object"==typeof exports?module.exports=e(require("jquery")):this.Picker=e(jQuery)
+}(function(m){function g(o,r,a,e){function s(){return g._.node("div",g._.node("div",g._.node("div",g._.node("div",f.component.nodes(u.open),h.box),
+h.wrap),h.frame),h.holder,'tabindex="-1"')}function l(e){e.stopPropagation(),p.addClass(h.target),f.$root.addClass(h.focused),f.open()}function c(e){
+var t=e.keyCode,n=/^(8|46)$/.test(t);return 27==t?(f.close(!0),!1):void((32==t||n||!u.open&&f.component.key[t])&&(e.preventDefault(),
+e.stopPropagation(),n?f.clear().close():f.open()))}if(!o)return g;var u={id:o.id||"P"+Math.abs(~~(Math.random()*new Date))},d=a?m.extend(!0,{},
+a.defaults,e):e||{},h=m.extend({},g.klasses(),d.klass),p=m(o),t=function(){return this.start()},f=t.prototype={constructor:t,$node:p,start:function(){
+return u&&u.start?f:(u.methods={},u.start=!0,u.open=!1,u.type=o.type,o.autofocus=o==y(),o.readOnly=!d.editable,o.id=o.id||u.id,"text"!=o.type&&(
+o.type="text"),f.component=new a(f,d),f.$root=m('<div class="'+h.picker+'" id="'+o.id+'_root" />'),v(f.$root[0],"hidden",!0),f.$holder=m(s()
+).appendTo(f.$root),f.$holder.on({keydown:c,"focus.toOpen":l,blur:function(){p.removeClass(h.target)},focusin:function(e){f.$root.removeClass(
+h.focused),e.stopPropagation()},"mousedown click":function(e){var t=e.target;t!=f.$holder[0]&&(e.stopPropagation(),"mousedown"!=e.type||m(t).is(
+"input, select, textarea, button, option")||(e.preventDefault(),f.$holder[0].focus()))}}).on("click",
+"[data-pick], [data-nav], [data-clear], [data-close]",function(){var e=m(this),t=e.data(),n=e.hasClass(h.navDisabled)||e.hasClass(h.disabled),i=y()
+;i=i&&(i.type||i.href),(n||i&&!m.contains(f.$root[0],i))&&f.$holder[0].focus(),!n&&t.nav?f.set("highlight",f.component.item.highlight,{nav:t.nav}
+):!n&&"pick"in t?(f.set("select",t.pick),d.closeOnSelect&&f.close(!0)):t.clear?(f.clear(),d.closeOnClear&&f.close(!0)):t.close&&f.close(!0)}),
+d.formatSubmit&&(!0===d.hiddenName?(i=o.name,o.name=""):i=(i=["string"==typeof d.hiddenPrefix?d.hiddenPrefix:"",
+"string"==typeof d.hiddenSuffix?d.hiddenSuffix:"_submit"])[0]+o.name+i[1],f._hidden=m('<input type=hidden name="'+i+'"'+(p.data("value"
+)||o.value?' value="'+f.get("select",d.formatSubmit)+'"':"")+">")[0],p.on("change."+u.id,function(){f._hidden.value=o.value?f.get("select",
+d.formatSubmit):""})),p.data(r,f).addClass(h.input).val(p.data("value")?f.get("select",d.format):o.value),d.editable||p.on(
+"focus."+u.id+" click."+u.id,function(e){e.preventDefault(),f.open()}).on("keydown."+u.id,c),v(o,{haspopup:!0,expanded:!1,readonly:!1,
+owns:o.id+"_root"}),d.containerHidden?m(d.containerHidden).append(f._hidden):p.after(f._hidden),d.container?m(d.container).append(f.$root):p.after(
+f.$root),f.on({start:f.component.onStart,render:f.component.onRender,stop:f.component.onStop,open:f.component.onOpen,close:f.component.onClose,
+set:f.component.onSet}).on({start:d.onStart,render:d.onRender,stop:d.onStop,open:d.onOpen,close:d.onClose,set:d.onSet}),e=f.$holder[0],n="position",
+e.currentStyle?t=e.currentStyle[n]:window.getComputedStyle&&(t=getComputedStyle(e)[n]),"fixed"==t,o.autofocus&&f.open(),f.trigger("start").trigger(
+"render"));var e,t,n,i},render:function(e){return e?(f.$holder=s(),f.$root.html(f.$holder)):f.$root.find("."+h.box).html(f.component.nodes(u.open)),
+f.trigger("render")},stop:function(){return u.start&&(f.close(),f._hidden&&f._hidden.parentNode.removeChild(f._hidden),f.$root.remove(),p.removeClass(
+h.input).removeData(r),setTimeout(function(){p.off("."+u.id)},0),o.type=u.type,o.readOnly=!1,f.trigger("stop"),u.methods={},u.start=!1),f},
+open:function(e){return u.open?f:(p.addClass(h.active),v(o,"expanded",!0),setTimeout(function(){f.$root.addClass(h.opened),v(f.$root[0],"hidden",!1)},
+0),!1!==e&&(u.open=!0,f.$holder[0].focus(),n.on("click."+u.id+" focusin."+u.id,function(e){var t=e.target;t!=o&&t!=document&&3!=e.which&&f.close(
+t===f.$holder[0])}).on("keydown."+u.id,function(e){var t=e.keyCode,n=f.component.key[t],i=e.target;27==t?f.close(!0
+):i!=f.$holder[0]||!n&&13!=t?m.contains(f.$root[0],i)&&13==t&&(e.preventDefault(),i.click()):(e.preventDefault(),n?g._.trigger(f.component.key.go,f,[
+g._.trigger(n)]):f.$root.find("."+h.highlighted).hasClass(h.disabled)||(f.set("select",f.component.item.highlight),d.closeOnSelect&&f.close(!0)))})),
+f.trigger("open"))},close:function(e){return e&&(d.editable?o.focus():(f.$holder.off("focus.toOpen").focus(),setTimeout(function(){f.$holder.on(
+"focus.toOpen",l)},0))),p.removeClass(h.active),v(o,"expanded",!1),setTimeout(function(){f.$root.removeClass(h.opened+" "+h.focused),v(f.$root[0],
+"hidden",!0)},0),u.open?(u.open=!1,n.off("."+u.id),f.trigger("close")):f},clear:function(e){return f.set("clear",null,e)},set:function(e,t,n){var i,o,
+r=m.isPlainObject(e),a=r?e:{};if(n=r&&m.isPlainObject(t)?t:n||{},e){for(i in r||(a[e]=t),a)o=a[i],i in f.component.item&&(void 0===o&&(o=null),
+f.component.set(i,o,n)),("select"==i||"clear"==i)&&p.val("clear"==i?"":f.get(i,d.format)).trigger("change");f.render()}return n.muted?f:f.trigger(
+"set",a)},get:function(e,t){if(null!=u[e=e||"value"])return u[e];if("valueSubmit"==e){if(f._hidden)return f._hidden.value;e="value"}if("value"==e
+)return o.value;if(e in f.component.item){if("string"!=typeof t)return f.component.get(e);var n=f.component.get(e);return n?g._.trigger(
+f.component.formats.toString,f.component,[t,n]):""}},on:function(e,t,n){var i,o,r=m.isPlainObject(e),a=r?e:{};if(e)for(i in r||(a[e]=t),a)o=a[i],n&&(
+i="_"+i),u.methods[i]=u.methods[i]||[],u.methods[i].push(o);return f},off:function(){var e,t,n=arguments;for(e=0,namesCount=n.length;namesCount>e;e+=1
+)(t=n[e])in u.methods&&delete u.methods[t];return f},trigger:function(e,n){var t=function(e){var t=u.methods[e];t&&t.map(function(e){g._.trigger(e,f,[
+n])})};return t("_"+e),t(e),f}};return new t}function v(e,t,n){if(m.isPlainObject(t))for(var i in t)o(e,i,t[i]);else o(e,t,n)}function o(e,t,n){
+e.setAttribute(("role"==t?"":"aria-")+t,n)}function y(){try{return document.activeElement}catch(e){}}m(window);var n=m(document);return m(
+document.documentElement),document.body.style.transition,g.klasses=function(e){return{picker:e=e||"picker",opened:e+"--opened",focused:e+"--focused",
+input:e+"__input",active:e+"__input--active",target:e+"__input--target",holder:e+"__holder",frame:e+"__frame",wrap:e+"__wrap",box:e+"__box"}},g._={
+group:function(e){for(var t,n="",i=g._.trigger(e.min,e);i<=g._.trigger(e.max,e,[i]);i+=e.i)t=g._.trigger(e.item,e,[i]),n+=g._.node(e.node,t[0],t[1],
+t[2]);return n},node:function(e,t,n,i){return t?"<"+e+(n=n?' class="'+n+'"':"")+(i=i?" "+i:"")+">"+(t=m.isArray(t)?t.join(""):t)+"</"+e+">":""},
+lead:function(e){return(e<10?"0":"")+e},trigger:function(e,t,n){return"function"==typeof e?e.apply(t,n||[]):e},digits:function(e){return/\d/.test(e[1]
+)?2:1},isDate:function(e){return-1<{}.toString.call(e).indexOf("Date")&&this.isInteger(e.getDate())},isInteger:function(e){return-1<{}.toString.call(e
+).indexOf("Number")&&0==e%1},ariaAttr:function(e,t){for(var n in m.isPlainObject(e)||(e={attribute:t}),t="",e){var i=("role"==n?"":"aria-")+n
+;t+=null==e[n]?"":i+'="'+e[n]+'"'}return t}},g.extend=function(i,o){m.fn[i]=function(e,t){var n=this.data(i)
+;return"picker"==e?n:n&&"string"==typeof e?g._.trigger(n[e],n,[t]):this.each(function(){m(this).data(i)||new g(this,i,o,e)})},
+m.fn[i].defaults=o.defaults},g}),function(e){"function"==typeof define&&define.amd?define(["picker","jquery"],e
+):"object"==typeof exports?module.exports=e(require("./picker.js"),require("jquery")):e(Picker,jQuery)}(function(e,f){function t(t,n){var e,i=this,
+o=t.$node[0],r=o.value,a=t.$node.data("value"),s=a?n.formatSubmit:n.format,l=a||r,c=function(){
+return o.currentStyle?"rtl"==o.currentStyle.direction:"rtl"==getComputedStyle(t.$root[0]).direction};i.settings=n,i.$node=t.$node,i.queue={
+min:"measure create",max:"measure create",now:"now create",select:"parse create validate",highlight:"parse navigate create validate",
+view:"parse create validate viewset",disable:"deactivate",enable:"activate"},i.item={},i.item.clear=null,i.item.disable=(n.disable||[]).slice(0),
+i.item.enable=-(!0===(e=i.item.disable)[0]?e.shift():-1),i.set("min",n.min).set("max",n.max).set("now"),l?i.set("select",l,{format:s,defaultValue:!0}
+):i.set("select",null).set("highlight",i.item.now),i.key={40:7,38:-7,39:function(){return c()?-1:1},37:function(){return c()?1:-1},go:function(e){
+var t=i.item.highlight,n=new Date(t.year,t.month,t.date+e);i.set("highlight",n,{interval:e}),this.render()}},t.on("render",function(){t.$root.find(
+"."+n.klass.selectMonth).on("change",function(){var e=this.value;e&&(t.set("highlight",[t.get("view").year,e,t.get("highlight").date]),t.$root.find(
+"."+n.klass.selectMonth).trigger("focus"))}),t.$root.find("."+n.klass.selectYear).on("change",function(){var e=this.value;e&&(t.set("highlight",[e,
+t.get("view").month,t.get("highlight").date]),t.$root.find("."+n.klass.selectYear).trigger("focus"))})},1).on("open",function(){var e="";i.disabled(
+i.get("now"))&&(e=":not(."+n.klass.buttonToday+")"),t.$root.find("button"+e+", select").attr("disabled",!1)},1).on("close",function(){t.$root.find(
+"button, select").attr("disabled",!0)},1)}var n,v=e._;t.prototype.set=function(t,n,i){var o=this,e=o.item;return null===n?("clear"==t&&(t="select"),
+e[t]=n):(e["enable"==t?"disable":"flip"==t?"enable":t]=o.queue[t].split(" ").map(function(e){return n=o[e](t,n,i)}).pop(),"select"==t?o.set(
+"highlight",e.select,i):"highlight"==t?o.set("view",e.highlight,i):t.match(/^(flip|min|max|disable|enable)$/)&&(e.select&&o.disabled(e.select)&&o.set(
+"select",e.select,i),e.highlight&&o.disabled(e.highlight)&&o.set("highlight",e.highlight,i))),o},t.prototype.get=function(e){return this.item[e]},
+t.prototype.create=function(e,t,n){var i;return(t=void 0===t?e:t)==-1/0||1/0==t?i=t:t=f.isPlainObject(t)&&v.isInteger(t.pick)?t.obj:f.isArray(t)?(
+t=new Date(t[0],t[1],t[2]),v.isDate(t)?t:this.create().obj):v.isInteger(t)||v.isDate(t)?this.normalize(new Date(t),n):this.now(e,t,n),{
+year:i||t.getFullYear(),month:i||t.getMonth(),date:i||t.getDate(),day:i||t.getDay(),obj:i||t,pick:i||t.getTime()}},t.prototype.createRange=function(e,
+t){var n=this,i=function(e){return!0===e||f.isArray(e)||v.isDate(e)?n.create(e):e};return v.isInteger(e)||(e=i(e)),v.isInteger(t)||(t=i(t)),
+v.isInteger(e)&&f.isPlainObject(t)?e=[t.year,t.month,t.date+e]:v.isInteger(t)&&f.isPlainObject(e)&&(t=[e.year,e.month,e.date+t]),{from:i(e),to:i(t)}},
+t.prototype.withinRange=function(e,t){return e=this.createRange(e.from,e.to),t.pick>=e.from.pick&&t.pick<=e.to.pick},
+t.prototype.overlapRanges=function(e,t){var n=this;return e=n.createRange(e.from,e.to),t=n.createRange(t.from,t.to),n.withinRange(e,t.from
+)||n.withinRange(e,t.to)||n.withinRange(t,e.from)||n.withinRange(t,e.to)},t.prototype.now=function(e,t,n){return t=new Date,n&&n.rel&&t.setDate(
+t.getDate()+n.rel),this.normalize(t,n)},t.prototype.navigate=function(e,t,n){var i,o,r,a,s=f.isArray(t),l=f.isPlainObject(t),c=this.item.view;if(s||l
+){for(a=l?(o=t.year,r=t.month,t.date):(o=+t[0],r=+t[1],+t[2]),n&&n.nav&&c&&c.month!==r&&(o=c.year,r=c.month),o=(i=new Date(o,r+(n&&n.nav?n.nav:0),1)
+).getFullYear(),r=i.getMonth();new Date(o,r,a).getMonth()!==r;)a-=1;t=[o,r,a]}return t},t.prototype.normalize=function(e){return e.setHours(0,0,0,0),e
+},t.prototype.measure=function(e,t){return t?"string"==typeof t?t=this.parse(e,t):v.isInteger(t)&&(t=this.now(e,t,{rel:t})):t="min"==e?-1/0:1/0,t},
+t.prototype.viewset=function(e,t){return this.create([t.year,t.month,1])},t.prototype.validate=function(e,n,t){var i,o,r,a,s=this,l=n,
+c=t&&t.interval?t.interval:1,u=-1===s.item.enable,d=s.item.min,h=s.item.max,p=u&&s.item.disable.filter(function(e){if(f.isArray(e)){var t=s.create(e
+).pick;t<n.pick?i=!0:t>n.pick&&(o=!0)}return v.isInteger(e)}).length;if((!t||!t.nav&&!t.defaultValue)&&(!u&&s.disabled(n)||u&&s.disabled(n)&&(p||i||o
+)||!u&&(n.pick<=d.pick||n.pick>=h.pick)))for(u&&!p&&(!o&&0<c||!i&&c<0)&&(c*=-1);s.disabled(n)&&(1<Math.abs(c)&&(n.month<l.month||n.month>l.month)&&(
+n=l,c=0<c?1:-1),n.pick<=d.pick?(r=!0,c=1,n=s.create([d.year,d.month,d.date+(n.pick===d.pick?0:-1)])):n.pick>=h.pick&&(a=!0,c=-1,n=s.create([h.year,
+h.month,h.date+(n.pick===h.pick?0:1)])),!r||!a);)n=s.create([n.year,n.month,n.date+c]);return n},t.prototype.disabled=function(t){var n=this,
+e=n.item.disable.filter(function(e){return v.isInteger(e)?t.day===(n.settings.firstDay?e:e-1)%7:f.isArray(e)||v.isDate(e)?t.pick===n.create(e
+).pick:f.isPlainObject(e)?n.withinRange(e,t):void 0});return e=e.length&&!e.filter(function(e){return f.isArray(e)&&"inverted"==e[3]||f.isPlainObject(
+e)&&e.inverted}).length,-1===n.item.enable?!e:e||t.pick<n.item.min.pick||t.pick>n.item.max.pick},t.prototype.parse=function(e,i,t){var o=this,r={}
+;return i&&"string"==typeof i?(t&&t.format||((t=t||{}).format=o.settings.format),o.formats.toArray(t.format).map(function(e){var t=o.formats[e],
+n=t?v.trigger(t,o,[i,r]):e.replace(/^!/,"").length;t&&(r[e]=i.substr(0,n)),i=i.substr(n)}),[r.yyyy||r.yy,+(r.mm||r.m)-1,r.dd||r.d]):i},
+t.prototype.formats=function(){function i(e,t,n){var i=e.match(/[^\x00-\x7F]+|\w+/)[0];return n.mm||n.m||(n.m=t.indexOf(i)+1),i.length}function n(e){
+return e.match(/\w+/)[0].length}return{d:function(e,t){return e?v.digits(e):t.date},dd:function(e,t){return e?2:v.lead(t.date)},ddd:function(e,t){
+return e?n(e):this.settings.weekdaysShort[t.day]},dddd:function(e,t){return e?n(e):this.settings.weekdaysFull[t.day]},m:function(e,t){
+return e?v.digits(e):t.month+1},mm:function(e,t){return e?2:v.lead(t.month+1)},mmm:function(e,t){var n=this.settings.monthsShort;return e?i(e,n,t
+):n[t.month]},mmmm:function(e,t){var n=this.settings.monthsFull;return e?i(e,n,t):n[t.month]},yy:function(e,t){return e?2:(""+t.year).slice(2)},
+yyyy:function(e,t){return e?4:t.year},toArray:function(e){return e.split(/(d{1,4}|m{1,4}|y{4}|yy|!.)/g)},toString:function(e,t){var n=this
+;return n.formats.toArray(e).map(function(e){return v.trigger(n.formats[e],n,[0,t])||e.replace(/^!/,"")}).join("")}}}(),
+t.prototype.isDateExact=function(e,t){return v.isInteger(e)&&v.isInteger(t)||"boolean"==typeof e&&"boolean"==typeof t?e===t:(v.isDate(e)||f.isArray(e)
+)&&(v.isDate(t)||f.isArray(t))?this.create(e).pick===this.create(t).pick:!(!f.isPlainObject(e)||!f.isPlainObject(t))&&(this.isDateExact(e.from,t.from
+)&&this.isDateExact(e.to,t.to))},t.prototype.isDateOverlap=function(e,t){var n=this.settings.firstDay?1:0;return v.isInteger(e)&&(v.isDate(t
+)||f.isArray(t))?(e=e%7+n)===this.create(t).day+1:v.isInteger(t)&&(v.isDate(e)||f.isArray(e))?(t=t%7+n)===this.create(e).day+1:!(!f.isPlainObject(e
+)||!f.isPlainObject(t))&&this.overlapRanges(e,t)},t.prototype.flipEnable=function(e){var t=this.item;t.enable=e||(-1==t.enable?1:-1)},
+t.prototype.deactivate=function(e,t){var i=this,o=i.item.disable.slice(0);return"flip"==t?i.flipEnable():!1===t?(i.flipEnable(1),o=[]):!0===t?(
+i.flipEnable(-1),o=[]):t.map(function(e){for(var t,n=0;n<o.length;n+=1)if(i.isDateExact(e,o[n])){t=!0;break}t||(v.isInteger(e)||v.isDate(e
+)||f.isArray(e)||f.isPlainObject(e)&&e.from&&e.to)&&o.push(e)}),o},t.prototype.activate=function(e,t){var r=this,a=r.item.disable,s=a.length
+;return"flip"==t?r.flipEnable():!0===t?(r.flipEnable(1),a=[]):!1===t?(r.flipEnable(-1),a=[]):t.map(function(e){var t,n,i,o;for(i=0;i<s;i+=1){if(n=a[i]
+,r.isDateExact(n,e)){t=a[i]=null,o=!0;break}if(r.isDateOverlap(n,e)){f.isPlainObject(e)?(e.inverted=!0,t=e):f.isArray(e)?(t=e)[3]||t.push("inverted"
+):v.isDate(e)&&(t=[e.getFullYear(),e.getMonth(),e.getDate(),"inverted"]);break}}if(t)for(i=0;i<s;i+=1)if(r.isDateExact(a[i],e)){a[i]=null;break}if(o
+)for(i=0;i<s;i+=1)if(r.isDateOverlap(a[i],e)){a[i]=null;break}t&&a.push(t)}),a.filter(function(e){return null!=e})},t.prototype.nodes=function(c){
+var t,n,u=this,d=u.settings,e=u.item,a=e.now,s=e.select,l=e.highlight,h=e.view,p=e.disable,f=e.min,m=e.max,i=(t=(
+d.showWeekdaysFull?d.weekdaysFull:d.weekdaysLetter).slice(0),n=d.weekdaysFull.slice(0),d.firstDay&&(t.push(t.shift()),n.push(n.shift())),v.node(
+"thead",v.node("tr",v.group({min:0,max:6,i:1,node:"th",item:function(e){return[t[e],d.klass.weekdays,'scope=col title="'+n[e]+'"']}})))),o=function(e
+){return v.node("div"," ",d.klass["nav"+(e?"Next":"Prev")]+(
+e&&h.year>=m.year&&h.month>=m.month||!e&&h.year<=f.year&&h.month<=f.month?" "+d.klass.navDisabled:""),"data-nav="+(e||-1)+" "+v.ariaAttr({
+role:"button",controls:u.$node[0].id+"_table"})+' title="'+(e?d.labelMonthNext:d.labelMonthPrev)+'"')},r=function(e){
+var t=d.showMonthsShort?d.monthsShort:d.monthsFull;return"short_months"==e&&(t=d.monthsShort),d.selectMonths&&null==e?v.node("select",v.group({min:0,
+max:11,i:1,node:"option",item:function(e){return[t[e],0,"value="+e+(h.month==e?" selected":"")+(
+h.year==f.year&&e<f.month||h.year==m.year&&e>m.month?" disabled":"")]}}),d.klass.selectMonth+" browser-default",(c?"":"disabled")+" "+v.ariaAttr({
+controls:u.$node[0].id+"_table"})+' title="'+d.labelMonthSelect+'"'):"short_months"==e?null!=s?v.node("div",t[s.month]):v.node("div",t[h.month]
+):v.node("div",t[h.month],d.klass.month)},g=function(e){var t=h.year,n=!0===d.selectYears?5:~~(d.selectYears/2);if(n){var i=f.year,o=m.year,r=t-n,
+a=t+n;if(r<i&&(a+=i-r,r=i),o<a){var s=r-i,l=a-o;r-=l<s?l:s,a=o}if(d.selectYears&&null==e)return v.node("select",v.group({min:r,max:a,i:1,
+node:"option",item:function(e){return[e,0,"value="+e+(t==e?" selected":"")]}}),d.klass.selectYear+" browser-default",(c?"":"disabled")+" "+v.ariaAttr(
+{controls:u.$node[0].id+"_table"})+' title="'+d.labelYearSelect+'"')}return"raw"==e?v.node("div",t):v.node("div",t,d.klass.year)}
+;return createDayLabel=function(){return null!=s?v.node("div",s.date):v.node("div",a.date)},createWeekdayLabel=function(){var e
+;return e=null!=s?s.day:a.day,d.weekdaysFull[e]},v.node("div",v.node("div",createWeekdayLabel(),"picker__weekday-display")+v.node("div",r(
+"short_months"),d.klass.month_display)+v.node("div",createDayLabel(),d.klass.day_display)+v.node("div",g("raw"),d.klass.year_display),
+d.klass.date_display)+v.node("div",(d.selectYears?g()+r():r()+g())+o()+o(1),d.klass.header)+v.node("table",i+v.node("tbody",v.group({min:0,max:5,i:1,
+node:"tr",item:function(e){var t=d.firstDay&&0===u.create([h.year,h.month,1]).day?-7:0;return[v.group({min:7*e-h.day+t+1,max:function(){
+return this.min+7-1},i:1,node:"td",item:function(e){e=u.create([h.year,h.month,e+(d.firstDay?1:0)]);var t,n=s&&s.pick==e.pick,i=l&&l.pick==e.pick,
+o=p&&u.disabled(e)||e.pick<f.pick||e.pick>m.pick,r=v.trigger(u.formats.toString,u,[d.format,e]);return[v.node("div",e.date,(t=[d.klass.day],t.push(
+h.month==e.month?d.klass.infocus:d.klass.outfocus),a.pick==e.pick&&t.push(d.klass.now),n&&t.push(d.klass.selected),i&&t.push(d.klass.highlighted),
+o&&t.push(d.klass.disabled),t.join(" ")),"data-pick="+e.pick+" "+v.ariaAttr({role:"gridcell",label:r,selected:!(!n||u.$node.val()!==r)||null,
+activedescendant:!!i||null,disabled:!!o||null})),"",v.ariaAttr({role:"presentation"})]}})]}})),d.klass.table,
+'id="'+u.$node[0].id+'_table" '+v.ariaAttr({role:"grid",controls:u.$node[0].id,readonly:!0}))+v.node("div",v.node("button",d.today,d.klass.buttonToday
+,"type=button data-pick="+a.pick+(c&&!u.disabled(a)?"":" disabled")+" "+v.ariaAttr({controls:u.$node[0].id}))+v.node("button",d.clear,
+d.klass.buttonClear,"type=button data-clear=1"+(c?"":" disabled")+" "+v.ariaAttr({controls:u.$node[0].id}))+v.node("button",d.close,
+d.klass.buttonClose,"type=button data-close=true "+(c?"":" disabled")+" "+v.ariaAttr({controls:u.$node[0].id})),d.klass.footer)},t.defaults={
+labelMonthNext:"Next month",labelMonthPrev:"Previous month",labelMonthSelect:"Select a month",labelYearSelect:"Select a year",monthsFull:["January",
+"February","March","April","May","June","July","August","September","October","November","December"],monthsShort:["Jan","Feb","Mar","Apr","May","Jun",
+"Jul","Aug","Sep","Oct","Nov","Dec"],weekdaysFull:["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],weekdaysShort:["Sun","Mon",
+"Tue","Wed","Thu","Fri","Sat"],weekdaysLetter:["S","M","T","W","T","F","S"],today:"Today",clear:"Cancel",close:"OK",closeOnClear:!0,format:"d/m/yyyy",
+klass:{table:(n=e.klasses().picker+"__")+"table",header:n+"header",date_display:n+"date-display",day_display:n+"day-display",
+month_display:n+"month-display",year_display:n+"year-display",calendar_container:n+"calendar-container",
+navPrev:n+"nav--prev icon icon-keyboard-arrow-left",navNext:n+"nav--next icon icon-keyboard-arrow-right",navDisabled:n+"nav--disabled",
+month:n+"month",year:n+"year",selectMonth:n+"select--month",selectYear:n+"select--year",weekdays:n+"weekday",day:n+"day",disabled:n+"day--disabled",
+selected:n+"day--selected",highlighted:n+"day--highlighted",now:n+"day--today",infocus:n+"day--infocus",outfocus:n+"day--outfocus",footer:n+"footer",
+buttonClear:n+"button--clear btn btn-flat btn-alt",buttonToday:n+"button--today btn btn-flat btn-alt",
+buttonClose:n+"button--close btn btn-flat btn-alt"}},e.extend("pickadate",t)}),$(".datepicker-adv-default").each(function(e){var t=$(this).pickadate({
+container:"body"}).pickadate("picker");t.on({close:function(){$(document.activeElement).blur()},open:function(){t.set("select",t.get(),{
+format:"d/m/yyyy"})}})}),$(document).on("hide.bs.dropdown",".dropdown",function(){$(this).parents(".header").length&&$("header").removeClass("open")})
+,$(document).on("show.bs.dropdown",".dropdown",function(){var e,t=$(".dropdown-menu",$(this)),n=$('[class*="dropdown-toggle"]',$(this)),i=$("a",t
+).css("padding-left").replace("px","");t.length&&n.length&&(e=t.hasClass("dropdown-menu-right")||t.parents(".nav.pull-right").length?n.offset(
+).left+n.outerWidth()-i:window.innerWidth-n.offset().left-i,t.css("max-width",e),t.parents(".header").length&&$("header").addClass("open"))}),$(
+document).keyup(function(e){"27"==e.which&&($(".menu.open").length?mReset():$("body").hasClass("modal-open")||tReset())}).keydown(function(e){if(
+/input|textarea/i.test(e.target.tagName)){if(9===e.which&&"TEXTAREA"==e.target.tagName){var t=e.target;t.value=t.value.slice(0,t.selectionStart
+)+String.fromCharCode(9)+t.value.slice(t.selectionStart)}}else 191===e.which&&(e.preventDefault(),$(".menu-toggle").click())}),footerPush=function(){
+$(".footer").length&&$("body").css("margin-bottom",$(".footer").outerHeight())},$(".checkbox-adv").each(function(){$("label",$(this)).append(
+'<span class="circle"></span><span class="circle-check"></span><span class="circle-icon icon icon-done"></span>')}),$(".radio-adv").each(function(){$(
+"label",$(this)).append('<span class="circle"></span><span class="circle-check"></span>')}),$(".form-group-label").length&&$(
+".form-group-label .form-control").each(function(){floatingLabel($(this))}),$(document).on("change",".form-group-label .form-control",function(){
+floatingLabel($(this))}),$(document).on("focusin",".form-group-label .form-control",function(){$(this).closest(".form-group-label").addClass(
+"control-focus")}),$(document).on("focusout",".form-group-label .form-control",function(){$(this).closest(".form-group-label").removeClass(
+"control-focus")}),$(document).on("focusin",".form-group-icon .form-control",function(){$(this).closest(".form-group-icon").addClass("control-focus")}
+),$(document).on("focusout",".form-group-icon .form-control",function(){$(this).closest(".form-group-icon").removeClass("control-focus")}),$(document
+).on("click",".switch-toggle",function(){var e=$(this);e.hasClass("switch-toggle-on")||(e.addClass("switch-toggle-on"),setTimeout(function(){
+e.removeClass("switch-toggle-on")},300))}),function(o,r,e,t){function n(e,t){this.element=e,this.$element=o(e),this.init()}var i="textareaAutoSize",
+a="plugin_"+i;n.prototype={init:function(){var i=parseInt(this.$element.css("paddingBottom"))+parseInt(this.$element.css("paddingTop"))+parseInt(
+this.$element.css("borderTopWidth"))+parseInt(this.$element.css("borderBottomWidth"))||0;0<this.element.value.replace(/\s/g,""
+).length&&this.$element.height(this.element.scrollHeight-i),this.$element.on("input keyup",function(e){var t=o(r),n=t.scrollTop();o(this).height(0
+).height(this.scrollHeight-i),t.scrollTop(n)})}},o.fn[i]=function(e){return this.each(function(){o.data(this,a)||o.data(this,a,new n(this,e))}),this}
+}(jQuery,window,document),$(".textarea-autosize").textareaAutoSize();var headerHeight,getTargetFromTrigger=function(e){var t;return e.attr(
+"data-target")||(t=e.attr("href"))&&t.replace(/.*(?=#[^\s]+$)/,"")},$header=$(".header"),headerNavMinWidth=0;$(window).on("scroll",function(){$(
+".header").length&&(window.pageYOffset>headerHeight?$header.addClass("fixed"):$header.removeClass("fixed"))}),headerHeightCal=function(){$(".header"
+).length&&(headerHeight=$header.height())},$(".header-nav-scroll").length&&$(".header-nav-scroll .nav > li").each(function(e){var t=$(this);if(!(e<3)
+)return!1;headerNavMinWidth+=t.width()}),headerNavPos=function(){var e=$(".header-nav-scroll");e.removeClass("pull-down"),e.width(
+)<headerNavMinWidth?e.addClass("pull-down"):e.removeClass("pull-down")},function(f){var m;function g(e,t,n){f("#jqoembeddata").data(t,e.code),
+m.beforeEmbed.call(n,e),m.onEmbed.call(n,e),m.afterEmbed.call(n,e)}function u(s,l,c){if(null!=f("#jqoembeddata").data(l)&&"iframe"!=c.embedtag.tag)g({
+code:f("#jqoembeddata").data(l)},l,s);else if(c.yql){var e=c.yql.from||"htmlstring",u=c.yql.url?c.yql.url(l):l,
+t="SELECT * FROM "+e+' WHERE url="'+u+'" and '+(/html/.test(e)?"xpath":"itemPath")+"='"+(c.yql.xpath||"/")+"'";"html"==e&&(t+=" and compat='html5'")
+;var n=f.extend({url:"//query.yahooapis.com/v1/public/yql",dataType:"jsonp",data:{q:t,format:"json",env:"store://datatables.org/alltableswithkeys",
+callback:"?"},success:function(e){var t;if(c.yql.xpath&&"//meta|//title|//link"==c.yql.xpath){var n={};null==e.query&&(e.query={}),
+null==e.query.results&&(e.query.results={meta:[]});for(var i=0,o=e.query.results.meta.length;i<o;i++){
+var r=e.query.results.meta[i].name||e.query.results.meta[i].property||null;null!=r&&(n[r.toLowerCase()]=e.query.results.meta[i].content)}if(
+n.hasOwnProperty("title")&&n.hasOwnProperty("og:title")||null!=e.query.results.title&&(n.title=e.query.results.title),!n.hasOwnProperty("og:image"
+)&&e.query.results.hasOwnProperty("link"))for(i=0,o=e.query.results.link.length;i<o;i++)e.query.results.link[i].hasOwnProperty("rel"
+)&&"apple-touch-icon"==e.query.results.link[i].rel&&("/"==e.query.results.link[i].href.charAt(0)?n["og:image"]=u.match(
+/^(([a-z]+:)?(\/\/)?[^\/]+\/).*$/)[1]+e.query.results.link[i].href:n["og:image"]=e.query.results.link[i].href);t=c.yql.datareturn(n)
+}else t=c.yql.datareturn?c.yql.datareturn(e.query.results):e.query.results.result;if(!1!==t){var a=f.extend({},t);a.code=t,g(a,l,s)}},
+error:m.onError.call(s,l,c)},m.ajaxOptions||{});f.ajax(n)}else if(c.templateRegex)if(""!==c.embedtag.tag){var i=c.embedtag.flashvars||"",
+o=c.embedtag.tag||"embed",r=c.embedtag.width||"auto",a=c.embedtag.height||"auto",d=l.replace(c.templateRegex,c.apiendpoint);c.nocache||(
+d+="&jqoemcache="+function e(t,n){return n=n||"",t?e(--t,"0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz".charAt(Math.floor(
+60*Math.random()))+n):n}(5)),c.apikey&&(d=d.replace("_APIKEY_",m.apikeys[c.name]));var h=f("<"+o+"/>").attr("src",d).attr("width",r).attr("height",a
+).attr("allowfullscreen",c.embedtag.allowfullscreen||"true").attr("allowscriptaccess",c.embedtag.allowfullscreen||"always").css("max-height",
+m.maxHeight||"auto").css("max-width",m.maxWidth||"auto");"embed"==o&&h.attr("type",c.embedtag.type||"application/x-shockwave-flash").attr("flashvars",
+l.replace(c.templateRegex,i)),"iframe"==o&&h.attr("scrolling",c.embedtag.scrolling||"no").attr("frameborder",c.embedtag.frameborder||"0"),g({code:h},l
+,s)}else c.apiendpoint?(c.apikey&&(c.apiendpoint=c.apiendpoint.replace("_APIKEY_",m.apikeys[c.name])),n=f.extend({url:l.replace(c.templateRegex,
+c.apiendpoint),dataType:"jsonp",success:function(e,t,n){var i=f.extend({},e);i.code=c.templateData(e),200!==n.status?m.onError.call(s,l,c):g(i,l,s)},
+error:m.onError.call(s,l,c)},m.ajaxOptions||{}),f.ajax(n)):g({code:l.replace(c.templateRegex,c.template)},l,s);else{var p=function(e,t){var n,
+i=e.apiendpoint,o="";for(n in i=(i+=i.indexOf("?")<=0?"?":"&").replace("#","%23"),
+null===e.maxWidth||void 0!==e.params.maxwidth&&null!==e.params.maxwidth||(e.params.maxwidth=e.maxWidth),
+null===e.maxHeight||void 0!==e.params.maxheight&&null!==e.params.maxheight||(e.params.maxheight=e.maxHeight),e.params
+)n!=e.callbackparameter&&null!==e.params[n]&&(o+="&"+escape(n)+"="+e.params[n]);return i+="format="+e.format+"&url="+escape(t)+o,"json"!=e.dataType&&(
+i+="&"+e.callbackparameter+"=?"),i}(c,l);n=f.extend({url:p,dataType:c.dataType||"jsonp",success:function(e){var t=f.extend({},e);switch(t.type){
+case"file":case"photo":t.code=f.fn.oembed.getPhotoCode(l,t);break;case"video":case"rich":t.code=f.fn.oembed.getRichCode(l,t);break;default:
+t.code=f.fn.oembed.getGenericCode(l,t)}g(t,l,s)},error:m.onError.call(s,l,c)},m.ajaxOptions||{}),f.ajax(n)}}function d(e){if(null===e)return null
+;var t,n={};for(t in e)null!==t&&(n[t.toLowerCase()]=e[t]);return n}f.fn.oembed=function(s,e,l){m=f.extend(!0,f.fn.oembed.defaults,e);var c=["0rz.tw",
+"1link.in","1url.com","2.gp","2big.at","2tu.us","3.ly","307.to","4ms.me","4sq.com","4url.cc","6url.com","7.ly","a.gg","a.nf","aa.cx","abcurl.net",
+"ad.vu","adf.ly","adjix.com","afx.cc","all.fuseurl.com","alturl.com","amzn.to","ar.gy","arst.ch","atu.ca","azc.cc","b23.ru","b2l.me","bacn.me",
+"bcool.bz","binged.it","bit.ly","bizj.us","bloat.me","bravo.ly","bsa.ly","budurl.com","canurl.com","chilp.it","chzb.gr","cl.lk","cl.ly","clck.ru",
+"cli.gs","cliccami.info","clickthru.ca","clop.in","conta.cc","cort.as","cot.ag","crks.me","ctvr.us","cutt.us","dai.ly","decenturl.com","dfl8.me",
+"digbig.com","http://digg.com/[^/]+$","disq.us","dld.bz","dlvr.it","do.my","doiop.com","dopen.us","easyuri.com","easyurl.net","eepurl.com","eweri.com"
+,"fa.by","fav.me","fb.me","fbshare.me","ff.im","fff.to","fire.to","firsturl.de","firsturl.net","flic.kr","flq.us","fly2.ws","fon.gs","freak.to",
+"fuseurl.com","fuzzy.to","fwd4.me","fwib.net","g.ro.lt","gizmo.do","gl.am","go.9nl.com","go.ign.com","go.usa.gov","goo.gl","goshrink.com","gurl.es",
+"hex.io","hiderefer.com","hmm.ph","href.in","hsblinks.com","htxt.it","huff.to","hulu.com","hurl.me","hurl.ws","icanhaz.com","idek.net","ilix.in",
+"is.gd","its.my","ix.lt","j.mp","jijr.com","kl.am","klck.me","korta.nu","krunchd.com","l9k.net","lat.ms","liip.to","liltext.com","linkbee.com",
+"linkbun.ch","liurl.cn","ln-s.net","ln-s.ru","lnk.gd","lnk.ms","lnkd.in","lnkurl.com","lru.jp","lt.tl","lurl.no","macte.ch","mash.to","merky.de",
+"migre.me","miniurl.com","minurl.fr","mke.me","moby.to","moourl.com","mrte.ch","myloc.me","myurl.in","n.pr","nbc.co","nblo.gs","nn.nf","not.my",
+"notlong.com","nsfw.in","nutshellurl.com","nxy.in","nyti.ms","o-x.fr","oc1.us","om.ly","omf.gd","omoikane.net","on.cnn.com","on.mktw.net","onforb.es",
+"orz.se","ow.ly","ping.fm","pli.gs","pnt.me","politi.co","post.ly","pp.gg","profile.to","ptiturl.com","pub.vitrue.com","qlnk.net","qte.me","qu.tc",
+"qy.fi","r.ebay.com","r.im","rb6.me","read.bi","readthis.ca","reallytinyurl.com","redir.ec","redirects.ca","redirx.com","retwt.me","ri.ms",
+"rickroll.it","riz.gd","rt.nu","ru.ly","rubyurl.com","rurl.org","rww.tw","s4c.in","s7y.us","safe.mn","sameurl.com","sdut.us","shar.es","shink.de",
+"shorl.com","short.ie","short.to","shortlinks.co.uk","shorturl.com","shout.to","show.my","shrinkify.com","shrinkr.com","shrt.fr","shrt.st",
+"shrten.com","shrunkin.com","simurl.com","slate.me","smallr.com","smsh.me","smurl.name","sn.im","snipr.com","snipurl.com","snurl.com","sp2.ro",
+"spedr.com","srnk.net","srs.li","starturl.com","stks.co","su.pr","surl.co.uk","surl.hu","t.cn","t.co","t.lh.com","ta.gd","tbd.ly","tcrn.ch","tgr.me",
+"tgr.ph","tighturl.com","tiniuri.com","tiny.cc","tiny.ly","tiny.pl","tinylink.in","tinyuri.ca","tinyurl.com","tk.","tl.gd","tmi.me","tnij.org",
+"tnw.to","tny.com","to.ly","togoto.us","totc.us","toysr.us","tpm.ly","tr.im","tra.kz","trunc.it","twhub.com","twirl.at","twitclicks.com",
+"twitterurl.net","twitterurl.org","twiturl.de","twurl.cc","twurl.nl","u.mavrev.com","u.nu","u76.org","ub0.cc","ulu.lu","updating.me","ur1.ca","url.az"
+,"url.co.uk","url.ie","url360.me","url4.eu","urlborg.com","urlbrief.com","urlcover.com","urlcut.com","urlenco.de","urli.nl","urls.im",
+"urlshorteningservicefortwitter.com","urlx.ie","urlzen.com","usat.ly","use.my","vb.ly","vevo.ly","vgn.am","vl.am","vm.lc","w55.de","wapo.st",
+"wapurl.co.uk","wipi.es","wp.me","x.vu","xr.com","xrl.in","xrl.us","xurl.es","xurl.jp","y.ahoo.it","yatuc.com","ye.pe","yep.it","yfrog.com","yhoo.it",
+"yiyd.com","youtu.be","yuarel.com","z0p.de","zi.ma","zi.mu","zipmyurl.com","zud.me","zurl.ws","zz.gd","zzang.kr","›.ws","✩.ws","✿.ws","❥.ws","➔.ws",
+"➞.ws","➡.ws","➨.ws","➯.ws","➹.ws","➽.ws"];return 0===f("#jqoembeddata").length&&f('<span id="jqoembeddata"></span>').appendTo("body"),this.each(
+function(){var t,n=f(this),i=!s||s.indexOf("http://")&&s.indexOf("https://")?n.attr("href"):s;if(l?m.onEmbed=l:m.onEmbed||(m.onEmbed=function(e){
+f.fn.oembed.insertCode(this,m.embedMethod,e)}),null!=i){for(var e=0,o=c.length;e<o;e++){var r=new RegExp("://"+c[e]+"/","i");if(null!==i.match(r)){
+var a=f.extend({url:"http://api.longurl.org/v2/expand",dataType:"jsonp",data:{url:i,format:"json"},success:function(e){i=e["long-url"],
+t=f.fn.oembed.getOEmbedProvider(e["long-url"]),!1==!!m.fallback&&(t="opengraph"===t.name.toLowerCase()?null:t),null!==t?(t.params=d(m[t.name])||{},
+t.maxWidth=m.maxWidth,t.maxHeight=m.maxHeight,u(n,i,t)):m.onProviderNotFound.call(n,i)},error:function(){m.onError.call(n,i)}},
+m.longUrlAjaxOptions||m.ajaxOptions||{});return f.ajax(a),n}}t=f.fn.oembed.getOEmbedProvider(i),!1==!!m.fallback&&(t="opengraph"===t.name.toLowerCase(
+)?null:t),null!==t?(t.params=d(m[t.name])||{},t.maxWidth=m.maxWidth,t.maxHeight=m.maxHeight,u(n,i,t)):m.onProviderNotFound.call(this,n,i)}return n})},
+f.fn.oembed.defaults={fallback:!0,maxWidth:null,maxHeight:null,includeHandle:!0,embedMethod:"auto",onProviderNotFound:function(){},
+beforeEmbed:function(){},afterEmbed:function(){},onEmbed:!1,onError:function(e,t,n,i){},ajaxOptions:{},longUrlAjaxOptions:{}},
+f.fn.oembed.insertCode=function(e,t,n){if(null!==n)switch("auto"===t&&null!==e.attr("href")?t="append":"auto"==t&&(t="replace"),t){case"replace":
+e.replaceWith(n.code);break;case"fill":e.html(n.code);break;case"append":e.wrap('<div class="oembedall-container"></div>');var i=e.parent()
+;m.includeHandle&&f('<span class="oembedall-closehide">&darr;</span>').insertBefore(e).click(function(){var e=encodeURIComponent(f(this).text());f(
+this).html("%E2%86%91"==e?"&darr;":"&uarr;"),f(this).parent().children().last().toggle()}),i.append("<br/>");try{n.code.clone().appendTo(i)}catch(e){
+i.append(n.code)}if(m.maxWidth){var o=i.parent().width();if(o<m.maxWidth){var r=f("iframe",i).width(),a=f("iframe",i).height(),s=r/o;f("iframe",i
+).width(r/s),f("iframe",i).height(a/s)}else m.maxWidth&&f("iframe",i).width(m.maxWidth),m.maxHeight&&f("iframe",i).height(m.maxHeight)}}},
+f.fn.oembed.getPhotoCode=function(e,t){var n,i=t.title?t.title:"";if(i+=t.author_name?" - "+t.author_name:"",
+i+=t.provider_name?" - "+t.provider_name:"",t.url)n='<div><a href="'+e+"\" target='_blank'><img src=\""+t.url+'" alt="'+i+'"/></a></div>';else if(
+t.thumbnail_url){n='<div><a href="'+e+"\" target='_blank'><img src=\""+t.thumbnail_url.replace("_s","_b")+'" alt="'+i+'"/></a></div>'
+}else n="<div>Error loading this picture</div>";return t.html&&(n+="<div>"+t.html+"</div>"),n},f.fn.oembed.getRichCode=function(e,t){return t.html},
+f.fn.oembed.getGenericCode=function(e,t){var n='<a href="'+e+'">'+(t.title&&null!==t.title?t.title:e)+"</a>";return t.html&&(
+n+="<div>"+t.html+"</div>"),n},f.fn.oembed.getOEmbedProvider=function(e){for(var t=0;t<f.fn.oembed.providers.length;t++)for(var n=0,
+i=f.fn.oembed.providers[t].urlschemes.length;n<i;n++){var o=new RegExp(f.fn.oembed.providers[t].urlschemes[n],"i");if(null!==e.match(o)
+)return f.fn.oembed.providers[t]}return null},f.fn.oembed.OEmbedProvider=function(e,t,n,i,o){for(var r in this.name=e,this.type=t,this.urlschemes=n,
+this.apiendpoint=i,this.maxWidth=500,this.maxHeight=400,(o=o||{}).useYQL&&("xml"==o.useYQL?o.yql={xpath:"//oembed/html",from:"xml",
+apiendpoint:this.apiendpoint,url:function(e){return this.apiendpoint+"?format=xml&url="+e},datareturn:function(e){return e.html.replace(
+/.*\[CDATA\[(.*)\]\]>$/,"$1")||""}}:o.yql={from:"json",apiendpoint:this.apiendpoint,url:function(e){return this.apiendpoint+"?format=json&url="+e},
+datareturn:function(e){return"video"!=e.json.type&&(e.json.url||e.json.thumbnail_url)?'<img src="'+(e.json.url||e.json.thumbnail_url
+)+'" />':e.json.html||""}},this.apiendpoint=null),o)this[r]=o[r];this.format=this.format||"json",
+this.callbackparameter=this.callbackparameter||"callback",this.embedtag=this.embedtag||{tag:""}},f.fn.updateOEmbedProvider=function(e,t,n,i,o){for(
+var r=0;r<f.fn.oembed.providers.length;r++)if(f.fn.oembed.providers[r].name===e&&(null!==t&&(f.fn.oembed.providers[r].type=t),null!==n&&(
+f.fn.oembed.providers[r].urlschemes=n),null!==i&&(f.fn.oembed.providers[r].apiendpoint=i),null!==o))for(
+var a in f.fn.oembed.providers[r].extraSettings=o)null!==a&&null!==o[a]&&(f.fn.oembed.providers[r][a]=o[a])},f.fn.oembed.providers=[
+new f.fn.oembed.OEmbedProvider("youtube","video",["youtube\\.com/watch.+v=[\\w-]+&?","youtu\\.be/[\\w-]+","youtube.com/embed"],
+"//www.youtube.com/embed/$1?wmode=transparent",{templateRegex:/.*(?:v\=|be\/|embed\/)([\w\-]+)&?.*/,embedtag:{tag:"iframe",width:"425",height:"349"}})
+,new f.fn.oembed.OEmbedProvider("wistia","video",["wistia.com/medias/.+","wistia.com/m/.+","wistia.com/embed/.+","wi.st/m/.+","wi.st/embed/.+"],
+"http://fast.wistia.com/oembed",{useYQL:"json"}),new f.fn.oembed.OEmbedProvider("xtranormal","video",["xtranormal\\.com/watch/.+"],
+"http://www.xtranormal.com/xtraplayr/$1/$2",{templateRegex:/.*com\/watch\/([\w\-]+)\/([\w\-]+).*/,embedtag:{tag:"iframe",width:"320",height:"269"}}),
+new f.fn.oembed.OEmbedProvider("scivee","video",["scivee.tv/node/.+"],"http://www.scivee.tv/flash/embedCast.swf?",{templateRegex:/.*tv\/node\/(.+)/,
+embedtag:{width:"480",height:"400",flashvars:"id=$1&type=3"}}),new f.fn.oembed.OEmbedProvider("veoh","video",["veoh.com/watch/.+"],
+"http://www.veoh.com/swf/webplayer/WebPlayer.swf?version=AFrontend.5.7.0.1337&permalinkId=$1&player=videodetailsembedded&videoAutoPlay=0&id=anonymous"
+,{templateRegex:/.*watch\/([^\?]+).*/,embedtag:{width:"410",height:"341"}}),new f.fn.oembed.OEmbedProvider("gametrailers","video",[
+"gametrailers\\.com/video/.+"],"http://media.mtvnservices.com/mgid:moses:video:gametrailers.com:$2",{
+templateRegex:/.*com\/video\/([\w\-]+)\/([\w\-]+).*/,embedtag:{width:"512",height:"288"}}),new f.fn.oembed.OEmbedProvider("funnyordie","video",[
+"funnyordie\\.com/videos/.+"],"http://player.ordienetworks.com/flash/fodplayer.swf?",{templateRegex:/.*videos\/([^\/]+)\/([^\/]+)?/,embedtag:{
+width:512,height:328,flashvars:"key=$1"}}),new f.fn.oembed.OEmbedProvider("colledgehumour","video",["collegehumor\\.com/video/.+"],
+"http://www.collegehumor.com/moogaloop/moogaloop.swf?clip_id=$1&use_node_id=true&fullscreen=1",{templateRegex:/.*video\/([^\/]+).*/,embedtag:{
+width:600,height:338}}),new f.fn.oembed.OEmbedProvider("metacafe","video",["metacafe\\.com/watch/.+"],"http://www.metacafe.com/fplayer/$1/$2.swf",{
+templateRegex:/.*watch\/(\d+)\/(\w+)\/.*/,embedtag:{width:400,height:345}}),new f.fn.oembed.OEmbedProvider("bambuser","video",[
+"bambuser\\.com/channel/.*/broadcast/.*"],"http://static.bambuser.com/r/player.swf?vid=$1",{
+templateRegex:/.*bambuser\.com\/channel\/.*\/broadcast\/(\w+).*/,embedtag:{width:512,height:339}}),new f.fn.oembed.OEmbedProvider("twitvid","video",[
+"twitvid\\.com/.+"],"http://www.twitvid.com/embed.php?guid=$1&autoplay=0",{templateRegex:/.*twitvid\.com\/(\w+).*/,embedtag:{tag:"iframe",width:480,
+height:360}}),new f.fn.oembed.OEmbedProvider("aniboom","video",["aniboom\\.com/animation-video/.+"],"http://api.aniboom.com/e/$1",{
+templateRegex:/.*animation-video\/(\d+).*/,embedtag:{width:594,height:334}}),new f.fn.oembed.OEmbedProvider("vzaar","video",["vzaar\\.com/videos/.+",
+"vzaar.tv/.+"],"http://view.vzaar.com/$1/player?",{templateRegex:/.*\/(\d+).*/,embedtag:{tag:"iframe",width:576,height:324}}),
+new f.fn.oembed.OEmbedProvider("snotr","video",["snotr\\.com/video/.+"],"http://www.snotr.com/embed/$1",{templateRegex:/.*\/(\d+).*/,embedtag:{
+tag:"iframe",width:400,height:330},nocache:1}),new f.fn.oembed.OEmbedProvider("youku","video",["v.youku.com/v_show/id_.+"],
+"http://player.youku.com/player.php/sid/$1/v.swf",{templateRegex:/.*id_(.+)\.html.*/,embedtag:{width:480,height:400},nocache:1}),
+new f.fn.oembed.OEmbedProvider("tudou","video",["tudou.com/programs/view/.+/"],"http://www.tudou.com/v/$1/v.swf",{templateRegex:/.*view\/(.+)\//,
+embedtag:{width:480,height:400},nocache:1}),new f.fn.oembed.OEmbedProvider("embedr","video",["embedr\\.com/playlist/.+"],
+"http://embedr.com/swf/slider/$1/425/520/default/false/std?",{templateRegex:/.*playlist\/([^\/]+).*/,embedtag:{width:425,height:520}}),
+new f.fn.oembed.OEmbedProvider("blip","video",["blip\\.tv/.+"],"//blip.tv/oembed/"),new f.fn.oembed.OEmbedProvider("minoto-video","video",[
+"http://api.minoto-video.com/publishers/.+/videos/.+","http://dashboard.minoto-video.com/main/video/details/.+","http://embed.minoto-video.com/.+"],
+"http://api.minoto-video.com/services/oembed.json",{useYQL:"json"}),new f.fn.oembed.OEmbedProvider("animoto","video",["animoto.com/play/.+"],
+"http://animoto.com/services/oembed"),new f.fn.oembed.OEmbedProvider("hulu","video",["hulu\\.com/watch/.*"],"//www.hulu.com/api/oembed.json"),
+new f.fn.oembed.OEmbedProvider("ustream","video",["ustream\\.tv/recorded/.*"],"http://www.ustream.tv/oembed",{useYQL:"json"}),
+new f.fn.oembed.OEmbedProvider("videojug","video",["videojug\\.com/(film|payer|interview).*"],"http://www.videojug.com/oembed.json",{useYQL:"json"}),
+new f.fn.oembed.OEmbedProvider("sapo","video",["videos\\.sapo\\.pt/.*"],"http://videos.sapo.pt/oembed",{useYQL:"json"}),
+new f.fn.oembed.OEmbedProvider("vodpod","video",["vodpod.com/watch/.*"],"http://vodpod.com/oembed.js",{useYQL:"json"}),new f.fn.oembed.OEmbedProvider(
+"vimeo","video",["www.vimeo.com/groups/.*/videos/.*","www.vimeo.com/.*","vimeo.com/groups/.*/videos/.*","vimeo.com/.*"],"//vimeo.com/api/oembed.json")
+,new f.fn.oembed.OEmbedProvider("dailymotion","video",["dailymotion\\.com/.+"],"//www.dailymotion.com/services/oembed"),
+new f.fn.oembed.OEmbedProvider("5min","video",["www\\.5min\\.com/.+"],"http://api.5min.com/oembed.xml",{useYQL:"xml"}),new f.fn.oembed.OEmbedProvider(
+"National Film Board of Canada","video",["nfb\\.ca/film/.+"],"http://www.nfb.ca/remote/services/oembed/",{useYQL:"json"}),
+new f.fn.oembed.OEmbedProvider("qik","video",["qik\\.com/\\w+"],"http://qik.com/api/oembed.json",{useYQL:"json"}),new f.fn.oembed.OEmbedProvider(
+"revision3","video",["revision3\\.com"],"http://revision3.com/api/oembed/"),new f.fn.oembed.OEmbedProvider("dotsub","video",["dotsub\\.com/view/.+"],
+"http://dotsub.com/services/oembed",{useYQL:"json"}),new f.fn.oembed.OEmbedProvider("clikthrough","video",["clikthrough\\.com/theater/video/\\d+"],
+"http://clikthrough.com/services/oembed"),new f.fn.oembed.OEmbedProvider("Kinomap","video",["kinomap\\.com/.+"],"http://www.kinomap.com/oembed"),
+new f.fn.oembed.OEmbedProvider("VHX","video",["vhx.tv/.+"],"http://vhx.tv/services/oembed.json"),new f.fn.oembed.OEmbedProvider("bambuser","video",[
+"bambuser.com/.+"],"http://api.bambuser.com/oembed/iframe.json"),new f.fn.oembed.OEmbedProvider("justin.tv","video",["justin.tv/.+"],
+"http://api.justin.tv/api/embed/from_url.json",{useYQL:"json"}),new f.fn.oembed.OEmbedProvider("vine","video",["vine.co/v/.*"],null,{
+templateRegex:/https?:\/\/w?w?w?.?vine\.co\/v\/([a-zA-Z0-9]*).*/,
+template:'<iframe src="https://vine.co/v/$1/embed/postcard" width="600" height="600" allowfullscreen="true" allowscriptaccess="always" scrolling="no" frameborder="0"></iframe><script async src="//platform.vine.co/static/scripts/embed.js" charset="utf-8"><\/script>',
+nocache:1}),new f.fn.oembed.OEmbedProvider("boxofficebuz","video",["boxofficebuz\\.com\\/embed/.+"],"http://boxofficebuz.com/embed/$1/$2",{
+templateRegex:[/.*boxofficebuz\.com\/embed\/(\w+)\/([\w*\-*]+)/],embedtag:{tag:"iframe",width:480,height:360}}),new f.fn.oembed.OEmbedProvider(
+"clipsyndicate","video",["clipsyndicate\\.com/video/play/.+","clipsyndicate\\.com/embed/iframe?.+"],
+"http://eplayer.clipsyndicate.com/embed/iframe?pf_id=1&show_title=0&va_id=$1&windows=1",{templateRegex:[
+/.*www\.clipsyndicate\.com\/video\/play\/(\w+)\/.*/,/.*eplayer\.clipsyndicate\.com\/embed\/iframe\?.*va_id=(\w+).*.*/],embedtag:{tag:"iframe",
+width:480,height:360},nocache:1}),new f.fn.oembed.OEmbedProvider("coub","video",["coub\\.com/.+"],
+"http://www.coub.com/embed/$1?muted=false&autostart=false&originalSize=false&hideTopBar=false&noSiteButtons=false&startWithHD=false",{templateRegex:[
+/.*coub\.com\/embed\/(\w+)\?*.*/,/.*coub\.com\/view\/(\w+).*/],embedtag:{tag:"iframe",width:480,height:360},nocache:1}),
+new f.fn.oembed.OEmbedProvider("discoverychannel","video",["snagplayer\\.video\\.dp\\.discovery\\.com/.+"],
+"http://snagplayer.video.dp.discovery.com/$1/snag-it-player.htm?auto=no",{templateRegex:[/.*snagplayer\.video\.dp\.discovery\/(\w+).*/],embedtag:{
+tag:"iframe",width:480,height:360}}),new f.fn.oembed.OEmbedProvider("telly","video",["telly\\.com/.+"],
+"http://www.telly.com/embed.php?guid=$1&autoplay=0",{templateRegex:[/.*telly\.com\/embed\.php\?guid=(\w+).*/,/.*telly\.com\/(\w+).*/],embedtag:{
+tag:"iframe",width:480,height:360}}),new f.fn.oembed.OEmbedProvider("minilogs","video",["minilogs\\.com/.+"],"http://www.minilogs.com/e/$1",{
+templateRegex:[/.*minilogs\.com\/e\/(\w+).*/,/.*minilogs\.com\/(\w+).*/],embedtag:{tag:"iframe",width:480,height:360},nocache:1}),
+new f.fn.oembed.OEmbedProvider("viddy","video",["viddy\\.com/.+"],"http://www.viddy.com/embed/video/$1",{templateRegex:[
+/.*viddy\.com\/embed\/video\/(\.*)/,/.*viddy\.com\/video\/(\.*)/],embedtag:{tag:"iframe",width:480,height:360},nocache:1}),
+new f.fn.oembed.OEmbedProvider("worldstarhiphop","video",["worldstarhiphop\\.com/embed/.+"],"http://www.worldstarhiphop.com/embed/$1",{
+templateRegex:/.*worldstarhiphop\.com\/embed\/(\w+).*/,embedtag:{tag:"iframe",width:480,height:360},nocache:1}),new f.fn.oembed.OEmbedProvider(
+"zapiks","video",["zapiks\\.fr/.+"],"http://www.zapiks.fr/index.php?action=playerIframe&media_id=$1&autoStart=fals",{
+templateRegex:/.*zapiks\.fr\/index.php\?[\w\=\&]*media_id=(\w+).*/,embedtag:{tag:"iframe",width:480,height:360},nocache:1}),
+new f.fn.oembed.OEmbedProvider("official.fm","rich",["official.fm/.+"],"http://official.fm/services/oembed",{useYQL:"json"}),
+new f.fn.oembed.OEmbedProvider("chirbit","rich",["chirb.it/.+"],"http://chirb.it/oembed.json",{useYQL:"json"}),new f.fn.oembed.OEmbedProvider(
+"chirbit","audio",["chirb\\.it/.+"],"http://chirb.it/wp/$1",{templateRegex:[/.*chirb\.it\/wp\/(\w+).*/,/.*chirb\.it\/(\w+).*/],embedtag:{tag:"iframe",
+width:480,height:360},nocache:1}),new f.fn.oembed.OEmbedProvider("Huffduffer","rich",["huffduffer.com/[-.\\w@]+/\\d+"],"http://huffduffer.com/oembed")
+,new f.fn.oembed.OEmbedProvider("Spotify","rich",["open.spotify.com/(track|album|user)/"],"https://embed.spotify.com/oembed/"),
+new f.fn.oembed.OEmbedProvider("shoudio","rich",["shoudio.com/.+","shoud.io/.+"],"http://shoudio.com/api/oembed"),new f.fn.oembed.OEmbedProvider(
+"mixcloud","rich",["mixcloud.com/.+"],"http://www.mixcloud.com/oembed/",{useYQL:"json"}),new f.fn.oembed.OEmbedProvider("rdio.com","rich",["rd.io/.+",
+"rdio.com"],"http://www.rdio.com/api/oembed/"),new f.fn.oembed.OEmbedProvider("Soundcloud","rich",["soundcloud.com/.+","snd.sc/.+"],
+"//soundcloud.com/oembed",{format:"js"}),new f.fn.oembed.OEmbedProvider("bandcamp","rich",["bandcamp\\.com/album/.+"],null,{yql:{
+xpath:"//meta[contains(@content, \\'EmbeddedPlayer\\')]",from:"html",datareturn:function(e){
+return!!e.meta&&'<iframe width="400" height="100" src="'+e.meta.content+'" allowtransparency="true" frameborder="0"></iframe>'}}}),
+new f.fn.oembed.OEmbedProvider("deviantart","photo",["deviantart.com/.+","fav.me/.+","deviantart.com/.+"],"//backend.deviantart.com/oembed",{
+format:"jsonp"}),new f.fn.oembed.OEmbedProvider("skitch","photo",["skitch.com/.+"],null,{yql:{xpath:"json",from:"json",url:function(e){
+return"http://skitch.com/oembed/?format=json&url="+e},datareturn:function(e){return f.fn.oembed.getPhotoCode(e.json.url,e.json)}}}),
+new f.fn.oembed.OEmbedProvider("mobypicture","photo",["mobypicture.com/user/.+/view/.+","moby.to/.+"],"http://api.mobypicture.com/oEmbed"),
+new f.fn.oembed.OEmbedProvider("flickr","photo",["flickr\\.com/photos/.+"],"//flickr.com/services/oembed",{callbackparameter:"jsoncallback"}),
+new f.fn.oembed.OEmbedProvider("photobucket","photo",["photobucket\\.com/(albums|groups)/.+"],"http://photobucket.com/oembed/"),
+new f.fn.oembed.OEmbedProvider("instagram","photo",["instagr\\.?am(\\.com)?/.+"],"//api.instagram.com/oembed"),new f.fn.oembed.OEmbedProvider(
+"SmugMug","photo",["smugmug.com/[-.\\w@]+/.+"],"http://api.smugmug.com/services/oembed/"),new f.fn.oembed.OEmbedProvider("dribbble","photo",[
+"dribbble.com/shots/.+"],"http://api.dribbble.com/shots/$1?callback=?",{templateRegex:/.*shots\/([\d]+).*/,templateData:function(e){
+return!!e.image_teaser_url&&'<img src="'+e.image_teaser_url+'"/>'}}),new f.fn.oembed.OEmbedProvider("chart.ly","photo",["chart\\.ly/[a-z0-9]{6,8}"],
+"http://chart.ly/uploads/large_$1.png",{templateRegex:/.*ly\/([^\/]+).*/,embedtag:{tag:"img"},nocache:1}),new f.fn.oembed.OEmbedProvider("circuitlab",
+"photo",["circuitlab.com/circuit/.+"],"https://www.circuitlab.com/circuit/$1/screenshot/540x405/",{templateRegex:/.*circuit\/([^\/]+).*/,embedtag:{
+tag:"img"},nocache:1}),new f.fn.oembed.OEmbedProvider("23hq","photo",["23hq.com/[-.\\w@]+/photo/.+"],"http://www.23hq.com/23/oembed",{useYQL:"json"}),
+new f.fn.oembed.OEmbedProvider("img.ly","photo",["img\\.ly/.+"],"//img.ly/show/thumb/$1",{templateRegex:/.*ly\/([^\/]+).*/,embedtag:{tag:"img"},
+nocache:1}),new f.fn.oembed.OEmbedProvider("twitgoo.com","photo",["twitgoo\\.com/.+"],"http://twitgoo.com/show/thumb/$1",{
+templateRegex:/.*com\/([^\/]+).*/,embedtag:{tag:"img"},nocache:1}),new f.fn.oembed.OEmbedProvider("imgur.com","photo",["imgur\\.com/gallery/.+"],
+"http://imgur.com/$1l.jpg",{templateRegex:/.*gallery\/([^\/]+).*/,embedtag:{tag:"img"},nocache:1}),new f.fn.oembed.OEmbedProvider("visual.ly","rich",[
+"visual\\.ly/.+"],null,{yql:{xpath:"//a[@id=\\'gc_article_graphic_image\\']/img",from:"htmlstring"}}),new f.fn.oembed.OEmbedProvider("achewood",
+"photo",["achewood\\.com\\/index.php\\?date=.+"],"http://www.achewood.com/comic.php?date=$1",{
+templateRegex:/.*achewood\.com\/index.php\?date=(\w+).*/,embedtag:{tag:"iframe",width:480,height:360},nocache:1}),new f.fn.oembed.OEmbedProvider(
+"fotokritik","photo",["fotokritik\\.com/.+"],"http://www.fotokritik.com/embed/$1",{templateRegex:[/.*fotokritik\.com\/embed\/(\w+).*/,
+/.*fotokritik\.com\/(\w+).*/],embedtag:{tag:"iframe",width:480,height:360},nocache:1}),new f.fn.oembed.OEmbedProvider("giflike","photo",[
+"giflike\\.com/.+"],"http://www.giflike.com/embed/$1",{templateRegex:[/.*giflike\.com\/embed\/(\w+).*/,/.*giflike\.com\/a\/(\w+).*/],embedtag:{
+tag:"iframe",width:480,height:360},nocache:1}),new f.fn.oembed.OEmbedProvider("twitter","rich",["twitter.com/.+"],
+"https://api.twitter.com/1/statuses/oembed.json"),new f.fn.oembed.OEmbedProvider("gmep","rich",["gmep.imeducate.com/.*","gmep.org/.*"],
+"http://gmep.org/oembed.json"),new f.fn.oembed.OEmbedProvider("urtak","rich",["urtak.com/(u|clr)/.+"],"http://oembed.urtak.com/1/oembed"),
+new f.fn.oembed.OEmbedProvider("cacoo","rich",["cacoo.com/.+"],"http://cacoo.com/oembed.json"),new f.fn.oembed.OEmbedProvider("dailymile","rich",[
+"dailymile.com/people/.*/entries/.*"],"http://api.dailymile.com/oembed"),new f.fn.oembed.OEmbedProvider("documentcloud","rich",[
+"documentcloud.org/documents/.+"],"https://www.documentcloud.org/api/oembed.json"),new f.fn.oembed.OEmbedProvider("dipity","rich",[
+"dipity.com/timeline/.+"],"http://www.dipity.com/oembed/timeline/",{useYQL:"json"}),new f.fn.oembed.OEmbedProvider("sketchfab","rich",[
+"sketchfab.com/show/.+"],"http://sketchfab.com/oembed",{useYQL:"json"}),new f.fn.oembed.OEmbedProvider("speakerdeck","rich",["speakerdeck.com/.+"],
+"http://speakerdeck.com/oembed.json",{useYQL:"json"}),new f.fn.oembed.OEmbedProvider("popplet","rich",["popplet.com/app/.*"],
+"http://popplet.com/app/Popplet_Alpha.swf?page_id=$1&em=1",{templateRegex:/.*#\/([^\/]+).*/,embedtag:{width:460,height:460}}),
+new f.fn.oembed.OEmbedProvider("pearltrees","rich",["pearltrees.com/.*"],"http://cdn.pearltrees.com/s/embed/getApp?",{
+templateRegex:/.*N-f=1_(\d+).*N-p=(\d+).*/,embedtag:{width:460,height:460,
+flashvars:"lang=en_US&amp;embedId=pt-embed-$1-693&amp;treeId=$1&amp;pearlId=$2&amp;treeTitle=Diagrams%2FVisualization&amp;site=www.pearltrees.com%2FF"
+}}),new f.fn.oembed.OEmbedProvider("prezi","rich",["prezi.com/.*"],"//prezi.com/bin/preziloader.swf?",{templateRegex:/.*com\/([^\/]+)\/.*/,embedtag:{
+width:550,height:400,flashvars:"prezi_id=$1&amp;lock_to_path=0&amp;color=ffffff&amp;autoplay=no&amp;autohide_ctrls=0"}}),
+new f.fn.oembed.OEmbedProvider("tourwrist","rich",["tourwrist.com/tours/.+"],null,{templateRegex:/.*tours.([\d]+).*/,template:function(e,t){
+return setTimeout(function(){loadEmbeds&&loadEmbeds()},2e3),
+"<div id='"+t+"' class='tourwrist-tour-embed direct'></div> <script type='text/javascript' src='http://tourwrist.com/tour_embed.js'><\/script>"}}),
+new f.fn.oembed.OEmbedProvider("meetup","rich",["meetup\\.(com|ps)/.+"],"http://api.meetup.com/oembed"),new f.fn.oembed.OEmbedProvider("ebay","rich",[
+"ebay\\.*"],"http://togo.ebay.com/togo/togo.swf?2008013100",{templateRegex:/.*\/([^\/]+)\/(\d{10,13}).*/,embedtag:{width:355,height:300,
+flashvars:"base=http://togo.ebay.com/togo/&lang=en-us&mode=normal&itemid=$2&query=$1"}}),new f.fn.oembed.OEmbedProvider("wikipedia","rich",[
+"wikipedia.org/wiki/.+"],"http://$1.wikipedia.org/w/api.php?action=parse&page=$2&format=json&section=0&callback=?",{
+templateRegex:/.*\/\/([\w]+).*\/wiki\/([^\/]+).*/,templateData:function(e){return e.parse,!1}}),new f.fn.oembed.OEmbedProvider("imdb","rich",[
+"imdb.com/title/.+"],"http://www.imdbapi.com/?i=$1&callback=?",{templateRegex:/.*\/title\/([^\/]+).*/,templateData:function(e){
+return!!e.Title&&'<div id="content"><h3><a class="nav-link" href="http://imdb.com/title/'+e.imdbID+'/">'+e.Title+"</a> ("+e.Year+")</h3><p>Rating: "+e.imdbRating+"<br/>Genre: "+e.Genre+"<br/>Starring: "+e.Actors+'</p></div>  <div id="view-photo-caption">'+e.Plot+"</div></div>"
+}}),new f.fn.oembed.OEmbedProvider("livejournal","rich",["livejournal.com/"],"http://ljpic.seacrow.com/json/$2$4?jsonp=?",{
+templateRegex:/(http:\/\/(((?!users).)+)\.livejournal\.com|.*users\.livejournal\.com\/([^\/]+)).*/,templateData:function(e){
+return!!e.username&&'<div><img src="'+e.image+'" align="left" style="margin-right: 1em;" /><span class="oembedall-ljuser"><a href="http://'+e.username+'.livejournal.com/profile"><img src="http://www.livejournal.com/img/userinfo.gif" alt="[info]" width="17" height="17" /></a><a href="http://'+e.username+'.livejournal.com/">'+e.username+"</a></span><br />"+e.name+"</div>"
+}}),new f.fn.oembed.OEmbedProvider("circuitbee","rich",["circuitbee\\.com/circuit/view/.+"],
+"http://c.circuitbee.com/build/r/schematic-embed.html?id=$1",{templateRegex:/.*circuit\/view\/(\d+).*/,embedtag:{tag:"iframe",width:"500",height:"350"
+}}),new f.fn.oembed.OEmbedProvider("googlecalendar","rich",["www.google.com/calendar/embed?.+"],"$1",{templateRegex:/(.*)/,embedtag:{tag:"iframe",
+width:"800",height:"600"}}),new f.fn.oembed.OEmbedProvider("jsfiddle","rich",["jsfiddle.net/[^/]+/?"],
+"http://jsfiddle.net/$1/embedded/result,js,resources,html,css/?",{templateRegex:/.*net\/([^\/]+).*/,embedtag:{tag:"iframe",width:"100%",height:"300"}}
+),new f.fn.oembed.OEmbedProvider("jsbin","rich",["jsbin.com/.+"],"http://jsbin.com/$1/?",{templateRegex:/.*com\/([^\/]+).*/,embedtag:{tag:"iframe",
+width:"100%",height:"300"}}),new f.fn.oembed.OEmbedProvider("jotform","rich",["form.jotform.co/form/.+"],"$1?",{templateRegex:/(.*)/,embedtag:{
+tag:"iframe",width:"100%",height:"507"}}),new f.fn.oembed.OEmbedProvider("reelapp","rich",["reelapp\\.com/.+"],"http://www.reelapp.com/$1/embed",{
+templateRegex:/.*com\/(\S{6}).*/,embedtag:{tag:"iframe",width:"400",height:"338"}}),new f.fn.oembed.OEmbedProvider("linkedin","rich",[
+"linkedin.com/pub/.+"],"https://www.linkedin.com/cws/member/public_profile?public_profile_url=$1&format=inline&isFramed=true",{templateRegex:/(.*)/,
+embedtag:{tag:"iframe",width:"368px",height:"auto"}}),new f.fn.oembed.OEmbedProvider("timetoast","rich",["timetoast.com/timelines/[0-9]+"],
+"http://www.timetoast.com/flash/TimelineViewer.swf?passedTimelines=$1",{templateRegex:/.*timelines\/([0-9]*)/,embedtag:{width:550,height:400},
+nocache:1}),new f.fn.oembed.OEmbedProvider("pastebin","rich",["pastebin\\.com/[\\S]{8}"],"http://pastebin.com/embed_iframe.php?i=$1",{
+templateRegex:/.*\/(\S{8}).*/,embedtag:{tag:"iframe",width:"100%",height:"auto"}}),new f.fn.oembed.OEmbedProvider("mixlr","rich",["mixlr.com/.+"],
+"http://mixlr.com/embed/$1?autoplay=ae",{templateRegex:/.*com\/([^\/]+).*/,embedtag:{tag:"iframe",width:"100%",height:"auto"}}),
+new f.fn.oembed.OEmbedProvider("pastie","rich",["pastie\\.org/pastes/.+"],null,{yql:{xpath:'//pre[@class="textmate-source"]'}}),
+new f.fn.oembed.OEmbedProvider("github","rich",["gist.github.com/.+"],"https://github.com/api/oembed"),new f.fn.oembed.OEmbedProvider("github","rich",
+["github.com/[-.\\w@]+/[-.\\w@]+"],"https://api.github.com/repos/$1/$2?callback=?",{templateRegex:/.*\/([^\/]+)\/([^\/]+).*/,templateData:function(e){
+return!!e.data.html_url&&'<div class="oembedall-githubrepos"><ul class="oembedall-repo-stats"><li>'+e.data.language+'</li><li class="oembedall-watchers"><a title="Watchers" href="'+e.data.html_url+'/watchers">&#x25c9; '+e.data.watchers+'</a></li><li class="oembedall-forks"><a title="Forks" href="'+e.data.html_url+'/network">&#x0265; '+e.data.forks+'</a></li></ul><h3><a href="'+e.data.html_url+'">'+e.data.name+'</a></h3><div class="oembedall-body"><p class="oembedall-description">'+e.data.description+'</p><p class="oembedall-updated-at">Last updated: '+e.data.pushed_at+"</p></div></div>"
+}}),new f.fn.oembed.OEmbedProvider("facebook","rich",["facebook.com"],null,{templateRegex:/.*\/([^\/]+)\/([^\/]+).*/,template:function(e){if(
+!f.fn.oembed.facebokScriptHasBeenAdded){f('<div id="fb-root"></div>').appendTo("body");var t=document.createElement("script");t.type="text/javascript"
+,
+t.text='(function(d, s, id) {var js, fjs = d.getElementsByTagName(s)[0];if (d.getElementById(id)) return;js = d.createElement(s); js.id = id;js.src = "//connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.0";fjs.parentNode.insertBefore(js, fjs);}(document, "script", "facebook-jssdk"));'
+,document.body.appendChild(t),f.fn.oembed.facebokScriptHasBeenAdded=!0}
+return'<div class="fb-post" data-href="'+e+'" data-width="520"><div class="fb-xfbml-parse-ignore"><a href="'+e+'"></div></div>'}}),
+new f.fn.oembed.OEmbedProvider("stackoverflow","rich",["stackoverflow.com/questions/[\\d]+"],
+"http://api.stackoverflow.com/1.1/questions/$1?body=true&jsonp=?",{templateRegex:/.*questions\/([\d]+).*/,templateData:function(e){if(!e.questions
+)return!1;var t=e.questions[0],n=f(t.body).text(),
+i='<div class="oembedall-stoqembed"><div class="oembedall-statscontainer"><div class="oembedall-statsarrow"></div><div class="oembedall-stats"><div class="oembedall-vote"><div class="oembedall-votes"><span class="oembedall-vote-count-post"><strong>'+(
+t.up_vote_count-t.down_vote_count
+)+'</strong></span><div class="oembedall-viewcount">vote(s)</div></div></div><div class="oembedall-status"><strong>'+t.answer_count+'</strong>answer</div></div><div class="oembedall-views">'+t.view_count+' view(s)</div></div><div class="oembedall-summary"><h3><a class="oembedall-question-hyperlink" href="http://stackoverflow.com/questions/'+t.question_id+'/">'+t.title+'</a></h3><div class="oembedall-excerpt">'+n.substring(
+0,100)+'...</div><div class="oembedall-tags">';for(var o in t.tags
+)i+='<a title="" class="oembedall-post-tag" href="http://stackoverflow.com/questions/tagged/'+t.tags[o]+'">'+t.tags[o]+"</a>"
+;return i+='</div><div class="oembedall-fr"><div class="oembedall-user-info"><div class="oembedall-user-gravatar32"><a href="http://stackoverflow.com/users/'+t.owner.user_id+"/"+t.owner.display_name+'"><img width="32" height="32" alt="" src="http://www.gravatar.com/avatar/'+t.owner.email_hash+'?s=32&amp;d=identicon&amp;r=PG"></a></div><div class="oembedall-user-details"><a href="http://stackoverflow.com/users/'+t.owner.user_id+"/"+t.owner.display_name+'">'+t.owner.display_name+'</a><br><span title="reputation score" class="oembedall-reputation-score">'+t.owner.reputation+"</span></div></div></div></div></div>"
+}}),new f.fn.oembed.OEmbedProvider("wordpress","rich",["wordpress\\.com/.+","blogs\\.cnn\\.com/.+","techcrunch\\.com/.+","wp\\.me/.+"],
+"http://public-api.wordpress.com/oembed/1.0/?for=jquery-oembed-all"),new f.fn.oembed.OEmbedProvider("screenr","rich",["screenr.com"],
+"http://www.screenr.com/embed/$1",{templateRegex:/.*\/([^\/]+).*/,embedtag:{tag:"iframe",width:"650",height:396}}),new f.fn.oembed.OEmbedProvider(
+"gigpans","rich",["gigapan\\.org/[-.\\w@]+/\\d+"],"http://gigapan.org/gigapans/$1/options/nosnapshots/iframe/flash.html",{
+templateRegex:/.*\/(\d+)\/?.*/,embedtag:{tag:"iframe",width:"100%",height:400}}),new f.fn.oembed.OEmbedProvider("scribd","rich",["scribd\\.com/.+"],
+"http://www.scribd.com/embeds/$1/content?start_page=1&view_mode=list",{templateRegex:/.*doc\/([^\/]+).*/,embedtag:{tag:"iframe",width:"100%",
+height:600}}),new f.fn.oembed.OEmbedProvider("kickstarter","rich",["kickstarter\\.com/projects/.+"],"$1/widget/card.html",{templateRegex:/([^\?]+).*/,
+embedtag:{tag:"iframe",width:"220",height:380}}),new f.fn.oembed.OEmbedProvider("amazon","rich",["amzn.com/B+","amazon.com.*/(B\\S+)($|\\/.*)"],
+"http://rcm.amazon.com/e/cm?t=_APIKEY_&o=1&p=8&l=as1&asins=$1&ref=qf_br_asin_til&fc1=000000&IS2=1&lt1=_blank&m=amazon&lc1=0000FF&bc1=000000&bg1=FFFFFF&f=ifr"
+,{apikey:!0,templateRegex:/.*\/(B[0-9A-Z]+)($|\/.*)/,embedtag:{tag:"iframe",width:"120px",height:"240px"}}),new f.fn.oembed.OEmbedProvider(
+"slideshare","rich",["slideshare.net"],"//www.slideshare.net/api/oembed/2",{format:"jsonp"}),new f.fn.oembed.OEmbedProvider("roomsharejp","rich",[
+"roomshare\\.jp/(en/)?post/.*"],"http://roomshare.jp/oembed.json"),new f.fn.oembed.OEmbedProvider("lanyard","rich",["lanyrd.com/\\d+/.+"],null,{yql:{
+xpath:'(//div[@class="primary"])[1]',from:"htmlstring",datareturn:function(e){return!!e.result&&'<div class="oembedall-lanyard">'+e.result+"</div>"}}}
+),new f.fn.oembed.OEmbedProvider("asciiartfarts","rich",["asciiartfarts.com/\\d+.html"],null,{yql:{xpath:"//pre/font",from:"htmlstring",
+datareturn:function(e){return!!e.result&&'<pre style="background-color:#000;">'+e.result+"</div>"}}}),new f.fn.oembed.OEmbedProvider("coveritlive",
+"rich",["coveritlive.com/"],null,{templateRegex:/(.*)/,
+template:'<iframe src="$1" allowtransparency="true" scrolling="no" width="615px" frameborder="0" height="625px"></iframe>'}),
+new f.fn.oembed.OEmbedProvider("polldaddy","rich",["polldaddy.com/"],null,{templateRegex:/(?:https?:\/\/w?w?w?.?polldaddy.com\/poll\/)([0-9]*)\//,
+template:'<script async type="text/javascript" charset="utf-8" src="http://static.polldaddy.com/p/$1.js"><\/script>',nocache:1}),
+new f.fn.oembed.OEmbedProvider("360io","rich",["360\\.io/.+"],"http://360.io/$1",{templateRegex:/.*360\.io\/(\w+).*/,embedtag:{tag:"iframe",width:480,
+height:360},nocache:1}),new f.fn.oembed.OEmbedProvider("bubbli","rich",["on\\.bubb\\.li/.+"],"http://on.bubb.li/$1",{
+templateRegex:/.*on\.bubb\.li\/(\w+).*/,embedtag:{tag:"iframe",width:480,height:360},nocache:1}),new f.fn.oembed.OEmbedProvider("cloudup","rich",[
+"cloudup\\.com/.+"],"http://cloudup.com/$1?chromeless",{templateRegex:[/.*cloudup\.com\/(\w+).*/],embedtag:{tag:"iframe",width:480,height:360}}),
+new f.fn.oembed.OEmbedProvider("codepen","rich",["codepen.io/.+"],"http://codepen.io/$1/embed/$2",{templateRegex:[/.*io\/(\w+)\/pen\/(\w+).*/,
+/.*io\/(\w+)\/full\/(\w+).*/],embedtag:{tag:"iframe",width:"100%",height:"300"},nocache:1}),new f.fn.oembed.OEmbedProvider("googleviews","rich",[
+"(.*maps\\.google\\.com\\/maps\\?).+(output=svembed).+(cbp=(.*)).*"],
+"https://maps.google.com/maps?layer=c&panoid=$3&ie=UTF8&source=embed&output=svembed&cbp=$5",{
+templateRegex:/(.*maps\.google\.com\/maps\?).+(panoid=(\w+)&).*(cbp=(.*)).*/,embedtag:{tag:"iframe",width:480,height:360},nocache:1}),
+new f.fn.oembed.OEmbedProvider("googlemaps","rich",["google\\.com/maps/place/.+"],"http://maps.google.com/maps?t=m&q=$1&output=embed",{
+templateRegex:/.*google\.com\/maps\/place\/([\w\+]*)\/.*/,embedtag:{tag:"iframe",width:480,height:360},nocache:1}),new f.fn.oembed.OEmbedProvider(
+"imajize","rich",["embed\\.imajize\\.com/.+"],"http://embed.imajize.com/$1",{templateRegex:/.*embed\.imajize\.com\/(.*)/,embedtag:{tag:"iframe",
+width:480,height:360},nocache:1}),new f.fn.oembed.OEmbedProvider("mapjam","rich",["mapjam\\.com/.+"],"http://www.mapjam.com/$1",{
+templateRegex:/.*mapjam\.com\/(.*)/,embedtag:{tag:"iframe",width:480,height:360},nocache:1}),new f.fn.oembed.OEmbedProvider("polar","rich",[
+"polarb\\.com/.+"],"http://assets-polarb-com.a.ssl.fastly.net/api/v4/publishers/unknown/embedded_polls/iframe?poll_id=$1",{
+templateRegex:/.*polarb\.com\/polls\/(\w+).*/,embedtag:{tag:"iframe",width:480,height:360},nocache:1}),new f.fn.oembed.OEmbedProvider("ponga","rich",[
+"ponga\\.com/.+"],"https://www.ponga.com/embedded?id=$1",{templateRegex:[/.*ponga\.com\/embedded\?id=(\w+).*/,/.*ponga\.com\/(\w+).*/],embedtag:{
+tag:"iframe",width:480,height:360},nocache:1}),new f.fn.oembed.OEmbedProvider("opengraph","rich",[".*"],null,{yql:{xpath:"//meta|//title|//link",
+from:"html",datareturn:function(e){if(!e["og:title"]&&e.title&&e.description&&(e["og:title"]=e.title),!e["og:title"]&&!e.title)return!1;var t=f("<p/>"
+);if(e["og:video"]){var n=f('<embed src="'+e["og:video"]+'"/>');n.attr("type",e["og:video:type"]||"application/x-shockwave-flash").css("max-height",
+m.maxHeight||"auto").css("max-width",m.maxWidth||"auto"),e["og:video:width"]&&n.attr("width",e["og:video:width"]),e["og:video:height"]&&n.attr(
+"height",e["og:video:height"]),t.append(n)}else if(e["og:image"]){var i=f('<img src="'+e["og:image"]+'">');i.css("max-height",m.maxHeight||"auto"
+).css("max-width",m.maxWidth||"auto"),e["og:image:width"]&&i.attr("width",e["og:image:width"]),e["og:image:height"]&&i.attr("height",
+e["og:image:height"]),t.append(i)}return e["og:title"]&&t.append("<b>"+e["og:title"]+"</b><br/>"),e["og:description"]?t.append(
+e["og:description"]+"<br/>"):e.description&&t.append(e.description+"<br/>"),t}}})]}(jQuery),String.prototype.md5=function(){var d=function(e,t){
+var n=(65535&e)+(65535&t);return(e>>16)+(t>>16)+(n>>16)<<16|65535&n},s=function(e,t,n,i,o,r){return d((a=d(d(t,e),d(i,r)))<<(s=o)|a>>>32-s,n);var a,s}
+,h=function(e,t,n,i,o,r,a){return s(t&n|~t&i,e,t,o,r,a)},p=function(e,t,n,i,o,r,a){return s(t&i|n&~i,e,t,o,r,a)},f=function(e,t,n,i,o,r,a){return s(
+t^n^i,e,t,o,r,a)},m=function(e,t,n,i,o,r,a){return s(n^(t|~i),e,t,o,r,a)};return function(e){var t,n="0123456789abcdef",i="",o=4*e.length;for(
+t=0;t<o;t++)i+=n.charAt(e[t>>2]>>t%4*8+4&15)+n.charAt(e[t>>2]>>t%4*8&15);return i}(function(e){var t,n,i,o,r,a=e.length,s=1732584193,l=-271733879,
+c=-1732584194,u=271733878;for(r=0;r<a;r+=16)s=h(t=s,n=l,i=c,o=u,e[r+0],7,-680876936),u=h(u,s,l,c,e[r+1],12,-389564586),c=h(c,u,s,l,e[r+2],17,606105819
+),l=h(l,c,u,s,e[r+3],22,-1044525330),s=h(s,l,c,u,e[r+4],7,-176418897),u=h(u,s,l,c,e[r+5],12,1200080426),c=h(c,u,s,l,e[r+6],17,-1473231341),l=h(l,c,u,s
+,e[r+7],22,-45705983),s=h(s,l,c,u,e[r+8],7,1770035416),u=h(u,s,l,c,e[r+9],12,-1958414417),c=h(c,u,s,l,e[r+10],17,-42063),l=h(l,c,u,s,e[r+11],22,
+-1990404162),s=h(s,l,c,u,e[r+12],7,1804603682),u=h(u,s,l,c,e[r+13],12,-40341101),c=h(c,u,s,l,e[r+14],17,-1502002290),l=h(l,c,u,s,e[r+15],22,1236535329
+),s=p(s,l,c,u,e[r+1],5,-165796510),u=p(u,s,l,c,e[r+6],9,-1069501632),c=p(c,u,s,l,e[r+11],14,643717713),l=p(l,c,u,s,e[r+0],20,-373897302),s=p(s,l,c,u,
+e[r+5],5,-701558691),u=p(u,s,l,c,e[r+10],9,38016083),c=p(c,u,s,l,e[r+15],14,-660478335),l=p(l,c,u,s,e[r+4],20,-405537848),s=p(s,l,c,u,e[r+9],5,
+568446438),u=p(u,s,l,c,e[r+14],9,-1019803690),c=p(c,u,s,l,e[r+3],14,-187363961),l=p(l,c,u,s,e[r+8],20,1163531501),s=p(s,l,c,u,e[r+13],5,-1444681467),
+u=p(u,s,l,c,e[r+2],9,-51403784),c=p(c,u,s,l,e[r+7],14,1735328473),l=p(l,c,u,s,e[r+12],20,-1926607734),s=f(s,l,c,u,e[r+5],4,-378558),u=f(u,s,l,c,e[r+8]
+,11,-2022574463),c=f(c,u,s,l,e[r+11],16,1839030562),l=f(l,c,u,s,e[r+14],23,-35309556),s=f(s,l,c,u,e[r+1],4,-1530992060),u=f(u,s,l,c,e[r+4],11,
+1272893353),c=f(c,u,s,l,e[r+7],16,-155497632),l=f(l,c,u,s,e[r+10],23,-1094730640),s=f(s,l,c,u,e[r+13],4,681279174),u=f(u,s,l,c,e[r+0],11,-358537222),
+c=f(c,u,s,l,e[r+3],16,-722521979),l=f(l,c,u,s,e[r+6],23,76029189),s=f(s,l,c,u,e[r+9],4,-640364487),u=f(u,s,l,c,e[r+12],11,-421815835),c=f(c,u,s,l,
+e[r+15],16,530742520),l=f(l,c,u,s,e[r+2],23,-995338651),s=m(s,l,c,u,e[r+0],6,-198630844),u=m(u,s,l,c,e[r+7],10,1126891415),c=m(c,u,s,l,e[r+14],15,
+-1416354905),l=m(l,c,u,s,e[r+5],21,-57434055),s=m(s,l,c,u,e[r+12],6,1700485571),u=m(u,s,l,c,e[r+3],10,-1894986606),c=m(c,u,s,l,e[r+10],15,-1051523),
+l=m(l,c,u,s,e[r+1],21,-2054922799),s=m(s,l,c,u,e[r+8],6,1873313359),u=m(u,s,l,c,e[r+15],10,-30611744),c=m(c,u,s,l,e[r+6],15,-1560198380),l=m(l,c,u,s,
+e[r+13],21,1309151649),s=m(s,l,c,u,e[r+4],6,-145523070),u=m(u,s,l,c,e[r+11],10,-1120210379),c=m(c,u,s,l,e[r+2],15,718787259),l=m(l,c,u,s,e[r+9],21,
+-343485551),s=d(s,t),l=d(l,n),c=d(c,i),u=d(u,o);return[s,l,c,u]}(function(e){var t,n,i=1+(e.length+8>>6),o=[],r=16*i,a=e.length;for(t=0;t<r;t++
+)o.push(0);for(n=0;n<a;n++)o[n>>2]|=(255&e.charCodeAt(n))<<n%4*8;return o[n>>2]|=128<<n%4*8,o[16*i-2]=8*a,o}(this)))},($("html").hasClass("touch")&&$(
+".menu").length||$(".nav-drawer").length)&&!$(".menu-backdrop").length&&$("body").append('<div class="menu-backdrop"></div>')
+;var menuBD=document.getElementsByClassName("menu-backdrop")[0];if(void 0!==menuBD){var menuBDTap=new Hammer(menuBD);menuBDTap.on("tap",function(e){$(
+".menu.open").length&&mReset()})}$(document).on("click",function(e){var t=$(e.target);$(".menu.open").length&&!t.is(".fbtn-container *, .menu *"
+)&&mReset()});var mReset=function(){var e=$("body");e.hasClass("menu-open")&&e.removeClass("menu-open"),e.hasClass("nav-drawer-open")&&e.removeClass(
+"nav-drawer-open"),$(".menu-toggle").closest(".active").removeClass("active"),$(".menu.open .menu-search-focus").length&&$(
+".menu.open .menu-search-focus").blur(),$(".menu.open").removeClass("open")};$(document).on("click",".menu-toggle",function(e){e.preventDefault(),
+e.stopPropagation();var t=$(this),n=t.parent(),i=$(getTargetFromTrigger(t));if(n.hasClass("active"))mReset();else{mReset(),i.hasClass("nav-drawer")?$(
+"body").addClass("nav-drawer-open"):$("body").addClass("menu-open"),n.addClass("active"),i.addClass("open");var o=null;localStorage&&(
+o=localStorage.getItem("lastSearch"));var r=$(".menu-search-focus",i);r.length&&(r.focus(),o&&r.val(o).trigger("input").select())}}),$(document).on(
+"click",".modal-close-iframe",function(e){e.preventDefault(),window.parent.closeModal(getTargetFromTrigger($(this)))}),window.closeModal=function(e){
+$(e).modal("hide")},function(e,t){"object"==typeof exports&&exports&&"string"!=typeof exports.nodeName?t(exports
+):"function"==typeof define&&define.amd?define(["exports"],t):(e.Mustache={},t(e.Mustache))}(this,function(A){var t=Object.prototype.toString,
+x=Array.isArray||function(e){return"[object Array]"===t.call(e)};function c(e){return"function"==typeof e}function k(e){return e.replace(
+/[\-\[\]{}()*+?.,\\\^$|#\s]/g,"\\$&")}function s(e,t){return null!=e&&"object"==typeof e&&t in e}var i=RegExp.prototype.test;var o=/\S/;function T(e){
+return t=o,n=e,!i.call(t,n);var t,n}var n={"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;","/":"&#x2F;","`":"&#x60;","=":"&#x3D;"}
+;var E=/\s*/,C=/\s+/,$=/\s*=/,S=/\s*\}/,_=/#|\^|\/|>|\{|&|=|!/;function D(e){this.string=e,this.tail=e,this.pos=0}function r(e,t){this.view=e,
+this.cache={".":this.view},this.parent=t}function e(){this.cache={}}D.prototype.eos=function(){return""===this.tail},D.prototype.scan=function(e){
+var t=this.tail.match(e);if(!t||0!==t.index)return"";var n=t[0];return this.tail=this.tail.substring(n.length),this.pos+=n.length,n},
+D.prototype.scanUntil=function(e){var t,n=this.tail.search(e);switch(n){case-1:t=this.tail,this.tail="";break;case 0:t="";break;default:
+t=this.tail.substring(0,n),this.tail=this.tail.substring(n)}return this.pos+=t.length,t},r.prototype.push=function(e){return new r(e,this)},
+r.prototype.lookup=function(e){var t,n=this.cache;if(n.hasOwnProperty(e))t=n[e];else{for(var i,o,r=this,a=!1;r;){if(0<e.indexOf("."))for(t=r.view,
+i=e.split("."),o=0;null!=t&&o<i.length;)o===i.length-1&&(a=s(t,i[o])),t=t[i[o++]];else t=r.view[e],a=s(r.view,e);if(a)break;r=r.parent}n[e]=t}
+return c(t)&&(t=t.call(this.view)),t},e.prototype.clearCache=function(){this.cache={}},e.prototype.parse=function(e,t){var n=this.cache,i=n[e]
+;return null==i&&(i=n[e]=function(e,t){if(!e)return[];var n,i,o,r=[],a=[],s=[],l=!1,c=!1;function u(){if(l&&!c)for(;s.length;)delete a[s.pop(
+)];else s=[];c=l=!1}function d(e){if("string"==typeof e&&(e=e.split(C,2)),!x(e)||2!==e.length)throw new Error("Invalid tags: "+e);n=new RegExp(k(e[0]
+)+"\\s*"),i=new RegExp("\\s*"+k(e[1])),o=new RegExp("\\s*"+k("}"+e[1]))}d(t||A.tags);for(var h,p,f,m,g,v,y=new D(e);!y.eos();){if(h=y.pos,
+f=y.scanUntil(n))for(var b=0,w=f.length;b<w;++b)T(m=f.charAt(b))?s.push(a.length):c=!0,a.push(["text",m,h,h+1]),h+=1,"\n"===m&&u();if(!y.scan(n))break
+;if(l=!0,p=y.scan(_)||"name",y.scan(E),"="===p?(f=y.scanUntil($),y.scan($),y.scanUntil(i)):"{"===p?(f=y.scanUntil(o),y.scan(S),y.scanUntil(i),p="&"
+):f=y.scanUntil(i),!y.scan(i))throw new Error("Unclosed tag at "+y.pos);if(g=[p,f,h,y.pos],a.push(g),"#"===p||"^"===p)r.push(g);else if("/"===p){if(!(
+v=r.pop()))throw new Error('Unopened section "'+f+'" at '+h);if(v[1]!==f)throw new Error('Unclosed section "'+v[1]+'" at '+h)
+}else"name"===p||"{"===p||"&"===p?c=!0:"="===p&&d(f)}if(v=r.pop())throw new Error('Unclosed section "'+v[1]+'" at '+y.pos);return function(e){for(
+var t,n=[],i=n,o=[],r=0,a=e.length;r<a;++r)switch((t=e[r])[0]){case"#":case"^":i.push(t),o.push(t),i=t[4]=[];break;case"/":o.pop()[5]=t[2],
+i=0<o.length?o[o.length-1][4]:n;break;default:i.push(t)}return n}(function(e){for(var t,n,i=[],o=0,r=e.length;o<r;++o)(t=e[o])&&(
+"text"===t[0]&&n&&"text"===n[0]?(n[1]+=t[1],n[3]=t[3]):(i.push(t),n=t));return i}(a))}(e,t)),i},e.prototype.render=function(e,t,n){var i=this.parse(e)
+,o=t instanceof r?t:new r(t);return this.renderTokens(i,o,n,e)},e.prototype.renderTokens=function(e,t,n,i){for(var o,r,a,s="",l=0,c=e.length;l<c;++l
+)a=void 0,"#"===(r=(o=e[l])[0])?a=this.renderSection(o,t,n,i):"^"===r?a=this.renderInverted(o,t,n,i):">"===r?a=this.renderPartial(o,t,n,i
+):"&"===r?a=this.unescapedValue(o,t):"name"===r?a=this.escapedValue(o,t):"text"===r&&(a=this.rawValue(o)),void 0!==a&&(s+=a);return s},
+e.prototype.renderSection=function(e,t,n,i){var o=this,r="",a=t.lookup(e[1]);if(a){if(x(a))for(var s=0,l=a.length;s<l;++s)r+=this.renderTokens(e[4],
+t.push(a[s]),n,i);else if("object"==typeof a||"string"==typeof a||"number"==typeof a)r+=this.renderTokens(e[4],t.push(a),n,i);else if(c(a)){if(
+"string"!=typeof i)throw new Error("Cannot use higher-order sections without the original template");null!=(a=a.call(t.view,i.slice(e[3],e[5]),
+function(e){return o.render(e,t,n)}))&&(r+=a)}else r+=this.renderTokens(e[4],t,n,i);return r}},e.prototype.renderInverted=function(e,t,n,i){
+var o=t.lookup(e[1]);if(!o||x(o)&&0===o.length)return this.renderTokens(e[4],t,n,i)},e.prototype.renderPartial=function(e,t,n){if(n){var i=c(n)?n(e[1]
+):n[e[1]];return null!=i?this.renderTokens(this.parse(i),t,n,i):void 0}},e.prototype.unescapedValue=function(e,t){var n=t.lookup(e[1]);if(null!=n
+)return n},e.prototype.escapedValue=function(e,t){var n=t.lookup(e[1]);if(null!=n)return A.escape(n)},e.prototype.rawValue=function(e){return e[1]},
+A.name="mustache.js",A.version="2.3.0",A.tags=["{{","}}"];var a=new e;return A.clearCache=function(){return a.clearCache()},A.parse=function(e,t){
+return a.parse(e,t)},A.render=function(e,t,n){if("string"!=typeof e)throw new TypeError('Invalid template! Template should be a "string" but "'+(x(i=e
+)?"array":typeof i)+'" was given as the first argument for mustache#render(template, view, partials)');var i;return a.render(e,t,n)},
+A.to_html=function(e,t,n,i){var o=A.render(e,t,n);if(!c(i))return o;i(o)},A.escape=function(e){return String(e).replace(/[&<>"'`=\/]/g,function(e){
+return n[e]})},A.Scanner=D,A.Context=r,A.Writer=e,A}),setTimeout(function(){"use strict";$(function(){var i=["youtube.com","dev.lucee.org",
+"luceeserver.atlassian.net","github.com"],t=function(t,n){$.ajax("http://open.iframe.ly/api/oembed?url="+n+"&origin=lucee").done(function(e){
+e.code=$.fn.oembed.getGenericCode(n,e),$.fn.oembed.insertCode(t,"replace",e)}).fail(function(e){console.error(e)})};$(".content-inner .body a").each(
+function(){if(!($(this).hasClass("edit-link")||$(this).hasClass("local-edit-link")||$(this).hasClass("no-oembed"))){var e=$(this).attr("href");if(
+!e||-1!==e.indexOf("http")){(function(e){var t=!1;for(var n in i)if(0<e.indexOf(i[n])){t=!0;break}})(String(e));e==$(this).text()&&$(this).oembed(e,{
+fallback:!1,onProviderNotFound:t})}}})})},200),function(e){"use strict";"function"==typeof define&&define.amd?define(["jquery"],e):e(jQuery)}(
+function(o){"use strict";function r(t,n){this.el=t,this.options=n=n||{};var e={group:Math.random(),sort:!0,disabled:!1,store:null,handle:null,
+scroll:!0,scrollSensitivity:30,scrollSpeed:10,draggable:/[uo]l/i.test(t.nodeName)?"li":">*",ghostClass:"sortable-ghost",ignore:"a, img",filter:null,
+animation:0,setData:function(e,t){e.setData("Text",t.textContent)},dropBubble:!1,dragoverBubble:!1};for(var i in e)!(i in n)&&(n[i]=e[i])
+;var o=n.group;for(var r in o&&"object"==typeof o||(o=n.group={name:o}),["pull","put"].forEach(function(e){e in o||(o[e]=!0)}),B.forEach(function(e){
+n[e]=a(this,n[e]||H),l(t,e.substr(2).toLowerCase(),n[e])},this),n.groups=" "+o.name+(o.put.join?" "+o.put.join(" "):"")+" ",t[N]=n,this
+)"_"===r.charAt(0)&&(this[r]=a(this,this[r]));l(t,"mousedown",this._onTapStart),l(t,"touchstart",this._onTapStart),l(t,"dragover",this),l(t,
+"dragenter",this),z.push(this._onDragOver),n.store&&this.sort(n.store.get(this))}function x(e){S&&S.state!==e&&(T(S,"display",e?"none":""),
+!e&&S.state&&_.insertBefore(S,C),S.state=e)}function a(e,t){var n=F.call(arguments,2);return t.bind?t.bind.apply(t,[e].concat(n)):function(){
+return t.apply(e,n.concat(F.call(arguments)))}}function k(e,t,n){if(e){n=n||A;var i=(t=t.split(".")).shift().toUpperCase(),o=new RegExp("\\s("+t.join(
+"|")+")\\s","g");do{if(">*"===i&&e.parentNode===n||(""===i||e.nodeName.toUpperCase()==i)&&(!t.length||((" "+e.className+" ").match(o)||[]
+).length==t.length))return e}while(e!==n&&(e=e.parentNode))}return null}function l(e,t,n){e.addEventListener(t,n,!1)}function i(e,t,n){
+e.removeEventListener(t,n,!1)}function s(e,t,n){if(e)if(e.classList)e.classList[n?"add":"remove"](t);else{var i=(" "+e.className+" ").replace(/\s+/g,
+" ").replace(" "+t+" ","");e.className=i+(n?" "+t:"")}}function T(e,t,n){var i=e&&e.style;if(i){if(void 0===n
+)return A.defaultView&&A.defaultView.getComputedStyle?n=A.defaultView.getComputedStyle(e,""):e.currentStyle&&(n=e.currentStyle),void 0===t?n:n[t]
+;t in i||(t="-webkit-"+t),i[t]=n+("string"==typeof n?"":"px")}}function c(e,t,n){if(e){var i=e.getElementsByTagName(t),o=0,r=i.length;if(n)for(
+;o<r;o++)n(i[o],o);return i}return[]}function u(e){e.draggable=!1}function E(){q=!1}function d(e){for(
+var t=e.tagName+e.className+e.src+e.href+e.textContent,n=t.length,i=0;n--;)i+=t.charCodeAt(n);return i.toString(36)}function h(e){for(var t=0;e&&(
+e=e.previousElementSibling);)"TEMPLATE"!==e.nodeName.toUpperCase()&&t++;return t}function e(e,t){var n,i;return function(){void 0===n&&(n=arguments,
+i=this,setTimeout(function(){1===n.length?e.call(i,n[0]):e.apply(i,n),n=void 0},t))}}var C,$,S,_,D,p,f,j,O,m,g,P,v,y,b={},N="Sortable"+(new Date
+).getTime(),w=window,A=w.document,R=w.parseInt,I=!!("draggable"in A.createElement("div")),q=!1,L=function(e,t,n,i,o,r){var a=A.createEvent("Event")
+;a.initEvent(t,!0,!0),a.item=n||e,a.from=i||e,a.clone=S,a.oldIndex=o,a.newIndex=r,e.dispatchEvent(a)},
+B="onAdd onUpdate onRemove onStart onEnd onFilter onSort".split(" "),H=function(){},M=Math.abs,F=[].slice,z=[],W=e(function(e,t,n){if(n&&t.scroll){
+var i,o,r,a,s=t.scrollSensitivity,l=t.scrollSpeed,c=e.clientX,u=e.clientY,d=window.innerWidth,h=window.innerHeight;if(f!==n&&(p=t.scroll,f=n,!0===p)){
+p=n;do{if(p.offsetWidth<p.scrollWidth||p.offsetHeight<p.scrollHeight)break}while(p=p.parentNode)}p&&(o=(i=p).getBoundingClientRect(),r=(M(o.right-c
+)<=s)-(M(o.left-c)<=s),a=(M(o.bottom-u)<=s)-(M(o.top-u)<=s)),r||a||(a=(h-u<=s)-(u<=s),((r=(d-c<=s)-(c<=s))||a)&&(i=w)),(b.vx!==r||b.vy!==a||b.el!==i
+)&&(b.el=i,b.vx=r,b.vy=a,clearInterval(b.pid),i&&(b.pid=setInterval(function(){i===w?w.scrollTo(w.scrollX+r*l,w.scrollY+a*l):(a&&(i.scrollTop+=a*l),
+r&&(i.scrollLeft+=r*l))},24)))}},30);r.prototype={constructor:r,_dragStarted:function(){_&&C&&(s(C,this.options.ghostClass,!0),r.active=this,L(_,
+"start",C,_,m))},_onTapStart:function(e){var t=e.type,n=e.touches&&e.touches[0],i=(n||e).target,o=i,r=this.options,a=this.el,s=r.filter;if(!(
+"mousedown"===t&&0!==e.button||r.disabled)&&(i=k(i,r.draggable,a))){if(m=h(i),"function"==typeof s){if(s.call(this,e,i,this))return L(o,"filter",i,a,m
+),void e.preventDefault()}else if(s&&(s=s.split(",").some(function(e){return(e=k(o,e.trim(),a))?(L(e,"filter",i,a,m),!0):void 0}))
+)return void e.preventDefault();if((!r.handle||k(o,r.handle,a))&&i&&!C&&i.parentNode===a){v=e,_=this.el,D=(C=i).nextSibling,P=this.options.group,
+C.draggable=!0,r.ignore.split(",").forEach(function(e){c(i,e.trim(),u)}),n&&(v={target:i,clientX:n.clientX,clientY:n.clientY},this._onDragStart(v,
+"touch"),e.preventDefault()),l(A,"mouseup",this._onDrop),l(A,"touchend",this._onDrop),l(A,"touchcancel",this._onDrop),l(C,"dragend",this),l(_,
+"dragstart",this._onDragStart),I||this._onDragStart(v,!0);try{A.selection?A.selection.empty():window.getSelection().removeAllRanges()}catch(e){}}}},
+_emulateDragOver:function(){if(y){T($,"display","none");var e=A.elementFromPoint(y.clientX,y.clientY),t=e,n=" "+this.options.group.name,i=z.length;if(
+t)do{if(t[N]&&-1<t[N].groups.indexOf(n)){for(;i--;)z[i]({clientX:y.clientX,clientY:y.clientY,target:e,rootEl:t});break}e=t}while(t=t.parentNode);T($,
+"display","")}},_onTouchMove:function(e){if(v){var t=e.touches?e.touches[0]:e,n=t.clientX-v.clientX,i=t.clientY-v.clientY,
+o=e.touches?"translate3d("+n+"px,"+i+"px,0)":"translate("+n+"px,"+i+"px)";y=t,T($,"webkitTransform",o),T($,"mozTransform",o),T($,"msTransform",o),T($,
+"transform",o),e.preventDefault()}},_onDragStart:function(e,t){var n=e.dataTransfer,i=this.options;if(this._offUpEvents(),"clone"==P.pull&&(T(
+S=C.cloneNode(!0),"display","none"),_.insertBefore(S,C)),t){var o,r=C.getBoundingClientRect(),a=T(C);T($=C.cloneNode(!0),"top",r.top-R(a.marginTop,10)
+),T($,"left",r.left-R(a.marginLeft,10)),T($,"width",r.width),T($,"height",r.height),T($,"opacity","0.8"),T($,"position","fixed"),T($,"zIndex","100000"
+),_.appendChild($),o=$.getBoundingClientRect(),T($,"width",2*r.width-o.width),T($,"height",2*r.height-o.height),"touch"===t?(l(A,"touchmove",
+this._onTouchMove),l(A,"touchend",this._onDrop),l(A,"touchcancel",this._onDrop)):(l(A,"mousemove",this._onTouchMove),l(A,"mouseup",this._onDrop)),
+this._loopId=setInterval(this._emulateDragOver,150)}else n&&(n.effectAllowed="move",i.setData&&i.setData.call(this,n,C)),l(A,"drop",this);setTimeout(
+this._dragStarted,0)},_onDragOver:function(e){var t,n,i,o,r,a,s=this.el,l=this.options,c=l.group,u=c.put,d=P===c,h=l.sort;if(C&&(
+void 0!==e.preventDefault&&(e.preventDefault(),!l.dragoverBubble&&e.stopPropagation()),P&&!l.disabled&&(d?h||(i=!_.contains(C)):P.pull&&u&&(
+P.name===c.name||u.indexOf&&~u.indexOf(P.name)))&&(void 0===e.rootEl||e.rootEl===this.el))){if(W(e,l,this.el),q)return;if(t=k(e.target,l.draggable,s),
+n=C.getBoundingClientRect(),i)return x(!0),void(S||D?_.insertBefore(C,S||D):h||_.appendChild(C));if(
+0===s.children.length||s.children[0]===$||s===e.target&&(o=e,r=s.lastElementChild,a=r.getBoundingClientRect(),t=5<o.clientY-(a.top+a.height)&&r)){if(t
+){if(t.animated)return;f=t.getBoundingClientRect()}x(d),s.appendChild(C),this._animate(n,C),t&&this._animate(f,t)}else if(
+t&&!t.animated&&t!==C&&void 0!==t.parentNode[N]){j!==t&&(O=T(j=t));var p,f=t.getBoundingClientRect(),m=f.right-f.left,g=f.bottom-f.top,
+v=/left|right|inline/.test(O.cssFloat+O.display),y=t.offsetWidth>C.offsetWidth,b=t.offsetHeight>C.offsetHeight,w=.5<(v?(e.clientX-f.left)/m:(
+e.clientY-f.top)/g),A=t.nextElementSibling;q=!0,setTimeout(E,30),x(d),(p=v?t.previousElementSibling===C&&!y||w&&y:A!==C&&!b||w&&b)&&!A?s.appendChild(C
+):t.parentNode.insertBefore(C,p?A:t),this._animate(n,C),this._animate(f,t)}}},_animate:function(e,t){var n=this.options.animation;if(n){
+var i=t.getBoundingClientRect();T(t,"transition","none"),T(t,"transform","translate3d("+(e.left-i.left)+"px,"+(e.top-i.top)+"px,0)"),t.offsetWidth,T(t
+,"transition","all "+n+"ms"),T(t,"transform","translate3d(0,0,0)"),clearTimeout(t.animated),t.animated=setTimeout(function(){T(t,"transition",""),T(t,
+"transform",""),t.animated=!1},n)}},_offUpEvents:function(){i(A,"mouseup",this._onDrop),i(A,"touchmove",this._onTouchMove),i(A,"touchend",this._onDrop
+),i(A,"touchcancel",this._onDrop)},_onDrop:function(e){var t=this.el,n=this.options;clearInterval(this._loopId),clearInterval(b.pid),i(A,"drop",this),
+i(A,"mousemove",this._onTouchMove),i(t,"dragstart",this._onDragStart),this._offUpEvents(),e&&(e.preventDefault(),!n.dropBubble&&e.stopPropagation(),
+$&&$.parentNode.removeChild($),C&&(i(C,"dragend",this),u(C),s(C,this.options.ghostClass,!1),_!==C.parentNode?(g=h(C),L(C.parentNode,"sort",C,_,m,g),L(
+_,"sort",C,_,m,g),L(C,"add",C,_,m,g),L(_,"remove",C,_,m,g)):(S&&S.parentNode.removeChild(S),C.nextSibling!==D&&(g=h(C),L(_,"update",C,_,m,g),L(_,
+"sort",C,_,m,g))),r.active&&L(_,"end",C,_,m,g)),_=C=$=D=S=p=f=v=y=j=O=P=r.active=null,this.save())},handleEvent:function(e){var t,n=e.type
+;"dragover"===n||"dragenter"===n?(this._onDragOver(e),(t=e).dataTransfer.dropEffect="move",t.preventDefault()):("drop"===n||"dragend"===n
+)&&this._onDrop(e)},toArray:function(){for(var e,t=[],n=this.el.children,i=0,o=n.length;i<o;i++)k(e=n[i],this.options.draggable,this.el)&&t.push(
+e.getAttribute("data-id")||d(e));return t},sort:function(e){var i={},o=this.el;this.toArray().forEach(function(e,t){var n=o.children[t];k(n,
+this.options.draggable,o)&&(i[e]=n)},this),e.forEach(function(e){i[e]&&(o.removeChild(i[e]),o.appendChild(i[e]))})},save:function(){
+var e=this.options.store;e&&e.set(this)},closest:function(e,t){return k(e,t||this.options.draggable,this.el)},option:function(e,t){var n=this.options
+;return void 0===t?n[e]:void(n[e]=t)},destroy:function(){var t=this.el,n=this.options;B.forEach(function(e){i(t,e.substr(2).toLowerCase(),n[e])}),i(t,
+"mousedown",this._onTapStart),i(t,"touchstart",this._onTapStart),i(t,"dragover",this),i(t,"dragenter",this),Array.prototype.forEach.call(
+t.querySelectorAll("[draggable]"),function(e){e.removeAttribute("draggable")}),z.splice(z.indexOf(this._onDragOver),1),this._onDrop(),this.el=null}},
+r.utils={on:l,off:i,css:T,find:c,bind:a,is:function(e,t){return!!k(e,t,e)},throttle:e,closest:k,toggleClass:s,dispatchEvent:L,index:h},
+r.version="1.1.1",r.create=function(e,t){return new r(e,t)},o.fn.sortable=function(n){var i;return this.each(function(){var e=o(this),t=e.data(
+"sortable");if(t||!(n instanceof Object)&&n||(t=new r(this,n),e.data("sortable",t)),t){if("widget"===n)return t;"destroy"===n?(t.destroy(),
+e.removeData("sortable")):n in t&&(i=t[t].apply(t,[].slice.call(arguments,1)))}}),void 0===i?this:i}}),$(".sortable-list").sortable({
+draggable:".sortable-item",ghostClass:"sortable-ghost",handle:".sortable-handle"}),$(function(){setTimeout(function(){window[String.fromCharCode(103
+)+String.fromCharCode(97)]||$(".header .nav-list.pull-right").prepend($("<li/>").attr("title",
+"Please consider unblocking Google Analytics, we only use the stats to improve the docs for people like you").append($("<a/>").attr("href",
+"/docs.html").append($("<i/>").addClass("fa fa-fw fa-exclamation-triangle").css("color","#F1A797"))))},750),$("a").click(function(){var t=$(this
+).attr("href");if(t&&0!==t.indexOf("#"))if(-1===t.indexOf("http"))document.location=t;else try{gtag("event","click",{event_category:"outbound",
+event_label:t,transport_type:"beacon",event_callback:function(){document.location=t}})}catch(e){document.location=t}})}),window.onerror=function(e,t,n
+,i,o){try{var r=[e,[t,n,i].join(":"),document.location.toString()];o.stack&&r.push(o.stack.toString().substr(0,400)),gtag("event","exception",{
+description:r.join(","+String.fromCharCode(13)),fatal:!0})}catch(e){}};var tabSwitch=function(e,t){var n=e.closest(".tab-nav"),i=$(
+".tab-nav-indicator",n),o=n.offset().left,r=n.width(),a=e.offset().left,s=e.outerWidth();null!=t&&t.offset().left>a&&(i.addClass("reverse"),
+setTimeout(function(){i.removeClass("reverse")},450)),i.css({left:a-o,right:o+r-a-s})};$(document).on("show.bs.tab",'.tab-nav a[data-toggle="tab"]',
+function(e){tabSwitch($(e.target),$(e.relatedTarget))}),$(".tab-nav").each(function(){$(this).append('<div class="tab-nav-indicator"></div>'),
+tabSwitch($(".nav > li.active",$(this)),null)}),$(document).on("click",function(e){var t=$(e.target);if(t.is(
+'[data-toggle="tile"], [data-toggle="tile"] *')&&!t.is('[data-ignore="tile"], [data-ignore="tile"] *')){var n=t.closest('[data-toggle="tile"]')
+;null!=n.attr("data-parent")&&$(n.attr("data-parent")).find(".tile-active-show").collapse("hide"),$(getTargetFromTrigger(n)).collapse("toggle")
+}else t.is('[data-dismiss="tile"]')?t.closest(".tile-collapse").find(".tile-active-show").collapse("hide"):t.is(".tile-collapse, .tile-collapse *"
+)||tReset()}),$(".expand-a-z").click(function(){var e=$(this),t=e.data("expanded");e.text(t?"Expand All":"Collapse"),$(".tile-active-show").each(
+function(){$(this).toggleClass("collapse",!$(this).hasClass("collapse"))}),e.data("expanded",!t)});var tReset=function(){$(".tile-collapse.active"
+).each(function(){var e=$(".tile-active-show",$(this));e.hasClass("tile-active-show-still")||e.collapse("hide")})};$(document).on("hide.bs.collapse",
+".tile-active-show",function(){$(this).closest(".tile-collapse").css({"-webkit-transition-delay":"","transition-delay":""}).removeClass("active")}),$(
+document).on("show.bs.collapse",".tile-active-show",function(){$(this).closest(".tile-collapse").css({"-webkit-transition-delay":"",
+"transition-delay":""}).addClass("active")}),$(".tile-wrap-animation").each(function(e){var t=0,n=100;$("> .tile",$(this)).each(function(e){$(this
+).css({"-webkit-transform":"translate(0, "+n+"%)","-ms-transform":"translate(0, "+n+"%)",transform:"translate(0, "+n+"%)",
+"-webkit-transition-delay":t+"s","transition-delay":t+"s"}),t+=.1,n+=10})}),$(window).on("DOMContentLoaded scroll",function(){tileInView()})
+;var toastTimeout,tileInView=function(){$(".tile-wrap-animation:not(.isinview)").each(function(){var e=$(this);tileInViewCheck(e)&&(!e.hasClass(
+"avoid-fout")||e.hasClass("avoid-fout")&&e.hasClass("avoid-fout-done"))&&(!e.hasClass("el-loading")||e.hasClass("el-loading")&&e.hasClass(
+"el-loading-done"))&&!e.parents(".avoid-fout:not(.avoid-fout-done)").length&&!e.parents(".el-loading:not(.el-loading-done)").length&&e.addClass(
+"isinview")})},tileInViewCheck=function(e){var t=(e=e[0]).getBoundingClientRect()
+;return t.top<=window.innerHeight&&0<=t.right&&0<=t.bottom&&t.left<=window.innerWidth};$('[data-toggle="toast"]').tooltip({animation:!1,
+container:".toast",html:!0,placement:"bottom",template:'<div class="tooltip"><div class="toast-inner tooltip-inner"></div></div>',trigger:"manual"}),
+$(document).on("click",'[data-dismiss="toast"]',function(e){e.preventDefault(),toastHide(0)}),toastHide=function(e,t){clearTimeout(toastTimeout),
+toastTimeout=setTimeout(function(){$(".toast").removeClass("toast-show"),$(".fbtn-container").length&&$(".fbtn-container").css("margin-bottom",""),$(
+".toast-inner").one("webkitTransitionEnd otransitionend oTransitionEnd msTransitionEnd transitionend",function(e){$(".toast-toggled").tooltip("hide"
+).removeClass("toast-toggled"),null!=t?t.tooltip("show").addClass("toast-toggled"):$(".toast").remove()})},e)},$(document).on("mouseenter",".toast",
+function(){clearTimeout(toastTimeout)}),$(document).on("mouseleave",".toast",function(){toastHide(6e3)}),$(document).on("click",
+'[data-toggle="toast"]',function(){var e=$(this);$(".toast").length||$("body").append('<div class="toast"></div>'),e.hasClass("toast-toggled")||($(
+".toast").hasClass("toast-show")?toastHide(0,e):e.tooltip("show").addClass("toast-toggled"))}),$(document).on("shown.bs.tooltip",
+'[data-toggle="toast"]',function(){$(this);$(".toast").addClass("toast-show"),$(window).width()<768&&$(".fbtn-container").length&&$(".fbtn-container"
+).css("margin-bottom",$(".toast").outerHeight()),$(".toast-inner").one(
+"webkitTransitionEnd otransitionend oTransitionEnd msTransitionEnd transitionend",function(e){toastHide(6e3)})}),function(a){var s,e=a("base[href]"
+).attr("href");s=e?e+"editor.html":"/editor.html",window.addEventListener("message",function(e){if(e.data){var t=e.data;if(
+t.id&&t.src&&"try-cf"==t.src){t.height||(t.height=350);var n=a("IFRAME.trycf-iframe#"+t.id);if(1==n.length)return n.height(t.height),void console.log(
+"postMessage try-cf resize success",t);console.log("Element IFRAME.trycf-iframe#"+t.id+" not found")}}console.log("postMessage ignored",e)},!1),
+a.fn.tryCfLoader=function(){return this.each(function(){var e=a(this),t=e.next(),n=e.attr("id"),i=e.data("script"),o=s+"?script="+i+"&id="+e.attr("id"
+),r=a('<iframe seamless="seamless" frameborder="0" src="'+o+'" name="'+n+'"" id="'+n+'" class="trycf-iframe" height="350" width="100%"></iframe>')
+;e.after(r),t.remove()})},a("script[data-trycf]").tryCfLoader()}(jQuery),function(t,n){"function"==typeof define&&define.amd?define("bloodhound",[
+"jquery"],function(e){return t.Bloodhound=n(e)}):"object"==typeof exports?module.exports=n(require("jquery")):t.Bloodhound=n(jQuery)}(this,function(p
+){var f=function(){"use strict";return{isMsie:function(){return!!/(msie|trident)/i.test(navigator.userAgent)&&navigator.userAgent.match(
+/(msie |rv:)(\d+(.\d+)?)/i)[2]},isBlankString:function(e){return!e||/^\s*$/.test(e)},escapeRegExChars:function(e){return e.replace(
+/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g,"\\$&")},isString:function(e){return"string"==typeof e},isNumber:function(e){return"number"==typeof e},
+isArray:p.isArray,isFunction:p.isFunction,isObject:p.isPlainObject,isUndefined:function(e){return void 0===e},isElement:function(e){return!(
+!e||1!==e.nodeType)},isJQuery:function(e){return e instanceof p},toStr:function(e){return f.isUndefined(e)||null===e?"":e+""},bind:p.proxy,
+each:function(e,n){p.each(e,function(e,t){return n(t,e)})},map:p.map,filter:p.grep,every:function(n,i){var o=!0;return n?(p.each(n,function(e,t){
+return!!(o=i.call(null,t,e,n))&&void 0}),!!o):o},some:function(n,i){var o=!1;return n?(p.each(n,function(e,t){return!(o=i.call(null,t,e,n))&&void 0}),
+!!o):o},mixin:p.extend,identity:function(e){return e},clone:function(e){return p.extend(!0,{},e)},getIdGenerator:function(){var e=0;return function(){
+return e++}},templatify:function(e){return p.isFunction(e)?e:function(){return String(e)}},defer:function(e){setTimeout(e,0)},debounce:function(o,r,a
+){var s,l;return function(){var e,t,n=this,i=arguments;return e=function(){s=null,a||(l=o.apply(n,i))},t=a&&!s,clearTimeout(s),s=setTimeout(e,r),t&&(
+l=o.apply(n,i)),l}},throttle:function(n,i){var o,r,a,s,l,c;return l=0,c=function(){l=new Date,a=null,s=n.apply(o,r)},function(){var e=new Date,t=i-(
+e-l);return o=this,r=arguments,t<=0?(clearTimeout(a),a=null,l=e,s=n.apply(o,r)):a||(a=setTimeout(c,t)),s}},stringify:function(e){return f.isString(e
+)?e:JSON.stringify(e)},noop:function(){}}}(),n=function(){"use strict";function e(e){return(e=f.toStr(e))?e.split(/\s+/):[]}function t(e){return(
+e=f.toStr(e))?e.split(/\W+/):[]}function n(i){return function(){var e=[].slice.call(arguments,0);return function(t){var n=[];return f.each(e,function(
+e){n=n.concat(i(f.toStr(t[e])))}),n}}}return{nonword:t,whitespace:e,obj:{nonword:n(t),whitespace:n(e)}}}(),i=function(){"use strict";function e(e){
+this.maxSize=f.isNumber(e)?e:100,this.reset(),this.maxSize<=0&&(this.set=this.get=p.noop)}function t(){this.head=this.tail=null}function o(e,t){
+this.key=e,this.val=t,this.prev=this.next=null}return f.mixin(e.prototype,{set:function(e,t){var n,i=this.list.tail;this.size>=this.maxSize&&(
+this.list.remove(i),delete this.hash[i.key],this.size--),(n=this.hash[e])?(n.val=t,this.list.moveToFront(n)):(n=new o(e,t),this.list.add(n),
+this.hash[e]=n,this.size++)},get:function(e){var t=this.hash[e];return t?(this.list.moveToFront(t),t.val):void 0},reset:function(){this.size=0,
+this.hash={},this.list=new t}}),f.mixin(t.prototype,{add:function(e){this.head&&(e.next=this.head,this.head.prev=e),this.head=e,this.tail=this.tail||e
+},remove:function(e){e.prev?e.prev.next=e.next:this.head=e.next,e.next?e.next.prev=e.prev:this.tail=e.prev},moveToFront:function(e){this.remove(e),
+this.add(e)}}),e}(),t=function(){"use strict";function e(e,t){this.prefix=["__",e,"__"].join(""),this.ttlKey="__ttl__",this.keyMatcher=new RegExp(
+"^"+f.escapeRegExChars(this.prefix)),this.ls=t||r,this.ls&&window.JSON||(this.get=this.set=this.remove=this.clear=this.isExpired=f.noop)}function i(){
+return(new Date).getTime()}function o(e){return JSON.stringify(f.isUndefined(e)?null:e)}function n(e){return p.parseJSON(e)}var r;try{(
+r=window.localStorage).setItem("~~~","!"),r.removeItem("~~~")}catch(e){r=null}return f.mixin(e.prototype,{_prefix:function(e){return this.prefix+e},
+_ttlKey:function(e){return this._prefix(e)+this.ttlKey},get:function(e){return this.isExpired(e)&&this.remove(e),n(this.ls.getItem(this._prefix(e)))},
+set:function(e,t,n){return f.isNumber(n)?this.ls.setItem(this._ttlKey(e),o(i()+n)):this.ls.removeItem(this._ttlKey(e)),this.ls.setItem(this._prefix(e)
+,o(t))},remove:function(e){return this.ls.removeItem(this._ttlKey(e)),this.ls.removeItem(this._prefix(e)),this},clear:function(){var e,t,n=[],
+i=this.ls.length;for(e=0;e<i;e++)(t=this.ls.key(e)).match(this.keyMatcher)&&n.push(t.replace(this.keyMatcher,""));for(e=n.length;e--;)this.remove(n[e]
+);return this},isExpired:function(e){var t=n(this.ls.getItem(this._ttlKey(e)));return!!(f.isNumber(t)&&i()>t)}}),e}(),o=function(){"use strict"
+;function e(e){e=e||{},this.cancelled=!1,this.lastReq=null,this._send=e.transport,this._get=e.limiter?e.limiter(this._get):this._get,
+this._cache=!1===e.cache?new i(0):t}var s=0,l={},c=6,t=new i(10);return e.setMaxPendingRequests=function(e){c=e},e.resetCache=function(){t.reset()},
+f.mixin(e.prototype,{_fingerprint:function(e){return(e=e||{}).url+e.type+p.param(e.data||{})},_get:function(e,t){function n(e){t(null,e),a._cache.set(
+o,e)}function i(){t(!0)}var o,r,a=this;o=this._fingerprint(e),this.cancelled||o!==this.lastReq||((r=l[o])?r.done(n).fail(i):s<c?(s++,l[o]=this._send(e
+).done(n).fail(i).always(function(){s--,delete l[o],a.onDeckRequestArgs&&(a._get.apply(a,a.onDeckRequestArgs),a.onDeckRequestArgs=null)})
+):this.onDeckRequestArgs=[].slice.call(arguments,0))},get:function(e,t){var n,i;t=t||p.noop,e=f.isString(e)?{url:e}:e||{},i=this._fingerprint(e),
+this.cancelled=!1,this.lastReq=i,(n=this._cache.get(i))?t(null,n):this._get(e,t)},cancel:function(){this.cancelled=!0}}),e}(),
+r=window.SearchIndex=function(){"use strict";function e(e){(e=e||{}).datumTokenizer&&e.queryTokenizer||p.error(
+"datumTokenizer and queryTokenizer are both required"),this.identify=e.identify||f.stringify,this.datumTokenizer=e.datumTokenizer,
+this.queryTokenizer=e.queryTokenizer,this.reset()}function n(e){return e=f.filter(e,function(e){return!!e}),f.map(e,function(e){return e.toLowerCase()
+})}function a(){var e={};return e[l]=[],e[s]={},e}var s="c",l="i";return f.mixin(e.prototype,{bootstrap:function(e){this.datums=e.datums,
+this.trie=e.trie},add:function(e){var r=this;e=f.isArray(e)?e:[e],f.each(e,function(e){var o,t;r.datums[o=r.identify(e)]=e,t=n(r.datumTokenizer(e)),
+f.each(t,function(e){var t,n,i;for(t=r.trie,n=e.split("");i=n.shift();)(t=t[s][i]||(t[s][i]=a()))[l].push(o)})})},get:function(e){var t=this
+;return f.map(e,function(e){return t.datums[e]})},search:function(e){var t,r,a=this;return t=n(this.queryTokenizer(e)),f.each(t,function(e){var t,n,i,
+o;if(r&&0===r.length)return!1;for(t=a.trie,n=e.split("");t&&(i=n.shift());)t=t[s][i];return t&&0===n.length?(o=t[l].slice(0),void(r=r?function(e,t){
+var n=0,i=0,o=[];e=e.sort(),t=t.sort();for(var r=e.length,a=t.length;n<r&&i<a;)e[n]<t[i]?n++:(e[n]>t[i]||(o.push(e[n]),n++),i++);return o}(r,o):o)):!(
+r=[])}),r?f.map(function(e){for(var t={},n=[],i=0,o=e.length;i<o;i++)t[e[i]]||(t[e[i]]=!0,n.push(e[i]));return n}(r),function(e){return a.datums[e]}
+):[]},all:function(){var e=[];for(var t in this.datums)e.push(this.datums[t]);return e},reset:function(){this.datums={},this.trie=a()},
+serialize:function(){return{datums:this.datums,trie:this.trie}}}),e}(),a=function(){"use strict";function e(e){this.url=e.url,this.ttl=e.ttl,
+this.cache=e.cache,this.transform=e.transform,this.transport=e.transport,this.thumbprint=e.thumbprint,this.storage=new t(e.cacheKey)}var n;return n={
+data:"data",protocol:"protocol",thumbprint:"thumbprint"},f.mixin(e.prototype,{_settings:function(){return{url:this.url,type:"GET",dataType:"json"}},
+store:function(e){this.cache&&(this.storage.set(n.data,e,this.ttl),this.storage.set(n.protocol,location.protocol,this.ttl),this.storage.set(
+n.thumbprint,this.thumbprint,this.ttl))},fromCache:function(){var e,t={};return this.cache?(t.data=this.storage.get(n.data),
+t.protocol=this.storage.get(n.protocol),t.thumbprint=this.storage.get(n.thumbprint),e=t.thumbprint!==this.thumbprint||t.protocol!==location.protocol,
+t.data&&!e?t.data:null):null},fromNetwork:function(t){var n=this;t&&this.transport(this._settings()).fail(function(){t(!0)}).done(function(e){t(null,
+n.transform(e))})},clear:function(){return this.storage.clear(),this}}),e}(),s=function(){"use strict";function e(e){this.url=e.url,
+this.prepare=e.prepare,this.transform=e.transform,this.transport=new o({cache:e.cache,limiter:e.limiter,transport:e.transport})}return f.mixin(
+e.prototype,{_settings:function(){return{url:this.url,type:"GET",dataType:"json"}},get:function(e,n){var t,i=this;if(n)return e=e||"",t=this.prepare(e
+,this._settings()),this.transport.get(t,function(e,t){n(e?[]:i.transform(t))})},cancelLastRequest:function(){this.transport.cancel()}}),e}(),
+l=function(){"use strict";function r(e){var t,n,i,o,r,a,s,l,c,u,d;if(e)return t={url:null,cache:!0,prepare:null,replace:null,wildcard:null,
+limiter:null,rateLimitBy:"debounce",rateLimitWait:300,transform:f.identity,transport:null},e=f.isString(e)?{url:e}:e,!(e=f.mixin(t,e)).url&&p.error(
+"remote requires url to be set"),e.transform=e.filter||e.transform,e.prepare=(c=(l=e).prepare,u=l.replace,d=l.wildcard,c||(c=u?function(e,t){
+return t.url=u(t.url,e),t}:l.wildcard?function(e,t){return t.url=t.url.replace(d,encodeURIComponent(e)),t}:function(e,t){return t})),e.limiter=(i=(n=e
+).limiter,o=n.rateLimitBy,r=n.rateLimitWait,i||(i=/^throttle$/i.test(o)?(s=r,function(e){return f.throttle(e,s)}):(a=r,function(e){return f.debounce(e
+,a)})),i),e.transport=e.transport?h(e.transport):p.ajax,delete e.replace,delete e.wildcard,delete e.rateLimitBy,delete e.rateLimitWait,e}function h(n
+){return function(e){var t=p.Deferred();return n(e,function(e){f.defer(function(){t.resolve(e)})},function(e){f.defer(function(){t.reject(e)})}),t}}
+return function(e){var t,n,i,o;return t={initialize:!0,identify:f.stringify,datumTokenizer:null,queryTokenizer:null,sufficient:5,sorter:null,local:[],
+prefetch:null,remote:null},!(e=f.mixin(t,e||{})).datumTokenizer&&p.error("datumTokenizer is required"),!e.queryTokenizer&&p.error(
+"queryTokenizer is required"),n=e.sorter,e.sorter=n?function(e){return e.sort(n)}:f.identity,e.local=f.isFunction(e.local)?e.local():e.local,
+e.prefetch=(i=e.prefetch)?(o={url:null,ttl:864e5,cache:!0,cacheKey:null,thumbprint:"",transform:f.identity,transport:null},i=f.isString(i)?{url:i}:i,
+!(i=f.mixin(o,i)).url&&p.error("prefetch requires url to be set"),i.transform=i.filter||i.transform,i.cacheKey=i.cacheKey||i.url,
+i.thumbprint="0.11.0"+i.thumbprint,i.transport=i.transport?h(i.transport):p.ajax,i):null,e.remote=r(e.remote),e}}();return function(){"use strict"
+;function e(e){e=l(e),this.sorter=e.sorter,this.identify=e.identify,this.sufficient=e.sufficient,this.local=e.local,this.remote=e.remote?new s(
+e.remote):null,this.prefetch=e.prefetch?new a(e.prefetch):null,this.index=new r({identify:this.identify,datumTokenizer:e.datumTokenizer,
+queryTokenizer:e.queryTokenizer}),!1!==e.initialize&&this.initialize()}var t;return t=window&&window.Bloodhound,e.noConflict=function(){
+return window&&(window.Bloodhound=t),e},e.tokenizers=n,f.mixin(e.prototype,{__ttAdapter:function(){var i=this;return this.remote?function(e,t,n){
+return i.search(e,t,n)}:function(e,t){return i.search(e,t)}},_loadPrefetch:function(){var n,e,i=this;return n=p.Deferred(),this.prefetch?(
+e=this.prefetch.fromCache())?(this.index.bootstrap(e),n.resolve()):this.prefetch.fromNetwork(function(e,t){return e?n.reject():(i.add(t),
+i.prefetch.store(i.index.serialize()),void n.resolve())}):n.resolve(),n.promise()},_initialize:function(){var e=this;return this.clear(),(
+this.initPromise=this._loadPrefetch()).done(function(){e.add(e.local)}),this.initPromise},initialize:function(e){
+return!this.initPromise||e?this._initialize():this.initPromise},add:function(e){return this.index.add(e),this},get:function(e){return e=f.isArray(e
+)?e:[].slice.call(arguments),this.index.get(e)},search:function(e,t,i){var o,r=this;return o=this.sorter(this.index.search(e)),t(this.remote?o.slice(
+):o),this.remote&&o.length<this.sufficient?this.remote.get(e,function(e){var n=[];f.each(e,function(t){!f.some(o,function(e){return r.identify(t
+)===r.identify(e)})&&n.push(t)}),i&&i(n)}):this.remote&&this.remote.cancelLastRequest(),this},all:function(){return this.index.all()},clear:function(
+){return this.index.reset(),this},clearPrefetchCache:function(){return this.prefetch&&this.prefetch.clear(),this},clearRemoteCache:function(){
+return o.resetCache(),this},ttAdapter:function(){return this.__ttAdapter()}}),e}()}),function(e,t){"function"==typeof define&&define.amd?define(
+"typeahead.js",["jquery"],function(e){return t(e)}):"object"==typeof exports?module.exports=t(require("jquery")):t(jQuery)}(0,function(b){
+var w=function(){"use strict";return{isMsie:function(){return!!/(msie|trident)/i.test(navigator.userAgent)&&navigator.userAgent.match(
+/(msie |rv:)(\d+(.\d+)?)/i)[2]},isBlankString:function(e){return!e||/^\s*$/.test(e)},escapeRegExChars:function(e){return e.replace(
+/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g,"\\$&")},isString:function(e){return"string"==typeof e},isNumber:function(e){return"number"==typeof e},
+isArray:b.isArray,isFunction:b.isFunction,isObject:b.isPlainObject,isUndefined:function(e){return void 0===e},isElement:function(e){return!(
+!e||1!==e.nodeType)},isJQuery:function(e){return e instanceof b},toStr:function(e){return w.isUndefined(e)||null===e?"":e+""},bind:b.proxy,
+each:function(e,n){b.each(e,function(e,t){return n(t,e)})},map:b.map,filter:b.grep,every:function(n,i){var o=!0;return n?(b.each(n,function(e,t){
+return!!(o=i.call(null,t,e,n))&&void 0}),!!o):o},some:function(n,i){var o=!1;return n?(b.each(n,function(e,t){return!(o=i.call(null,t,e,n))&&void 0}),
+!!o):o},mixin:b.extend,identity:function(e){return e},clone:function(e){return b.extend(!0,{},e)},getIdGenerator:function(){var e=0;return function(){
+return e++}},templatify:function(e){return b.isFunction(e)?e:function(){return String(e)}},defer:function(e){setTimeout(e,0)},debounce:function(o,r,a
+){var s,l;return function(){var e,t,n=this,i=arguments;return e=function(){s=null,a||(l=o.apply(n,i))},t=a&&!s,clearTimeout(s),s=setTimeout(e,r),t&&(
+l=o.apply(n,i)),l}},throttle:function(n,i){var o,r,a,s,l,c;return l=0,c=function(){l=new Date,a=null,s=n.apply(o,r)},function(){var e=new Date,t=i-(
+e-l);return o=this,r=arguments,t<=0?(clearTimeout(a),a=null,l=e,s=n.apply(o,r)):a||(a=setTimeout(c,t)),s}},stringify:function(e){return w.isString(e
+)?e:JSON.stringify(e)},noop:function(){}}}(),n=function(){"use strict";var s={wrapper:"twitter-typeahead",input:"tt-input",hint:"tt-hint",
+menu:"tt-menu",dataset:"tt-dataset",suggestion:"tt-suggestion",selectable:"tt-selectable",empty:"tt-empty",open:"tt-open",cursor:"tt-cursor",
+highlight:"tt-highlight"};return function(e){var t,n,i,o,r,a;return n=w.mixin({},s,e),{css:(t={css:(a={wrapper:{position:"relative",
+display:"inline-block"},hint:{position:"absolute",top:"0",left:"0",borderColor:"transparent",boxShadow:"none",opacity:"1"},input:{position:"relative",
+verticalAlign:"top",backgroundColor:"transparent"},inputWithNoHint:{position:"relative",verticalAlign:"top"},menu:{position:"absolute",top:"100%",
+left:"0",zIndex:"100",display:"none"},ltr:{left:"0",right:"auto"},rtl:{left:"auto",right:" 0"}},w.isMsie()&&w.mixin(a.input,{
+backgroundImage:"url(data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7)"}),a),classes:n,html:(r=n,{
+wrapper:'<span class="'+r.wrapper+'"></span>',menu:'<div class="'+r.menu+'"></div>'}),selectors:(i=n,o={},w.each(i,function(e,t){o[t]="."+e}),o)}
+).css,html:t.html,classes:t.classes,selectors:t.selectors,mixin:function(e){w.mixin(e,t)}}}}(),A=function(){"use strict";function e(e){
+e&&e.el||b.error("EventBus initialized without el"),this.$el=b(e.el)}var n;return"typeahead:",n={render:"rendered",cursorchange:"cursorchanged",
+select:"selected",autocomplete:"autocompleted"},w.mixin(e.prototype,{_trigger:function(e,t){var n;return n=b.Event("typeahead:"+e),(t=t||[]).unshift(n
+),this.$el.trigger.apply(this.$el,t),n},before:function(e){var t;return t=[].slice.call(arguments,1),this._trigger("before"+e,t).isDefaultPrevented()
+},trigger:function(e){var t;this._trigger(e,[].slice.call(arguments,1)),(t=n[e])&&this._trigger(t,[].slice.call(arguments,1))}}),e}(),t=function(){
+"use strict";function i(e,t,n,i){var o;if(!n)return this;for(t=t.split(s),n=i?function(e,t){return e.bind?e.bind(t):function(){e.apply(t,[
+].slice.call(arguments,0))}}(n,i):n,this._callbacks=this._callbacks||{};o=t.shift();)this._callbacks[o]=this._callbacks[o]||{sync:[],async:[]},
+this._callbacks[o][e].push(n);return this}function a(i,o,r){return function(){for(var e,t=0,n=i.length;!e&&t<n;t+=1)e=!1===i[t].apply(o,r);return!e}}
+var s=/\s+/,l=window.setImmediate?function(e){setImmediate(function(){e()})}:function(e){setTimeout(function(){e()},0)};return{onSync:function(e,t,n){
+return i.call(this,"sync",e,t,n)},onAsync:function(e,t,n){return i.call(this,"async",e,t,n)},off:function(e){var t;if(!this._callbacks)return this
+;for(e=e.split(s);t=e.shift();)delete this._callbacks[t];return this},trigger:function(e){var t,n,i,o,r;if(!this._callbacks)return this;for(e=e.split(
+s),i=[].slice.call(arguments,1);(t=e.shift())&&(n=this._callbacks[t]);)o=a(n.sync,this,[t].concat(i)),r=a(n.async,this,[t].concat(i)),o()&&l(r)
+;return this}}}(),l=function(a){"use strict";var e={node:null,pattern:null,tagName:"strong",className:null,wordsOnly:!1,caseSensitive:!1}
+;return function(o){var r;(o=w.mixin({},e,o)).node&&o.pattern&&(o.pattern=w.isArray(o.pattern)?o.pattern:[o.pattern],r=function(e,t,n){for(var i,o=[],
+r=0,a=e.length;r<a;r++)o.push(w.escapeRegExChars(e[r]));return i=n?"\\b("+o.join("|")+")\\b":"("+o.join("|")+")",t?new RegExp(i):new RegExp(i,"i")}(
+o.pattern,o.caseSensitive,o.wordsOnly),function e(t,n){for(var i,o=0;o<t.childNodes.length;o++)3===(i=t.childNodes[o]).nodeType?o+=n(i)?1:0:e(i,n)}(
+o.node,function(e){var t,n,i;return(t=r.exec(e.data))&&(i=a.createElement(o.tagName),o.className&&(i.className=o.className),(n=e.splitText(t.index)
+).splitText(t[0].length),i.appendChild(n.cloneNode(!0)),e.parentNode.replaceChild(i,n)),!!t}))}}(window.document),x=function(){"use strict"
+;function a(e,t){var n;(e=e||{}).input||b.error("input is missing"),t.mixin(this),this.$hint=b(e.hint),this.$input=b(e.input),
+this.query=this.$input.val(),this.queryWhenFocused=this.hasFocus()?this.query:null,this.$overflowHelper=(n=this.$input,b(
+'<pre aria-hidden="true"></pre>').css({position:"absolute",visibility:"hidden",whiteSpace:"pre",fontFamily:n.css("font-family"),fontSize:n.css(
+"font-size"),fontStyle:n.css("font-style"),fontVariant:n.css("font-variant"),fontWeight:n.css("font-weight"),wordSpacing:n.css("word-spacing"),
+letterSpacing:n.css("letter-spacing"),textIndent:n.css("text-indent"),textRendering:n.css("text-rendering"),textTransform:n.css("text-transform")}
+).insertAfter(n)),this._checkLanguageDirection(),0===this.$hint.length&&(this.setHint=this.getHint=this.clearHint=this.clearHintIfInvalid=w.noop)}
+function i(e){return e.altKey||e.ctrlKey||e.metaKey||e.shiftKey}var r;return r={9:"tab",27:"esc",37:"left",39:"right",13:"enter",38:"up",40:"down"},
+a.normalizeQuery=function(e){return(e||"").replace(/^\s*/g,"").replace(/\s{2,}/g," ")},w.mixin(a.prototype,t,{_onBlur:function(){this.resetInputValue(
+),this.trigger("blurred")},_onFocus:function(){this.queryWhenFocused=this.query,this.trigger("focused")},_onKeydown:function(e){
+var t=r[e.which||e.keyCode];this._managePreventDefault(t,e),t&&this._shouldTrigger(t,e)&&this.trigger(t+"Keyed",e)},_onInput:function(){
+this._setQuery(this.getInputValue()),this.clearHintIfInvalid(),this._checkLanguageDirection()},_managePreventDefault:function(e,t){var n;switch(e){
+case"up":case"down":n=!i(t);break;default:n=!1}n&&t.preventDefault()},_shouldTrigger:function(e,t){var n;switch(e){case"tab":n=!i(t);break;default:
+n=!0}return n},_checkLanguageDirection:function(){var e=(this.$input.css("direction")||"ltr").toLowerCase();this.dir!==e&&(this.dir=e,this.$hint.attr(
+"dir",e),this.trigger("langDirChanged",e))},_setQuery:function(e,t){var n,i,o,r;o=e,r=this.query,i=!!(n=a.normalizeQuery(o)===a.normalizeQuery(r)
+)&&this.query.length!==e.length,this.query=e,t||n?!t&&i&&this.trigger("whitespaceChanged",this.query):this.trigger("queryChanged",this.query)},
+bind:function(){var e,t,n,i,o=this;return e=w.bind(this._onBlur,this),t=w.bind(this._onFocus,this),n=w.bind(this._onKeydown,this),i=w.bind(
+this._onInput,this),this.$input.on("blur.tt",e).on("focus.tt",t).on("keydown.tt",n),!w.isMsie()||9<w.isMsie()?this.$input.on("input.tt",i
+):this.$input.on("keydown.tt keypress.tt cut.tt paste.tt",function(e){r[e.which||e.keyCode]||w.defer(w.bind(o._onInput,o,e))}),this},focus:function(){
+this.$input.focus()},blur:function(){this.$input.blur()},getLangDir:function(){return this.dir},getQuery:function(){return this.query||""},
+setQuery:function(e,t){this.setInputValue(e),this._setQuery(e,t)},hasQueryChangedSinceLastFocus:function(){return this.query!==this.queryWhenFocused},
+getInputValue:function(){return this.$input.val()},setInputValue:function(e){this.$input.val(e),this.clearHintIfInvalid(),
+this._checkLanguageDirection()},resetInputValue:function(){this.setInputValue(this.query)},getHint:function(){return this.$hint.val()},
+setHint:function(e){this.$hint.val(e)},clearHint:function(){this.setHint("")},clearHintIfInvalid:function(){var e,t,n;n=(e=this.getInputValue())!==(
+t=this.getHint())&&0===t.indexOf(e),!(""!==e&&n&&!this.hasOverflow())&&this.clearHint()},hasFocus:function(){return this.$input.is(":focus")},
+hasOverflow:function(){var e=this.$input.width()-2;return this.$overflowHelper.text(this.getInputValue()),this.$overflowHelper.width()>=e},
+isCursorAtEnd:function(){var e,t,n;return e=this.$input.val().length,t=this.$input[0].selectionStart,w.isNumber(t)?t===e:!document.selection||((
+n=document.selection.createRange()).moveStart("character",-e),e===n.text.length)},destroy:function(){this.$hint.off(".tt"),this.$input.off(".tt"),
+this.$overflowHelper.remove(),this.$hint=this.$input=this.$overflowHelper=null}}),a}(),o=function(){"use strict";function e(e,t){var n,i,o,r;(e=e||{}
+).templates=e.templates||{},e.templates.notFound=e.templates.notFound||e.templates.empty,e.source||b.error("missing source"),e.node||b.error(
+"missing node"),e.name&&(r=e.name,!/^[_a-zA-Z0-9-]+$/.test(r))&&b.error("invalid dataset name: "+e.name),t.mixin(this),this.highlight=!!e.highlight,
+this.name=e.name||s(),this.limit=e.limit||5,this.displayFn=(o=(o=e.display||e.displayKey)||w.stringify,w.isFunction(o)?o:function(e){return e[o]}),
+this.templates=(n=e.templates,i=this.displayFn,{notFound:n.notFound&&w.templatify(n.notFound),pending:n.pending&&w.templatify(n.pending),
+header:n.header&&w.templatify(n.header),footer:n.footer&&w.templatify(n.footer),suggestion:n.suggestion||function(e){return"<div><p>"+i(e
+)+"</p></div>"}}),this.source=e.source.__ttAdapter?e.source.__ttAdapter():e.source,this.async=w.isUndefined(e.async)?2<this.source.length:!!e.async,
+this._resetLastSuggestion(),this.$el=b(e.node).addClass(this.classes.dataset).addClass(this.classes.dataset+"-"+this.name)}var a,s;return a={
+val:"tt-selectable-display",obj:"tt-selectable-object"},s=w.getIdGenerator(),e.extractData=function(e){var t=b(e);return t.data(a.obj)?{val:t.data(
+a.val)||"",obj:t.data(a.obj)||null}:null},w.mixin(e.prototype,t,{_overwrite:function(e,t){(t=t||[]).length?this._renderSuggestions(e,t
+):this.async&&this.templates.pending?this._renderPending(e):!this.async&&this.templates.notFound?this._renderNotFound(e):this._empty(),this.trigger(
+"rendered",this.name,t,!1)},_append:function(e,t){(t=t||[]).length&&this.$lastSuggestion.length?this._appendSuggestions(e,t
+):t.length?this._renderSuggestions(e,t):!this.$lastSuggestion.length&&this.templates.notFound&&this._renderNotFound(e),this.trigger("rendered",
+this.name,t,!0)},_renderSuggestions:function(e,t){var n;n=this._getSuggestionsFragment(e,t),this.$lastSuggestion=n.children().last(),this.$el.html(n
+).prepend(this._getHeader(e,t)).append(this._getFooter(e,t))},_appendSuggestions:function(e,t){var n,i;i=(n=this._getSuggestionsFragment(e,t)
+).children().last(),this.$lastSuggestion.after(n),this.$lastSuggestion=i},_renderPending:function(e){var t=this.templates.pending
+;this._resetLastSuggestion(),t&&this.$el.html(t({query:e,dataset:this.name}))},_renderNotFound:function(e){var t=this.templates.notFound
+;this._resetLastSuggestion(),t&&this.$el.html(t({query:e,dataset:this.name}))},_empty:function(){this.$el.empty(),this._resetLastSuggestion()},
+_getSuggestionsFragment:function(i,e){var o,r=this;return o=document.createDocumentFragment(),w.each(e,function(e){var t,n;n=r._injectQuery(i,e),t=b(
+r.templates.suggestion(n)).data(a.obj,e).data(a.val,r.displayFn(e)).addClass(r.classes.suggestion+" "+r.classes.selectable),o.appendChild(t[0])}),
+this.highlight&&l({className:this.classes.highlight,node:o,pattern:i}),b(o)},_getFooter:function(e,t){
+return this.templates.footer?this.templates.footer({query:e,suggestions:t,dataset:this.name}):null},_getHeader:function(e,t){
+return this.templates.header?this.templates.header({query:e,suggestions:t,dataset:this.name}):null},_resetLastSuggestion:function(){
+this.$lastSuggestion=b()},_injectQuery:function(e,t){return w.isObject(t)?w.mixin({_query:e},t):t},update:function(t){function e(e){o||(o=!0,e=(e||[]
+).slice(0,n.limit),r=e.length,n._overwrite(t,e),r<n.limit&&n.async&&n.trigger("asyncRequested",t))}var n=this,i=!1,o=!1,r=0;this.cancel(),
+this.cancel=function(){i=!0,n.cancel=b.noop,n.async&&n.trigger("asyncCanceled",t)},this.source(t,e,function(e){e=e||[],!i&&r<n.limit&&(n.cancel=b.noop
+,r+=e.length,n._append(t,e.slice(0,n.limit-r)),n.async&&n.trigger("asyncReceived",t))}),!o&&e([])},cancel:b.noop,clear:function(){this._empty(),
+this.cancel(),this.trigger("cleared")},isEmpty:function(){return this.$el.is(":empty")},destroy:function(){this.$el=null}}),e}(),k=function(){
+"use strict";function e(e,n){var i=this;(e=e||{}).node||b.error("node is required"),n.mixin(this),this.$node=b(e.node),this.query=null,
+this.datasets=w.map(e.datasets,function(e){var t=i.$node.find(e.node).first();return e.node=t.length?t:b("<div>").appendTo(i.$node),new o(e,n)})}
+return w.mixin(e.prototype,t,{_onSelectableClick:function(e){this.trigger("selectableClicked",b(e.currentTarget))},_onRendered:function(e,t,n,i){
+this.$node.toggleClass(this.classes.empty,this._allDatasetsEmpty()),this.trigger("datasetRendered",t,n,i)},_onCleared:function(){
+this.$node.toggleClass(this.classes.empty,this._allDatasetsEmpty()),this.trigger("datasetCleared")},_propagate:function(){this.trigger.apply(this,
+arguments)},_allDatasetsEmpty:function(){return w.every(this.datasets,function(e){return e.isEmpty()})},_getSelectables:function(){
+return this.$node.find(this.selectors.selectable)},_removeCursor:function(){var e=this.getActiveSelectable();e&&e.removeClass(this.classes.cursor)},
+_ensureVisible:function(e){var t,n,i,o;n=(t=e.position().top)+e.outerHeight(!0),i=this.$node.scrollTop(),o=this.$node.height()+parseInt(
+this.$node.css("paddingTop"),10)+parseInt(this.$node.css("paddingBottom"),10),t<0?this.$node.scrollTop(i+t):o<n&&this.$node.scrollTop(i+(n-o))},
+bind:function(){var e,t=this;return e=w.bind(this._onSelectableClick,this),this.$node.on("click.tt",this.selectors.selectable,e),w.each(this.datasets,
+function(e){e.onSync("asyncRequested",t._propagate,t).onSync("asyncCanceled",t._propagate,t).onSync("asyncReceived",t._propagate,t).onSync("rendered",
+t._onRendered,t).onSync("cleared",t._onCleared,t)}),this},isOpen:function(){return this.$node.hasClass(this.classes.open)},open:function(){
+this.$node.addClass(this.classes.open)},close:function(){this.$node.removeClass(this.classes.open),this._removeCursor()},
+setLanguageDirection:function(e){this.$node.attr("dir",e)},selectableRelativeToCursor:function(e){var t,n,i;return n=this.getActiveSelectable(),
+t=this._getSelectables(),-1===(i=(i=((i=(n?t.index(n):-1)+e)+1)%(t.length+1)-1)<-1?t.length-1:i)?null:t.eq(i)},setCursor:function(e){
+this._removeCursor(),(e=e&&e.first())&&(e.addClass(this.classes.cursor),this._ensureVisible(e))},getSelectableData:function(e){
+return e&&e.length?o.extractData(e):null},getActiveSelectable:function(){var e=this._getSelectables().filter(this.selectors.cursor).first()
+;return e.length?e:null},getTopSelectable:function(){var e=this._getSelectables().first();return e.length?e:null},update:function(t){
+var e=t!==this.query;return e&&(this.query=t,w.each(this.datasets,function(e){e.update(t)})),e},empty:function(){w.each(this.datasets,function(e){
+e.clear()}),this.query=null,this.$node.addClass(this.classes.empty)},destroy:function(){this.$node.off(".tt"),this.$node=null,w.each(this.datasets,
+function(e){e.destroy()})}}),e}(),T=function(){"use strict";function e(){k.apply(this,[].slice.call(arguments,0))}var t=k.prototype;return w.mixin(
+e.prototype,k.prototype,{open:function(){return!this._allDatasetsEmpty()&&this._show(),t.open.apply(this,[].slice.call(arguments,0))},close:function(
+){return this._hide(),t.close.apply(this,[].slice.call(arguments,0))},_onRendered:function(){return this._allDatasetsEmpty()?this._hide():this.isOpen(
+)&&this._show(),t._onRendered.apply(this,[].slice.call(arguments,0))},_onCleared:function(){return this._allDatasetsEmpty()?this._hide():this.isOpen(
+)&&this._show(),t._onCleared.apply(this,[].slice.call(arguments,0))},setLanguageDirection:function(e){return this.$node.css(
+"ltr"===e?this.css.ltr:this.css.rtl),t.setLanguageDirection.apply(this,[].slice.call(arguments,0))},_hide:function(){this.$node.hide()},
+_show:function(){this.$node.css("display","block")}}),e}(),E=function(){"use strict";function e(e,t){var n,i,o,r,a,s,l,c,u,d,h;(e=e||{}
+).input||b.error("missing input"),e.menu||b.error("missing menu"),e.eventBus||b.error("missing event bus"),t.mixin(this),this.eventBus=e.eventBus,
+this.minLength=w.isNumber(e.minLength)?e.minLength:1,this.input=e.input,this.menu=e.menu,this.enabled=!0,this.active=!1,this.input.hasFocus(
+)&&this.activate(),this.dir=this.input.getLangDir(),this._hacks(),this.menu.bind().onSync("selectableClicked",this._onSelectableClicked,this).onSync(
+"asyncRequested",this._onAsyncRequested,this).onSync("asyncCanceled",this._onAsyncCanceled,this).onSync("asyncReceived",this._onAsyncReceived,this
+).onSync("datasetRendered",this._onDatasetRendered,this).onSync("datasetCleared",this._onDatasetCleared,this),n=p(this,"activate","open","_onFocused")
+,i=p(this,"deactivate","_onBlurred"),o=p(this,"isActive","isOpen","_onEnterKeyed"),r=p(this,"isActive","isOpen","_onTabKeyed"),a=p(this,"isActive",
+"_onEscKeyed"),s=p(this,"isActive","open","_onUpKeyed"),l=p(this,"isActive","open","_onDownKeyed"),c=p(this,"isActive","isOpen","_onLeftKeyed"),u=p(
+this,"isActive","isOpen","_onRightKeyed"),d=p(this,"_openIfActive","_onQueryChanged"),h=p(this,"_openIfActive","_onWhitespaceChanged"),
+this.input.bind().onSync("focused",n,this).onSync("blurred",i,this).onSync("enterKeyed",o,this).onSync("tabKeyed",r,this).onSync("escKeyed",a,this
+).onSync("upKeyed",s,this).onSync("downKeyed",l,this).onSync("leftKeyed",c,this).onSync("rightKeyed",u,this).onSync("queryChanged",d,this).onSync(
+"whitespaceChanged",h,this).onSync("langDirChanged",this._onLangDirChanged,this)}function p(n){var e=[].slice.call(arguments,1);return function(){
+var t=[].slice.call(arguments);w.each(e,function(e){return n[e].apply(n,t)})}}return w.mixin(e.prototype,{_hacks:function(){var o,r
+;o=this.input.$input||b("<div>"),r=this.menu.$node||b("<div>"),o.on("blur.tt",function(e){var t,n,i;t=document.activeElement,n=r.is(t),i=0<r.has(t
+).length,w.isMsie()&&(n||i)&&(e.preventDefault(),e.stopImmediatePropagation(),w.defer(function(){o.focus()}))}),r.on("mousedown.tt",function(e){
+e.preventDefault()})},_onSelectableClicked:function(e,t){this.select(t)},_onDatasetCleared:function(){this._updateHint()},_onDatasetRendered:function(
+e,t,n,i){this._updateHint(),this.eventBus.trigger("render",n,i,t)},_onAsyncRequested:function(e,t,n){this.eventBus.trigger("asyncrequest",n,t)},
+_onAsyncCanceled:function(e,t,n){this.eventBus.trigger("asynccancel",n,t)},_onAsyncReceived:function(e,t,n){this.eventBus.trigger("asyncreceive",n,t)
+},_onFocused:function(){this._minLengthMet()&&this.menu.update(this.input.getQuery())},_onBlurred:function(){this.input.hasQueryChangedSinceLastFocus(
+)&&this.eventBus.trigger("change",this.input.getQuery())},_onEnterKeyed:function(e,t){var n;(n=this.menu.getActiveSelectable())&&this.select(n
+)&&t.preventDefault()},_onTabKeyed:function(e,t){var n;(n=this.menu.getActiveSelectable())?this.select(n)&&t.preventDefault():(
+n=this.menu.getTopSelectable())&&this.autocomplete(n)&&t.preventDefault()},_onEscKeyed:function(){this.close()},_onUpKeyed:function(){this.moveCursor(
+-1)},_onDownKeyed:function(){this.moveCursor(1)},_onLeftKeyed:function(){"rtl"===this.dir&&this.input.isCursorAtEnd()&&this.autocomplete(
+this.menu.getTopSelectable())},_onRightKeyed:function(){"ltr"===this.dir&&this.input.isCursorAtEnd()&&this.autocomplete(this.menu.getTopSelectable())
+},_onQueryChanged:function(e,t){this._minLengthMet(t)?this.menu.update(t):this.menu.empty()},_onWhitespaceChanged:function(){this._updateHint()},
+_onLangDirChanged:function(e,t){this.dir!==t&&(this.dir=t,this.menu.setLanguageDirection(t))},_openIfActive:function(){this.isActive()&&this.open()},
+_minLengthMet:function(e){return(e=w.isString(e)?e:this.input.getQuery()||"").length>=this.minLength},_updateHint:function(){var e,t,n,i,o,r
+;e=this.menu.getTopSelectable(),t=this.menu.getSelectableData(e),n=this.input.getInputValue(),!t||w.isBlankString(n)||this.input.hasOverflow(
+)?this.input.clearHint():(i=x.normalizeQuery(n),o=w.escapeRegExChars(i),(r=new RegExp("^(?:"+o+")(.+$)","i").exec(t.val))&&this.input.setHint(n+r[1]))
+},isEnabled:function(){return this.enabled},enable:function(){this.enabled=!0},disable:function(){this.enabled=!1},isActive:function(){
+return this.active},activate:function(){return!!this.isActive()||!(!this.isEnabled()||this.eventBus.before("active"))&&(this.active=!0,
+this.eventBus.trigger("active"),!0)},deactivate:function(){return!this.isActive()||!this.eventBus.before("idle")&&(this.active=!1,this.close(),
+this.eventBus.trigger("idle"),!0)},isOpen:function(){return this.menu.isOpen()},open:function(){return this.isOpen()||this.eventBus.before("open")||(
+this.menu.open(),this._updateHint(),this.eventBus.trigger("open")),this.isOpen()},close:function(){return this.isOpen()&&!this.eventBus.before("close"
+)&&(this.menu.close(),this.input.clearHint(),this.input.resetInputValue(),this.eventBus.trigger("close")),!this.isOpen()},setVal:function(e){
+this.input.setQuery(w.toStr(e))},getVal:function(){return this.input.getQuery()},select:function(e){var t=this.menu.getSelectableData(e);return!(
+!t||this.eventBus.before("select",t.obj))&&(this.input.setQuery(t.val,!0),this.eventBus.trigger("select",t.obj),this.close(),!0)},
+autocomplete:function(e){var t,n;return t=this.input.getQuery(),!(!((n=this.menu.getSelectableData(e))&&t!==n.val)||this.eventBus.before(
+"autocomplete",n.obj))&&(this.input.setQuery(n.val),this.eventBus.trigger("autocomplete",n.obj),!0)},moveCursor:function(e){var t,n,i,o
+;return t=this.input.getQuery(),n=this.menu.selectableRelativeToCursor(e),o=(i=this.menu.getSelectableData(n))?i.obj:null,!(this._minLengthMet(
+)&&this.menu.update(t))&&!this.eventBus.before("cursorchange",o)&&(this.menu.setCursor(n),i?this.input.setInputValue(i.val):(
+this.input.resetInputValue(),this._updateHint()),this.eventBus.trigger("cursorchange",o),!0)},destroy:function(){this.input.destroy(),
+this.menu.destroy()}}),e}();!function(){"use strict";function i(e,n){e.each(function(){var e,t=b(this);(e=t.data(y.typeahead))&&n(e,t)})}function v(e
+){var t;return(t=w.isJQuery(e)||w.isElement(e)?b(e).first():[]).length?t:null}var e,y,t;e=b.fn.typeahead,y={www:"tt-www",attrs:"tt-attrs",
+typeahead:"tt-typeahead"},t={initialize:function(f,m){var g;return m=w.isArray(m)?m:[].slice.call(arguments,1),g=n((f=f||{}).classNames),this.each(
+function(){var e,t,n,i,o,r,a,s,l,c,u,d,h,p;w.each(m,function(e){e.highlight=!!f.highlight}),e=b(this),t=b(g.html.wrapper),n=v(f.hint),i=v(f.menu),
+o=!1!==f.hint&&!n,r=!1!==f.menu&&!i,o&&(h=g,n=(d=e).clone().addClass(h.classes.hint).removeData().css(h.css.hint).css((p=d,{
+backgroundAttachment:p.css("background-attachment"),backgroundClip:p.css("background-clip"),backgroundColor:p.css("background-color"),
+backgroundImage:p.css("background-image"),backgroundOrigin:p.css("background-origin"),backgroundPosition:p.css("background-position"),
+backgroundRepeat:p.css("background-repeat"),backgroundSize:p.css("background-size")})).prop("readonly",!0).removeAttr("id name placeholder required"
+).attr({autocomplete:"off",spellcheck:"false",tabindex:-1})),r&&(i=b(g.html.menu).css(g.css.menu)),n&&n.val(""),e=function(e,t){e.data(y.attrs,{
+dir:e.attr("dir"),autocomplete:e.attr("autocomplete"),spellcheck:e.attr("spellcheck"),style:e.attr("style")}),e.addClass(t.classes.input).attr({
+autocomplete:"off",spellcheck:!1});try{!e.attr("dir")&&e.attr("dir","auto")}catch(e){}return e}(e,g),(o||r)&&(t.css(g.css.wrapper),e.css(
+o?g.css.input:g.css.inputWithNoHint),e.wrap(t).parent().prepend(o?n:null).append(r?i:null)),u=r?T:k,a=new A({el:e}),s=new x({hint:n,input:e},g),
+l=new u({node:i,datasets:m},g),c=new E({input:s,menu:l,eventBus:a,minLength:f.minLength},g),e.data(y.www,g),e.data(y.typeahead,c)})},
+isEnabled:function(){var t;return i(this.first(),function(e){t=e.isEnabled()}),t},enable:function(){return i(this,function(e){e.enable()}),this},
+disable:function(){return i(this,function(e){e.disable()}),this},isActive:function(){var t;return i(this.first(),function(e){t=e.isActive()}),t},
+activate:function(){return i(this,function(e){e.activate()}),this},deactivate:function(){return i(this,function(e){e.deactivate()}),this},
+isOpen:function(){var t;return i(this.first(),function(e){t=e.isOpen()}),t},open:function(){return i(this,function(e){e.open()}),this},close:function(
+){return i(this,function(e){e.close()}),this},select:function(e){var t=!1,n=b(e);return i(this.first(),function(e){t=e.select(n)}),t},
+autocomplete:function(e){var t=!1,n=b(e);return i(this.first(),function(e){t=e.autocomplete(n)}),t},moveCursor:function(t){var n=!1;return i(
+this.first(),function(e){n=e.moveCursor(t)}),n},val:function(t){var n;return arguments.length?(i(this,function(e){e.setVal(t)}),this):(i(this.first(),
+function(e){n=e.getVal()}),n)},destroy:function(){return i(this,function(e,t){var n,i,o;i=(n=t).data(y.www),o=n.parent().filter(i.selectors.wrapper),
+w.each(n.data(y.attrs),function(e,t){w.isUndefined(e)?n.removeAttr(t):n.attr(t,e)}),n.removeData(y.typeahead).removeData(y.www).removeData(y.attr
+).removeClass(i.classes.input),o.length&&(n.detach().insertAfter(o),o.remove()),e.destroy()}),this}},b.fn.typeahead=function(e){
+return t[e]?t[e].apply(this,[].slice.call(arguments,1)):t.initialize.apply(this,arguments)},b.fn.typeahead.noConflict=function(){
+return b.fn.typeahead=e,this}}()}),function(s){var e,i,n,l,a,o=s("#lucee-docs-search-input");s(".search-link"),s(".search-container");e=function(){
+setupSearchEngine(function(e){var t={source:e,displayKey:"display",limit:100,templates:{suggestion:c}};o.typeahead({hint:!0,highlight:!1,minLength:1},
+t),o.on("typeahead:selected",function(e,t){i(t)});var n=s(".file-not-found-suggestions");n.length&&u(n),d()})},setupSearchEngine=function(t){s.ajax(
+"/assets/js/searchIndex.json",{method:"GET",success:function(e){a=e,t(function(e,t){t(l(e))})}})};var r="";l=function(s){
+localStorage&&localStorage.setItem("lastSearch",s);var e,t,l=n(r=s);return t=(t=a.filter(function(e){for(var t,n,i,o=e.desc?e.desc:e.text,
+r=e.text.length,a=0;a<r&&(n=o.substr(a).match(l.expr));a++)(!t||n[0].length<t[0].length)&&(t=n,i=e.text.substr(0,a)+e.text.substr(a).replace(l.expr,
+l.replace));if(t)return e.score=t[0].length-s.length,e.highlight=i,!0})).sort(function(e,t){return e.score-t.score||e.text.length-t.text.length}),(e={
+value:"https://duckduckgo.com/?q=site:docs.lucee.org "+encodeURIComponent(s),text:'Search all docs for "'+s+'"',
+highlight:'<em>Search all docs for <strong>"'+s+'</strong>"</em>',score:1e6,icon:"search",type:""}).display=e.text,t.unshift(e),t},n=function(e){var t
+,n=e.replace(/[\W]+/g,"").split(""),i={};if(n.length<14)for(i.expr=new RegExp("("+n.join(")(.*?)(")+")","i"),i.replace="",t=0;t<n.length;t++
+)i.replace+="<b>$"+(2*t+1)+"</b>",t+1<n.length&&(i.replace+="$"+(2*t+2));else i.expr=new RegExp("("+e.replace(/[-\/\\^$*+?.()|[\]{}]/g,"\\$&")+")","i"
+),i.replace="<b>$1</b>";return" "==e.charAt(e.length-1)&&(i+=" "),i};var c=function(e){return Mustache.render(
+'<div><i class="fa fa-fw fa-{{icon}}"></i> {{{highlight}}}</div>',e)};i=function(e){t(function(){0===window.location.pathname.indexOf("/static/"
+)?window.location="/static"+e.value:window.location=e.value})},e();var t=function(e){var t="/search.html?q=",n=!1
+;0===document.location.pathname.indexOf("/search.html")?n=!0:0===document.location.pathname.indexOf("/static/search.html")&&(
+t="/static/search.html?q=",n=!0),t+=encodeURIComponent(r),n&&window.history.pushState&&window.history.pushState({q:r},"Search: "+r,t);try{gtag(
+"config",window._gaTrackingID,{page_path:t})}catch(e){}setTimeout(e,100)},u=function(e){var t=document.location.pathname.split(".")[0].split("/"),n=l(
+t[t.length-1].split("-").join(" "));1<n.length&&e.append(s("<p/>").text("Perhaps one of these pages is what your looking for?"));for(
+var i=0;i<n.length;i++){var o=n[i],r=o.value;-1==r.indexOf("http")&&(r=o.value.substr(1));var a=s("<a/>").text(o.display).attr("href",r);e.append(s(
+"<div/>").append(a))}},d=function(){var e=s(".search-fullpage");if(1===e.length){var t=document.location.search,n=t.indexOf("q=");-1!==n&&-1!==(n=(
+t=decodeURIComponent(t.substr(n+2))).indexOf("&"))&&(t=t.substr(0,n-1));var i=s("#search").find(".menu-content-inner").detach(),o=i.find(
+".menu-search-focus");i.find(".tt-menu").attr("style",""),0<t.length&&o.val(t),e.append(i),o.trigger("input"),s(".menu-toggle").hide()}};s(
+".menu-search-focus").on("keyup",function(e){if(13===e.which||10===e.which){var t=s(".tt-dataset .tt-suggestion");2===t.length&&s(t[1]).click()}}),s(
+".menu-random").on("click",function(e){for(var t,n,i,o=document.location.pathname.toLowerCase(),r=o;r==o;)n=1,i=a.length,t=Math.floor(Math.random()*(
+i-n+1))+n,r=a[t-1].value.toLowerCase();document.location=r})}(jQuery),function(e,t){"use strict";"function"==typeof define&&define.amd?define([],
+function(){return t.apply(e)}):"object"==typeof exports?module.exports=t.call(e):e.Waves=t.call(e)}("object"==typeof global?global:this,function(){
+"use strict";function g(e){var t="";for(var n in e)e.hasOwnProperty(n)&&(t+=n+":"+e[n]+";");return t}function t(e){var t=function(e){if(
+!1===l.allowEvent(e))return null;for(var t=null,n=e.target||e.srcElement;null!==n.parentElement;){if(!(
+n instanceof SVGElement||-1===n.className.indexOf("waves-effect"))){t=n;break}if(n.classList.contains("waves-effect")){t=n;break}n=n.parentElement}
+return t}(e);null!==t&&(v.show(e,t),"ontouchstart"in window&&(t.addEventListener("touchend",v.hide,!1),t.addEventListener("touchcancel",v.hide,!1)),
+t.addEventListener("mouseup",v.hide,!1),t.addEventListener("mouseleave",v.hide,!1))}var e=e||{},n=document.querySelectorAll.bind(document),v={
+duration:750,show:function(e,t){if(2===e.button)return!1;var n=t||this,i=document.createElement("div");i.className="waves-ripple",n.appendChild(i)
+;var o,r,a,s,l,c,u,d=(c={top:0,left:0},u=(o=n)&&o.ownerDocument,r=u.documentElement,void 0!==o.getBoundingClientRect&&(c=o.getBoundingClientRect()),
+a=null!==(l=s=u)&&l===l.window?s:9===s.nodeType&&s.defaultView,{top:c.top+a.pageYOffset-r.clientTop,left:c.left+a.pageXOffset-r.clientLeft}),
+h=e.pageY-d.top,p=e.pageX-d.left,f="scale("+n.clientWidth/100*3+")";"touches"in e&&(h=e.touches[0].pageY-d.top,p=e.touches[0].pageX-d.left),
+i.setAttribute("data-hold",Date.now()),i.setAttribute("data-scale",f),i.setAttribute("data-x",p),i.setAttribute("data-y",h);var m={top:h+"px",
+left:p+"px"};i.className=i.className+" waves-notransition",i.setAttribute("style",g(m)),i.className=i.className.replace("waves-notransition",""),
+m["-webkit-transform"]=f,m["-moz-transform"]=f,m["-ms-transform"]=f,m["-o-transform"]=f,m.transform=f,m.opacity="1",
+m["-webkit-transition-duration"]=v.duration+"ms",m["-moz-transition-duration"]=v.duration+"ms",m["-o-transition-duration"]=v.duration+"ms",
+m["transition-duration"]=v.duration+"ms",i.setAttribute("style",g(m))},hide:function(e){l.touchup(e);var t=this,n=(t.clientWidth,null),
+i=t.getElementsByClassName("waves-ripple");if(!(0<i.length))return!1;var o=(n=i[i.length-1]).getAttribute("data-x"),r=n.getAttribute("data-y"),
+a=n.getAttribute("data-scale"),s=350-(Date.now()-Number(n.getAttribute("data-hold")));s<0&&(s=0),setTimeout(function(){var e={top:r+"px",left:o+"px",
+opacity:"0","-webkit-transition-duration":v.duration+"ms","-moz-transition-duration":v.duration+"ms","-o-transition-duration":v.duration+"ms",
+"transition-duration":v.duration+"ms","-webkit-transform":a,"-moz-transform":a,"-ms-transform":a,"-o-transform":a,transform:a};n.setAttribute("style",
+g(e)),setTimeout(function(){try{t.removeChild(n)}catch(e){return!1}},v.duration)},s)},wrapInput:function(e){for(var t=0;t<e.length;t++){var n=e[t];if(
+"input"===n.tagName.toLowerCase()){var i=n.parentNode;if("i"===i.tagName.toLowerCase()&&-1!==i.className.indexOf("waves-effect"))continue
+;var o=document.createElement("i");o.className=n.className+" waves-input-wrapper";var r=n.getAttribute("style");r||(r=""),o.setAttribute("style",r),
+n.className="waves-button-input",n.removeAttribute("style"),i.replaceChild(o,n),o.appendChild(n)}}}},l={touches:0,allowEvent:function(e){var t=!0
+;return"touchstart"===e.type?l.touches+=1:"touchend"===e.type||"touchcancel"===e.type?setTimeout(function(){0<l.touches&&(l.touches-=1)},500
+):"mousedown"===e.type&&0<l.touches&&(t=!1),t},touchup:function(e){l.allowEvent(e)}};return e.displayEffect=function(e){"duration"in(e=e||{})&&(
+v.duration=e.duration),v.wrapInput(n(".waves-effect")),"ontouchstart"in window&&document.body.addEventListener("touchstart",t,!1),
+document.body.addEventListener("mousedown",t,!1)},e.attach=function(e){"input"===e.tagName.toLowerCase()&&(v.wrapInput([e]),e=e.parentElement),
+"ontouchstart"in window&&e.addEventListener("touchstart",t,!1),e.addEventListener("mousedown",t,!1)},e}),Waves.displayEffect({duration:900}),
+WebFontConfig={classes:!1,fontactive:function(){$(".avoid-fout").each(function(e){$(this).addClass("avoid-fout-done")}),contentFixPushCal(),
+footerPush(),headerHeightCal(),tileInView()},fontinactive:function(){$(".avoid-fout").each(function(e){$(this).addClass("avoid-fout-done")}),
+contentFixPushCal(),footerPush(),headerHeightCal(),tileInView()},google:{families:["Roboto:300,300italic,400,400italic,700,700italic"]}},function(){
+var e=document.createElement("script");e.src=("https:"==document.location.protocol?"https":"http"
+)+"://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js",e.type="text/javascript",e.async="true";var t=document.getElementsByTagName("script"
+)[0];t.parentNode.insertBefore(e,t)}(),on_resize=function(e,t){return onresize=function(){clearTimeout(t),t=setTimeout(e,100)},e},on_resize(function(
+){contentFixPushCal(),footerPush(),headerHeightCal(),$(".header-nav-scroll").length&&headerNavPos(),$(".tab-nav").each(function(){tabSwitch($(
+".nav > li.active",$(this)),null)}),$(".tile-wrap-animation:not(.isinview)").length&&tileInView()})();

--- a/docs/03.reference/01.functions/cleartimezone/function.md
+++ b/docs/03.reference/01.functions/cleartimezone/function.md
@@ -1,9 +1,0 @@
----
-title: clearTimeZone
-id: function-clearTimeZone
-categories:
-- datetime
-- internationalization
----
-
-Clears the timezone that you'd set.

--- a/server/Application.cfc
+++ b/server/Application.cfc
@@ -15,12 +15,12 @@ component {
 	this.mappings[ "/docs"     ] = this.baseDir & "docs";
 	this.mappings[ "/listener" ] = this.baseDir;
 	*/
-	this.assetBundleVersion = 34;  // see parent application.cfc
+	this.assetBundleVersion = 35;  // see parent application.cfc
 
 	
 
 	public void function onApplicationStart()  {
-		application.assetBundleVersion = 34;
+		application.assetBundleVersion = 35;
 		//_addChangeWatcher();
 	}
 


### PR DESCRIPTION
This css fixes  the ugly code breaking in `<pre>` tags that wraps code examples by making the pre tag horizontally scrollable. See the red rectangle vs the green rectangle in the image below.

This fix also adds a css cursor: pointer to the search result when the result box gets populated with results.

Please merge with care, because I'm still not that most experienced with the bundling of the assets. However, it worked good on my local dev environment.

![cssfix](https://user-images.githubusercontent.com/5096188/171490605-5b6a5786-4c89-4287-9cfe-d9b6facd9c94.jpg)
.