### PR TITLE
Update guide to install options on Mac

### DIFF
--- a/docs/04.guides/02.installing-lucee/03.osx/chapter.md
+++ b/docs/04.guides/02.installing-lucee/03.osx/chapter.md
@@ -4,10 +4,12 @@ id: running-lucee-osx
 menuTitle: MacOS
 ---
 
-Here you can find guides on how to run Lucee on MacOS / OS X:
+Here you can find guides on how to run Lucee on MacOS / OS X. 
 
-There isn't currently an official Lucee Installer for MacOS, [[getting-started-commandbox]] is a good alternative
+While there isn't currently an official Lucee installer for MacOS, there are still several other ways to run Lucee on a Mac:
+* [Lucee Express](https://docs.lucee.org/guides/installing-lucee/download-and-install.html#download-and-install-lucee-server) (zip install approach) 
+* [[running-lucee-installing-tomcat-and-lucee-on-os-x-using-the-lucee-war-file]]
+* [Lucee Docker containers](https://github.com/lucee/lucee-dockerfile) 
+* [[getting-started-commandbox]]
 
-[[running-lucee-installing-tomcat-and-lucee-on-os-x-using-the-lucee-war-file]]
-
-[[setting-dev-environment-osx]]
+Consider also this older resource:[[setting-dev-environment-osx]]


### PR DESCRIPTION
The previous version was missing a couple of important alternatives. (I could not find better "guides" for those alternatives, here in the docs. So I offered the only suitable resource links I I could find. Is there in fact a "guide" for running the Express edition, or for he docker images?) 

Also tweaked some grammar/typos.