### PR TITLE
Correct dody encoding of HYPHEN

### DIFF
--- a/docs/04.guides/12.deploying-lucee-server-apps/06.preparing-your-server-linux/page.md
+++ b/docs/04.guides/12.deploying-lucee-server-apps/06.preparing-your-server-linux/page.md
@@ -19,7 +19,7 @@ Once the initial minimal firewall is configured by the installation process, you
 
 	-A RH-Firewall-1-INPUT -m state --state NEW -m tcp -p tcp --dport 22 -s 192.168.254.0/24 -j ACCEPT
 
-Note the line above, the "dport" or "Destination Port" is port 22, which is the default SSH port. Next, note the IP range we used as an example here, which is 192.168.254.0 – a very common internal network range. Please adjust the allowed IP ranges as necessary for your network.
+Note the line above, the "dport" or "Destination Port" is port 22, which is the default SSH port. Next, note the IP range we used as an example here, which is 192.168.254.0 - a very common internal network range. Please adjust the allowed IP ranges as necessary for your network.
 
 Once you've added or edited the line for the SSH port 22, don't forget to restart the iptables firewall with the following command (Again, using CentOS 6 as an example):
 

--- a/docs/04.guides/13.Various/26.server2008-IIS7.5/page.md
+++ b/docs/04.guides/13.Various/26.server2008-IIS7.5/page.md
@@ -19,7 +19,7 @@ Select Application Pools under the main node of your site. You'll notice there a
 
 Click Set Application Pool Defaults from the right column. Here we see that Plesk has set Enable 32 Bit Applications to True. We need to set this to false.
 
-It's important here to have a clear understanding as to what Enable means. For IIS 7.5, Enable means Only Allow. So If you have this set in Application Pool Defaults IIS will create all new AppPools with 32 bit enabled preventing 64 bit apps from running. When trying to run a 64 bit app with 32 bit enabled, you will get an error: HTTP Error 500.0 – Internal Server Error Calling LoadLibraryEx on ISAPI filter "C:\lucee\connector\isapi_redirect-1.2.31.dll" failed.
+It's important here to have a clear understanding as to what Enable means. For IIS 7.5, Enable means Only Allow. So If you have this set in Application Pool Defaults IIS will create all new AppPools with 32 bit enabled preventing 64 bit apps from running. When trying to run a 64 bit app with 32 bit enabled, you will get an error: HTTP Error 500.0 - Internal Server Error Calling LoadLibraryEx on ISAPI filter "C:\lucee\connector\isapi_redirect-1.2.31.dll" failed.
 
 The other very confusing thing is that if you change the default bit-ness in Application Pool Defaults to 32, IIS overrides individually set AppPool settings and breaks all 64 bit websites. In order to have a mixed 32/64 bit environment you MUST have Application Pool > Enabled 32 bit Application set to FALSE. To allow an individual site to run 32 bit apps, you need to click on the appPool you want to change and click Advanced Settings from the right column. Change the drop down from False (the default) to True
 


### PR DESCRIPTION
It doesn't look like it from the plain-text representation,
But the previous version were displaying the HYPHENS as weird unicode characters.