### PR TITLE
Update throwOnError.md

### DIFF
--- a/docs/03.reference/02.tags/http/_attributes/throwOnError.md
+++ b/docs/03.reference/02.tags/http/_attributes/throwOnError.md
@@ -8,4 +8,4 @@ Errors include
 - unable to resolve hostname (i.e. DNS)
 - TLS/SSL problems
 
-The default is NO.
+The default is YES.


### PR DESCRIPTION
Existing guidance does not match actual behaviour. It throws an exception if the req does not return a 2xx response.