### PR TITLE
Update page.md

### DIFF
--- a/docs/04.guides/04.cookbooks/57.mail_listeners/page.md
+++ b/docs/04.guides/04.cookbooks/57.mail_listeners/page.md
@@ -11,9 +11,9 @@ description: Mail Listeners can be configured to fire before and after sending a
 
 # Mail Listeners in Lucee
 
-Mail Listeners can be configured to triggered before and after sending mails (only for mail sending as async).
+Mail Listeners can be configured to be triggered before and after sending email (only for email sending as async).
 
-These follow the same pattern as [[cookbook-query-listeners]]
+These follow the same pattern as [[cookbook-query-listeners]].
 
 This is available as an experimental feature in Lucee 5.3 and is officially supported in Lucee 6.0.
 
@@ -21,22 +21,23 @@ This is available as an experimental feature in Lucee 5.3 and is officially supp
 
 It can be configured:
 
-- application wide, via [[tag-application]] i.e. `Application.cfc`
-- per [[tag-mail]] tag (listeners defined in listener attribute overwrites any mail listener defined in the [[tag-application]])
+- application wide, via [[tag-application]]; 
+- per [[tag-mail]] tag (listeners defined in the listener attribute overwrite any mail listener defined in the [[tag-application]]).
 
-You can change the arguments (content) of an email in via the `before` listener method, by returning a modified arguments struct, which has the following keys:
+You can change the arguments (content) of an email in via the `before` listener method, by returning a struct, with some or all of the following keys:
 
 - from 
-- to, 
+- to 
 - bcc 
 - replyTo 
 - failTo 
-- subject (ex: <code>{from:"modified@lucee.org" 
-- to:"modifiedto@lucee.org"}</code>)
+- subject
 
-A Mail Listener is a component with two methods, `before()` and `after()`. You can have other methods in your listener component, but Lucee will only call these two.
+(ex: <code>{from:"modified@lucee.org", to:"modifiedto@lucee.org"}</code>)
 
-Also Mail listener can be a struct (that has a keys before/after with closure as value) OR closure (that triggered after the sending mails)
+A Mail Listener is a component with two methods, `before()` and/or `after()`. You can have other methods in your listener component, but Lucee will only call these two.
+
+Also a Mail Listener can be a struct that has a keys `before` and/or `after` with closure as value, OR a closure (that is triggered after sending the email)
 
 ```luceescript
 this.mail.listener = {
@@ -66,7 +67,6 @@ this.mail.listener = function () {
 i.e. `MailListener.cfc`
 
 ```luceescript
-<cfscript>
 component {
 
 	function before() {
@@ -78,16 +78,15 @@ component {
 		return arguments;
 	}
 }
-</cfscript>
 ```
 
-To add an Application wide Mail listener, add the following to your `Application.cfc`
+To add an Application-wide Mail Listener, add the following to your `Application.cfc`:
 
 ```luceescript
 this.mail.listener = new MailListener();
 ```
 
-To add a Mail listener to an individual [[tag-mail]] tag (listeners defined in the listener attribute overwrites any mail listener defined in the [[tag-application]]
+To add a Mail Listener to an individual [[tag-mail]] tag (listeners defined in the listener attribute overwrites any mail listener defined in the [[tag-application]]
 
 ```luceescript
 <cfset listener = new MailListener()>
@@ -103,6 +102,6 @@ To add a Mail listener to an individual [[tag-mail]] tag (listeners defined in t
 
 ### Dump of arguments to the Mail Listener after() method (cfmail)
 
-You can see the `from` and `to` mail ids were changed in the arguments to the `after` function, the args struct contains the modified `from` and `to` keys from the `before` function
+You can see the `from` and `to` mail IDs were changed in the arguments to the `after` function, the arguments struct contains the modified `from` and `to` keys from the `before` function.
 
 <img alt="Mail Listener After()" src="/assets/images/listeners/MailListener_after_arguments.png">


### PR DESCRIPTION
Updated grammar.

Outstanding questions / thoughts:
* "Mail Listener" is not a proper noun, so strictly-speaking oughtn't be capitalised. However it's mostly capitalised here, so I have just made the ones that _weren't_ capitalised conform with the majority.
* Why is " (cfmail)" at the end of this heading: "Dump of arguments to the Mail Listener after() method (cfmail)"
* Not sure why "(content)" is at the end of "You can change the arguments (content)"
* You do not mention `body` as possible key of the return struct from `before`, however it's shown in the dumps at the bottom. Should it be listed? If it is an option, how are mailparts handled?
* I have guessed that the struct that is returned from `before` does not have to contain _all_ the listed keys, as that would be dumb. The previous wording was... awkward.
* I presume the struct version of the listener just needs to pass _functions_ as the handlers. They don't need to be closures per se. I left it as-is just in case.
* In most places you specifically use  `[[tag-application]]` to mention both `<cfapplication>` and `Application.cfc`, but in "To add an Application-wide Mail Listener, add the following to your `Application.cfc`" you only mention `Application.cfc`. Is that just cos the example is only appropriate for `Application.cfc`? Should you also have an example for `<cfapplication>`, given you go to the effort of mentioning it everywhere else?