### PR TITLE
typo in Update page.md

### DIFF
--- a/docs/04.guides/13.Various/01.system-properties/page.md
+++ b/docs/04.guides/13.Various/01.system-properties/page.md
@@ -257,7 +257,7 @@ Also, make sure not to publish these files with sensitive data as part of open s
 
 		<tr>
 			<td>
-				<div class="attribute">LUCEE_EXTENSIONS_INSTALL<br>lucee.extension.install</div>
+				<div class="attribute">LUCEE_EXTENSIONS_INSTALL<br>lucee.extensions.install</div>
 			</td>
 			<td>
 


### PR DESCRIPTION
incorrect spelling:
`lucee.extension.install `

correct spelling
`lucee.extensions.install`
see https://github.com/lucee/Lucee/blob/d5c7aec9fbae99ae9d0adac210ab89da6d01b18b/core/src/main/java/resource/setting/sysprop-envvar.json