### PR TITLE
Remove change that was reverted Jul 2025

### DIFF
--- a/docs/recipes/breaking-changes-7.0.md
+++ b/docs/recipes/breaking-changes-7.0.md
@@ -81,12 +81,6 @@ This should have minimal impact on existing code and may avoid some concurrency 
 
 [LDEV-5416](https://luceeserver.atlassian.net/browse/LDEV-5416)
 
-## Enable Limit evaluation by default
-
-Adopting secure defaults, Lucee 7 by default sets this to true
-
-[LDEV-5177](https://luceeserver.atlassian.net/browse/LDEV-5177)
-
 ## Enabled correct encoding of spaces in urls with CFHTTP
 
 Older versions of Lucee double encoded spaces in CFHTTP, causing problems calling some APIs


### PR DESCRIPTION
The Jira ticket (listed for this intended Lucee 7 change) shows that the intention to enable this by default was reversed as of Jul 2025.