### PR TITLE
Update requestTimeOut.md

### DIFF
--- a/docs/03.reference/02.tags/setting/_attributes/requestTimeOut.md
+++ b/docs/03.reference/02.tags/setting/_attributes/requestTimeOut.md
@@ -1,3 +1,5 @@
-number of seconds. Time limit, after which CFML processes the page as an unresponsive thread.
+Number of seconds. Time limit, after which CFML processes the page as an unresponsive thread.
 
 Overrides the timeout set in the Lucee Administrator.
+
+If one specifies a `requesttimeout` of `0`, the request will not time out.


### PR DESCRIPTION
Adding "If one specifies a `requesttimeout` of `0`, the request will not time out.", because it's... well... true ;-)