### PR TITLE
Correct seeming mistake and minor typos

### DIFF
--- a/docs/04.guides/05.working-with-source/01.build-from-source/page.md
+++ b/docs/04.guides/05.working-with-source/01.build-from-source/page.md
@@ -20,9 +20,9 @@ Before you can start building Lucee from source, you will need a few things inst
 - Java 11 is *recommended*, Java 15 is *not yet supported* due the removal of the Nashorn JavaScript engine which is used in the build process 
 - Java 17 *isn't yet fully supported* due to some Apache Felix issues (fixed in 5.3.9, but some extensions need updating)
 
-1. **Apache Maven** - the source code contains several build scripts that will automate the build process for you. you will need Maven installed in order to run these build scripts. <http://maven.apache.org/>
+1. **Apache Maven** - the source code contains several build scripts that will automate the build process for you. You will need Maven installed in order to run these build scripts. <http://maven.apache.org/>
 
-1. **Apache Ant** - the source code contains several build scripts that will automate the build process for you. you will need Maven installed in order to run these build scripts. <http://ant.apache.org/bindownload.cgi>
+1. **Apache Ant** - the source code contains several build scripts that will automate the build process for you. You will need Ant installed in order to run these build scripts. <http://ant.apache.org/bindownload.cgi>
 
 ### 2. Get the source code
 


### PR DESCRIPTION
The typos are about caps, but the seeming mistake is the reference to Maven where it seems Ant should be named.