### PR TITLE
Correct sessionType returned values

### DIFF
--- a/docs/03.reference/01.functions/getapplicationmetadata/function.md
+++ b/docs/03.reference/01.functions/getapplicationmetadata/function.md
@@ -44,7 +44,7 @@ The returned struct contains the following data:
 |sessionManagement| Boolean | true | |
 |sessionStorage| String | "memory" | |
 |sessionTimeout| TimeSpan | | Session Scope timeout |
-|sessionType| Boolean | "cfml" | Either "cfml" or "j2ee" |
+|sessionType| Boolean | "cfml" | Either "cfml" or "jee" |
 |setClientCookies| Boolean | true | |
 |setDomainCookies| Boolean | false | |
 |source| String | | Alias for `component` |


### PR DESCRIPTION
GetApplicationMetadata().sessionType returns "jee" not "j2ee"