### PR TITLE
Correct typos blocking lint

### DIFF
--- a/docs/recipes/configuration.md
+++ b/docs/recipes/configuration.md
@@ -120,7 +120,7 @@ variable or the `-Dlucee.server.dir` system property.
 At startup, Lucee reads this configuration, applying the settings and resolving resources (e.g., extensions,
 [[maven|Maven endpoints]], etc.). 
 
-A good apporach is to configure Lucee through the administrator, then take the resulting `.CFConfig.json` file as a base for future installations / dpeloyments.
+A good approach is to configure Lucee through the administrator, then take the resulting `.CFConfig.json` file as a base for future installations / dpeloyments.
 
 ## Web Configurations
 


### PR DESCRIPTION
This is one of 3 edits offered because they were blocking the lint checking spelling for all pr's. Sorry for not offering these on a single pr.

Somehow the github web ui (on mobile) was not readily allowing me to do that. It forced each change into its own patch, and offered no means I could see to merge them into one. I welcome anyone telling me where I went wrong (about how to solve this in the web ui, when I'm trying to contribute from a phone).