### PR TITLE
cfdocs export: add body field to tag JSON

### DIFF
--- a/builders/cfdocs/Builder.cfc
+++ b/builders/cfdocs/Builder.cfc
@@ -197,6 +197,12 @@ component {
 		}
 		if ( fn.getPageType() == "tag" ){
 			var jsonfile = variables.cfdocsPath & "/cf" & lcase( fn.name ) & ".json";
+			switch ( fn.getBodyContentType() ) {
+				case "prohibited":
+				case "empty":     data["body"] = "none";     break;
+				case "free":      data["body"] = "optional"; break;
+				case "required":  data["body"] = "required"; break;
+			}
 			if ( len( required ) eq 0 ) {
 				data["syntax"] = "<cf" & LCase( fn.name ) & "/>";
 			} else {


### PR DESCRIPTION
## Summary

Adds a `body` field to the cfdocs JSON output for tags, indicating whether the tag accepts a body.

- `"body": "none"` — empty/prohibited (e.g. `cfbreak`, `cfset`)
- `"body": "optional"` — free (e.g. `cfcache`, `cfquery`)
- `"body": "required"` — required (e.g. `cfif`, `cffunction`)

The cfdocs schema currently has no body-content field, so consumers can only infer body rules from the free-form `syntax` string (and inconsistently — `cfif.json` upstream lists `"<cfif>"` with no closing tag). Additive change; the cfdocs JSON Schema doesn't restrict additional properties, so existing validators stay green.

Functions don't get the field. Output only emitted for the four normalized values returned by `getTagData().bodyType`.

## Test plan

- [ ] Run a cfdocs build and spot-check a few JSONs (`cfbreak.json` → none, `cfif.json` → required, `cfcache.json` → optional)
- [ ] Confirm the field is absent on function JSONs