### PR TITLE
fixed typo in documentation: example for function "fileWriteLine" has syntax error.

### DIFF
--- a/docs/03.reference/01.functions/filewriteline/_examples.md
+++ b/docs/03.reference/01.functions/filewriteline/_examples.md
@@ -1,5 +1,5 @@
 ```luceescript
 openFile = fileopen(filepath,"read");
 readfromfile = filereadline(openfile);
-filewriteline(filepath),readfromfile);
+filewriteline(filepath,readfromfile);
 ```


### PR DESCRIPTION
Fixed typo in the documentation example of the function fileWriteLine