### PR TITLE
remove mistaken duplicated env var

### DIFF
--- a/docs/recipes/environment-variables-system-properties.md
+++ b/docs/recipes/environment-variables-system-properties.md
@@ -211,13 +211,6 @@ This setting functions similarly to `LUCEE_ADMIN_MODE`, but it only affects the 
 *SysProp:* `-Dlucee.cascading.write.to.variables.log`
 *EnvVar:* `LUCEE_CASCADING_WRITE_TO_VARIABLES.LOG`
 
-This setting only applies to Lucee 6 (above `6.2.1.82`). Enables logging when variables are implicitly written to the variables scope (without an explicit scope definition). When set to a log level name (e.g., "application"), Lucee will log details about variables being assigned without explicit scope at the DEBUG level. This helps identify code that could be optimized by using proper variable scoping. 
-
-#### LUCEE_CASCADING_WRITE_TO_VARIABLES_LOG
-
-*SysProp:* `-Dlucee.cascading.write.to.variables.log`
-*EnvVar:* `LUCEE_CASCADING_WRITE_TO_VARIABLES.LOG`
-
 This setting only applies to Lucee 6 (above `6.2.1.82`). Enables logging when variables are implicitly written to the variables scope (without an explicit scope definition). When set to a log name (e.g., "application"), Lucee will log details about variables being assigned without explicit scope. The log level can be customized using the `LUCEE_CASCADING_WRITE_TO_VARIABLES_LOGLEVEL` setting. This helps identify code that could be optimized by using proper variable scoping. This setting excludes certain internal variables (_cfquery, _cflock, _thread) from being logged.
 
 #### LUCEE_CASCADING_WRITE_TO_VARIABLES_LOGLEVEL


### PR DESCRIPTION
This env var, LUCEE_CASCADING_WRITE_TO_VARIABLES_LOG, is listed twice. The second variant (right below it) is a fuller discussion--and that seems to have been added when the new one following it was added, LOG_CASCADING_WRITE_LOG_LEVEL.