### PR TITLE
Update interval.md

### DIFF
--- a/docs/03.reference/02.tags/schedule/_attributes/interval.md
+++ b/docs/03.reference/02.tags/schedule/_attributes/interval.md
@@ -1,3 +1,3 @@
 Required when creating tasks with action = 'update'. Interval at which task should be scheduled.
 Can be set in seconds or as Once, Daily, Weekly, and Monthly. The default interval is one hour. The
-minimum interval is one minute.
+minimum interval is 10 seconds.


### PR DESCRIPTION
Docs conflict with what Lucee itself is telling me if I put in a too-low value: it says the minimum is 10sec in the error message. I have tested this, and it's correct. Updating docs accordingly.