### PR TITLE
Correct typos blocking lint

### DIFF
--- a/docs/04.guides/01.getting-started/07.lucee-editors-IDEs/page.md
+++ b/docs/04.guides/01.getting-started/07.lucee-editors-IDEs/page.md
@@ -36,7 +36,7 @@ CFML Editor has an option to use the full Lucee docs as the source for inline he
 
 Vim and NeoVim both have built in syntax highlighting since 2017.
 
-Code completion in NeoVim can be achived with [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) and [cfcomplete](https://codeberg.org/oricat/cfcomplete.nvim)
+Code completion in NeoVim can be achieved with [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) and [cfcomplete](https://codeberg.org/oricat/cfcomplete.nvim)
 
 ## Sublime Text
 


### PR DESCRIPTION
This is one of 3 edits offered because they were blocking the lint checking spelling for all pr's. Sorry for not offering these on a single pr.

Somehow the github web ui (on mobile) was not readily allowing me to do that. It forced each change into its own patch, and offered no means I could see to merge them into one. I welcome anyone telling me where I went wrong (about how to solve this in the web ui, when I'm trying to contribute from a phone).