### PR TITLE
fix(docs): correct age filtering description

### DIFF
--- a/docs/04.guides/04.cookbooks/20.query-of-queries/page.md
+++ b/docs/04.guides/04.cookbooks/20.query-of-queries/page.md
@@ -45,7 +45,7 @@ Let's say you have the following database query, ```myQuery```:
 
 You would now have a list of names, ages and locations for all the people in a query called ```myQuery```.
 
-Say you want to filter out people under 18 and over 90, but you don't want to hit the database again:
+Say you want to filter out people under 90 and over 18, but you don't want to hit the database again:
 
 ```lucee
 <cfquery name="filteredQuery" dbtype="query">


### PR DESCRIPTION
Issue
The documentation contains an error in the description of filtering people by age. The current text incorrectly states that the filter is for people "under 18 and over 90," which contradicts the actual query logic.

Fix
Correct the description to accurately reflect the query logic, which filters out people "under 90 and over 18."

Changes Made
Updated the description to correctly state the age filtering criteria.

### Before
Say you want to filter out people under 18 and over 90, but you don't want to hit the database again:

```lucee
<cfquery name="filteredQuery" dbtype="query">
  SELECT     Name, Age, Location
  FROM    myQuery
  WHERE    Age >= 18
            AND Age <= 90
</cfquery>
```
`filteredQry` contains the desired records.

#### After
Say you want to filter out people under 90 and over 18, but you don't want to hit the database again:

```lucee
<cfquery name="filteredQuery" dbtype="query">
  SELECT     Name, Age, Location
  FROM    myQuery
  WHERE    Age >= 18
            AND Age <= 90
</cfquery>
```
`filteredQry` contains the desired records.

