### PR TITLE
Fix word case and style

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -52,7 +52,7 @@ if [ "$DOCS_BRANCH" = "refs/heads/master" ] && [ "$DOCS_EVENT" = "push" ] ; then
   tar -czf ../../builds/artifacts/dash/lucee.tgz lucee.docset
   cd ../../
   echo "Prepared for s3 upload."
-  # this is now done in a github action step
+  # this is now done in a GitHub Action step
   #echo "Syncing with S3..."
   #s3_website push
   #echo "All done :)"

--- a/docs/04.guides/13.Various/30.TIPS/05.TIPS-builtIn-Tag/page.md
+++ b/docs/04.guides/13.Various/30.TIPS/05.TIPS-builtIn-Tag/page.md
@@ -5,8 +5,8 @@ id: tips-built-in-tag
 
 ### How do I make my custom tag built-in (e.g.: cfwave instead of cf_wave)? ###
 
-* For your local web context install them to {local host web directory}/WEB-INF/lucee/library/tag
-* Or if you want it globally to all context: {lucee installation directory}lucee-server/context/library/tag
+* For your local web context install them to `{local host web directory}/WEB-INF/lucee/library/tag`
+* Or if you want it globally to all context: `{lucee installation directory}lucee-server/context/library/tag`
 
 ## Bonus Material ##
 


### PR DESCRIPTION
Also in `docs/04.guides/13.Various/30.TIPS/05.TIPS-builtIn-Tag/page.md` the three blog post links are broken.

Seems `http://www.lucee.ch` is down.

I did a search for `http://www.lucee.ch` in the codebase:

<img width="1339" alt="Screen Shot 2022-11-10 at 12 46 40 am" src="https://user-images.githubusercontent.com/418747/200863570-4dadd330-93cd-492f-b29e-ac0203ef4223.png">
